### PR TITLE
Feature/redis windows

### DIFF
--- a/models.go
+++ b/models.go
@@ -348,9 +348,13 @@ func (d *DBClient) getResponse(req *http.Request) *http.Response {
 
 	} else {
 		log.WithFields(log.Fields{
-			"error": err.Error(),
-			"mode":  AppConfig.mode,
-		}).Error("Failed to retrieve response from cache")
+			"error":       err.Error(),
+			"mode":        AppConfig.mode,
+			"query":       req.URL.RawQuery,
+			"path":        req.URL.RawPath,
+			"destination": req.Host,
+			"method":      req.Method,
+		}).Warn("Failed to retrieve response from cache")
 		// return error? if we return nil - proxy forwards request to original destination
 		return goproxy.NewResponse(req,
 			goproxy.ContentTypeText, http.StatusPreconditionFailed,

--- a/models.go
+++ b/models.go
@@ -31,6 +31,7 @@ type requestDetails struct {
 	Path        string              `json:"path"`
 	Method      string              `json:"method"`
 	Destination string              `json:"destination"`
+	Scheme      string              `json:"scheme"`
 	Query       string              `json:"query"`
 	Body        string              `json:"body"`
 	RemoteAddr  string              `json:"remoteAddr"`
@@ -199,6 +200,7 @@ func (d *DBClient) save(req *http.Request, resp *http.Response, respBody []byte,
 			Path:        req.URL.Path,
 			Method:      req.Method,
 			Destination: req.Host,
+			Scheme:      req.URL.Scheme,
 			Query:       req.URL.RawQuery,
 			Body:        string(reqBody),
 			RemoteAddr:  req.RemoteAddr,

--- a/settings.go
+++ b/settings.go
@@ -22,7 +22,7 @@ func initSettings() {
 	// getting redis connection
 	redisAddress := os.Getenv("RedisAddress")
 	if redisAddress == "" {
-		redisAddress = ":6379"
+		redisAddress = "127.0.0.1:6379"
 	}
 	AppConfig.redisAddress = redisAddress
 	// getting redis password


### PR DESCRIPTION
showing a bit more information when hoverfly couldn't match request in virtualize mode. Also adding current scheme information for requests, although not matching based on it.
Fixed a problem when hoverfly didn't launch on windows if redis address env variable not provided