### PR TITLE
Extra delay matching

### DIFF
--- a/core/admin.go
+++ b/core/admin.go
@@ -827,16 +827,13 @@ func (d *Hoverfly) DeleteMetadataHandler(w http.ResponseWriter, req *http.Reques
 }
 
 func (d *Hoverfly) GetResponseDelaysHandler(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	resp := models.ResponseDelayJson{
-		Data: &d.ResponseDelays,
-	}
-	b, _ := json.Marshal(resp)
+	b := d.ResponseDelays.Json()
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.Write(b)
 }
 
 func (d *Hoverfly) DeleteAllResponseDelaysHandler(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	d.ResponseDelays = models.ResponseDelayList{}
+	d.ResponseDelays = &models.ResponseDelayList{}
 
 	var response messageResponse
 	response.Message = "Delays deleted successfuly"

--- a/core/admin.go
+++ b/core/admin.go
@@ -596,7 +596,7 @@ func (d *Hoverfly) CurrentStateHandler(w http.ResponseWriter, req *http.Request,
 
 // StateHandler handles current proxy state
 func (d *Hoverfly) StateHandler(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-		var sr stateRequest
+	var sr stateRequest
 
 	// this is mainly for testing, since when you create
 	if r.Body == nil {
@@ -893,15 +893,15 @@ func (d *Hoverfly) UpdateResponseDelaysHandler(w http.ResponseWriter, req *http.
 		}).Error("Failed to unmarshal request body!")
 		mr.Message = fmt.Sprintf("Failed to decode request body. Error: %s", err.Error())
 		w.WriteHeader(400)
-	}  else if rd.Data == nil {
+	} else if rd.Data == nil {
 		log.Error("No delay data in the request body!")
 		mr.Message = fmt.Sprintf("Failed to get data from the request body.")
 		w.WriteHeader(422)
 	} else {
 		err = models.ValidateResponseDelayJson(rd)
-		if (err != nil) {
+		if err != nil {
 			log.WithFields(log.Fields{
-				"error":  err.Error(),
+				"error": err.Error(),
 			}).Error("Error validating response delays config supplied")
 			mr.Message = fmt.Sprintf("Failed to validate response delays config. Error: %s", err.Error())
 			w.WriteHeader(422)

--- a/core/admin.go
+++ b/core/admin.go
@@ -74,7 +74,7 @@ func (m *messageResponse) Encode() ([]byte, error) {
 func (d *Hoverfly) StartAdminInterface() {
 
 	// starting admin interface
-	mux := getBoneRouter(*d)
+	mux := getBoneRouter(d)
 	n := negroni.Classic()
 
 	logLevel := log.ErrorLevel
@@ -95,7 +95,7 @@ func (d *Hoverfly) StartAdminInterface() {
 }
 
 // getBoneRouter returns mux for admin interface
-func getBoneRouter(d Hoverfly) *bone.Mux {
+func getBoneRouter(d *Hoverfly) *bone.Mux {
 	mux := bone.New()
 
 	// getting auth controllers and middleware
@@ -828,7 +828,7 @@ func (d *Hoverfly) DeleteMetadataHandler(w http.ResponseWriter, req *http.Reques
 
 func (d *Hoverfly) GetResponseDelaysHandler(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	resp := models.ResponseDelayJson{
-		Data: &d.Cfg.ResponseDelays,
+		Data: &d.ResponseDelays,
 	}
 	b, _ := json.Marshal(resp)
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
@@ -836,7 +836,7 @@ func (d *Hoverfly) GetResponseDelaysHandler(w http.ResponseWriter, req *http.Req
 }
 
 func (d *Hoverfly) DeleteAllResponseDelaysHandler(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	d.Cfg.ResponseDelays = []models.ResponseDelay{}
+	d.ResponseDelays = models.ResponseDelayList{}
 
 	var response messageResponse
 	response.Message = "Delays deleted successfuly"

--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/testutil"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"testing"
-	"github.com/SpectoLabs/hoverfly/core/models"
 	"reflect"
+	"testing"
 )
 
 func TestGetAllRecords(t *testing.T) {
@@ -731,10 +731,9 @@ func TestGetResponseDelays(t *testing.T) {
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
 
-
 	delay := models.ResponseDelay{
 		UrlPattern: ".",
-		Delay: 100,
+		Delay:      100,
 	}
 	delays := models.ResponseDelayList{delay}
 	dbClient.UpdateResponseDelays(delays)
@@ -762,14 +761,13 @@ func TestDeleteAllResponseDelaysHandler(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	delay :=models.ResponseDelay{
+	delay := models.ResponseDelay{
 		UrlPattern: ".",
-		Delay: 100,
+		Delay:      100,
 	}
 	delays := models.ResponseDelayList{delay}
 	dbClient.ResponseDelays = &delays
 	m := getBoneRouter(dbClient)
-
 
 	req, err := http.NewRequest("DELETE", "/api/delays", nil)
 	testutil.Expect(t, err, nil)
@@ -788,16 +786,16 @@ func TestUpdateResponseDelays(t *testing.T) {
 	defer dbClient.RequestCache.DeleteData()
 	m := getBoneRouter(dbClient)
 
-	delayOne :=models.ResponseDelay{
+	delayOne := models.ResponseDelay{
 		UrlPattern: ".",
-		Delay: 100,
+		Delay:      100,
 	}
 	delayTwo := models.ResponseDelay{
 		UrlPattern: "example",
-		Delay:       100,
+		Delay:      100,
 	}
 	delays := models.ResponseDelayList{delayOne, delayTwo}
-	delayJson := models.ResponseDelayJson{ Data: &delays }
+	delayJson := models.ResponseDelayJson{Data: &delays}
 	bts, err := json.Marshal(&delayJson)
 	testutil.Expect(t, err, nil)
 
@@ -903,4 +901,3 @@ func TestJSONWithMissingFieldUpdateResponseDelays(t *testing.T) {
 	// normal equality checking doesn't work on slices (!!)
 	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, &models.ResponseDelayList{}), true)
 }
-

--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -17,7 +17,7 @@ func TestGetAllRecords(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	req, err := http.NewRequest("GET", "/api/records", nil)
 	testutil.Expect(t, err, nil)
@@ -49,7 +49,7 @@ func TestGetAllRecordsWRecords(t *testing.T) {
 		dbClient.captureRequest(req)
 	}
 	// performing query
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	req, err := http.NewRequest("GET", "/api/records", nil)
 	testutil.Expect(t, err, nil)
@@ -73,7 +73,7 @@ func TestGetRecordsCount(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	req, err := http.NewRequest("GET", "/api/count", nil)
 	testutil.Expect(t, err, nil)
@@ -105,7 +105,7 @@ func TestGetRecordsCountWRecords(t *testing.T) {
 		dbClient.captureRequest(req)
 	}
 	// performing query
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	req, err := http.NewRequest("GET", "/api/count", nil)
 	testutil.Expect(t, err, nil)
@@ -129,7 +129,7 @@ func TestExportImportRecords(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// inserting some payloads
 	for i := 0; i < 5; i++ {
@@ -173,7 +173,7 @@ func TestDeleteHandler(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// inserting some payloads
 	for i := 0; i < 5; i++ {
@@ -200,7 +200,7 @@ func TestDeleteHandlerNoBucket(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// deleting through handler
 	importReq, err := http.NewRequest("DELETE", "/api/records", nil)
@@ -216,7 +216,7 @@ func TestGetState(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// setting initial mode
 	dbClient.Cfg.SetMode(SimulateMode)
@@ -241,7 +241,7 @@ func TestSetSimulateState(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// setting mode to capture
 	dbClient.Cfg.SetMode("capture")
@@ -270,7 +270,7 @@ func TestSetCaptureState(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// setting mode to simulate
 	dbClient.Cfg.SetMode(SimulateMode)
@@ -299,7 +299,7 @@ func TestSetModifyState(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// setting mode to simulate
 	dbClient.Cfg.SetMode(SimulateMode)
@@ -328,7 +328,7 @@ func TestSetSynthesizeState(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// setting mode to simulate
 	dbClient.Cfg.SetMode(SimulateMode)
@@ -357,7 +357,7 @@ func TestSetRandomState(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// setting mode to simulate
 	dbClient.Cfg.SetMode(SimulateMode)
@@ -386,7 +386,7 @@ func TestSetNoBody(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// setting mode to simulate
 	dbClient.Cfg.SetMode(SimulateMode)
@@ -408,7 +408,7 @@ func TestStatsHandler(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// deleting through handler
 	req, err := http.NewRequest("GET", "/api/stats", nil)
@@ -427,7 +427,7 @@ func TestStatsHandlerSimulateMetrics(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	dbClient.Counter.Counters[SimulateMode].Inc(1)
 
@@ -454,7 +454,7 @@ func TestStatsHandlerCaptureMetrics(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	dbClient.Counter.Counters[CaptureMode].Inc(1)
 
@@ -481,7 +481,7 @@ func TestStatsHandlerModifyMetrics(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	dbClient.Counter.Counters[ModifyMode].Inc(1)
 
@@ -508,7 +508,7 @@ func TestStatsHandlerSynthesizeMetrics(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	dbClient.Counter.Counters[SynthesizeMode].Inc(1)
 
@@ -535,7 +535,7 @@ func TestStatsHandlerRecordCountMetrics(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// inserting some payloads
 	for i := 0; i < 5; i++ {
@@ -565,7 +565,7 @@ func TestSetMetadata(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// preparing to set mode through rest api
 	var reqBody setMetadata
@@ -594,7 +594,7 @@ func TestSetMetadataBadBody(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// deleting through handler
 	req, err := http.NewRequest("PUT", "/api/metadata", ioutil.NopCloser(bytes.NewBuffer([]byte("you shall not decode me!!"))))
@@ -610,7 +610,7 @@ func TestSetMetadataMissingKey(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// preparing to set mode through rest api
 	var reqBody setMetadata
@@ -641,7 +641,7 @@ func TestGetMetadata(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 	// adding some metadata
 	for i := 0; i < 3; i++ {
 		k := fmt.Sprintf("key_%d", i)
@@ -676,7 +676,7 @@ func TestDeleteMetadata(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 	// adding some metadata
 	for i := 0; i < 3; i++ {
 		k := fmt.Sprintf("key_%d", i)
@@ -709,7 +709,7 @@ func TestDeleteMetadataEmpty(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	// deleting it
 	req, err := http.NewRequest("DELETE", "/api/metadata", nil)
@@ -730,14 +730,16 @@ func TestGetResponseDelays(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
 
-	delay :=models.ResponseDelay{
-		HostPattern: ".",
+
+	delay := models.ResponseDelay{
+		UrlPattern: ".",
 		Delay: 100,
 	}
-	delays := []models.ResponseDelay{delay}
-	dbClient.Cfg.ResponseDelays = delays
+	delays := models.ResponseDelayList{delay}
+	dbClient.UpdateResponseDelays(delays)
+
+	m := getBoneRouter(dbClient)
 
 	req, err := http.NewRequest("GET", "/api/delays", nil)
 	testutil.Expect(t, err, nil)
@@ -760,14 +762,14 @@ func TestDeleteAllResponseDelaysHandler(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
-
 	delay :=models.ResponseDelay{
-		HostPattern: ".",
+		UrlPattern: ".",
 		Delay: 100,
 	}
-	delays := []models.ResponseDelay{delay}
-	dbClient.Cfg.ResponseDelays = delays
+	delays := models.ResponseDelayList{delay}
+	dbClient.ResponseDelays = delays
+	m := getBoneRouter(dbClient)
+
 
 	req, err := http.NewRequest("DELETE", "/api/delays", nil)
 	testutil.Expect(t, err, nil)
@@ -777,24 +779,24 @@ func TestDeleteAllResponseDelaysHandler(t *testing.T) {
 	m.ServeHTTP(rec, req)
 	testutil.Expect(t, rec.Code, http.StatusOK)
 
-	testutil.Expect(t, len(dbClient.Cfg.ResponseDelays), 0)
+	testutil.Expect(t, len(dbClient.ResponseDelays), 0)
 }
 
 func TestUpdateResponseDelays(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	delayOne :=models.ResponseDelay{
-		HostPattern: ".",
+		UrlPattern: ".",
 		Delay: 100,
 	}
 	delayTwo := models.ResponseDelay{
-		HostPattern: "example",
+		UrlPattern: "example",
 		Delay:       100,
 	}
-	delays := []models.ResponseDelay{delayOne, delayTwo}
+	delays := models.ResponseDelayList{delayOne, delayTwo}
 	delayJson := models.ResponseDelayJson{ Data: &delays }
 	bts, err := json.Marshal(&delayJson)
 	testutil.Expect(t, err, nil)
@@ -809,14 +811,14 @@ func TestUpdateResponseDelays(t *testing.T) {
 	testutil.Expect(t, rec.Code, http.StatusCreated)
 
 	// normal equality checking doesn't work on slices (!!)
-	testutil.Expect(t, reflect.DeepEqual(dbClient.Cfg.ResponseDelays, delays), true)
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, delays), true)
 }
 
 func TestInvalidJSONSyntaxUpdateResponseDelays(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	delayJson := "{aseuifhksejfc}"
 
@@ -828,18 +830,18 @@ func TestInvalidJSONSyntaxUpdateResponseDelays(t *testing.T) {
 
 	m.ServeHTTP(rec, req)
 	testutil.Expect(t, rec.Code, http.StatusBadRequest)
-	fmt.Println(dbClient.Cfg.ResponseDelays)
+	fmt.Println(dbClient.ResponseDelays)
 
 	// normal equality checking doesn't work on slices (!!)
-	var expd []models.ResponseDelay
-	testutil.Expect(t, reflect.DeepEqual(dbClient.Cfg.ResponseDelays, expd), true)
+	var expd models.ResponseDelayList
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, expd), true)
 }
 
 func TestInvalidJSONSemanticsUpdateResponseDelays(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	delayJson := "{ \"madeupfield\" : \"somevalue\" }"
 
@@ -851,18 +853,18 @@ func TestInvalidJSONSemanticsUpdateResponseDelays(t *testing.T) {
 
 	m.ServeHTTP(rec, req)
 	testutil.Expect(t, rec.Code, 422)
-	fmt.Println(dbClient.Cfg.ResponseDelays)
+	fmt.Println(dbClient.ResponseDelays)
 
 	// normal equality checking doesn't work on slices (!!)
-	var expd []models.ResponseDelay
-	testutil.Expect(t, reflect.DeepEqual(dbClient.Cfg.ResponseDelays, expd), true)
+	var expd models.ResponseDelayList
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, expd), true)
 }
 
 func TestJSONWithInvalidHostPatternUpdateResponseDelays(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	delayJson := "{ \"data\": [{\"hostPattern\": \"*\", \"delay\": 100}] }"
 
@@ -875,18 +877,18 @@ func TestJSONWithInvalidHostPatternUpdateResponseDelays(t *testing.T) {
 	m.ServeHTTP(rec, req)
 	fmt.Println(req.Body)
 	testutil.Expect(t, rec.Code, 422)
-	fmt.Println(dbClient.Cfg.ResponseDelays)
+	fmt.Println(dbClient.ResponseDelays)
 
 	// normal equality checking doesn't work on slices (!!)
-	var expd []models.ResponseDelay
-	testutil.Expect(t, reflect.DeepEqual(dbClient.Cfg.ResponseDelays, expd), true)
+	var expd models.ResponseDelayList
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, expd), true)
 }
 
 func TestJSONWithMissingFieldUpdateResponseDelays(t *testing.T) {
 	server, dbClient := testTools(200, `{'message': 'here'}`)
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
-	m := getBoneRouter(*dbClient)
+	m := getBoneRouter(dbClient)
 
 	delayJson := "{ \"data\" : [{\"hostPattern\": \".\"}] }"
 
@@ -899,9 +901,10 @@ func TestJSONWithMissingFieldUpdateResponseDelays(t *testing.T) {
 	m.ServeHTTP(rec, req)
 	fmt.Println(req.Body)
 	testutil.Expect(t, rec.Code, 422)
-	fmt.Println(dbClient.Cfg.ResponseDelays)
+	fmt.Println(dbClient.ResponseDelays)
 
 	// normal equality checking doesn't work on slices (!!)
-	var expd []models.ResponseDelay
-	testutil.Expect(t, reflect.DeepEqual(dbClient.Cfg.ResponseDelays, expd), true)
+	var expd models.ResponseDelayList
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, expd), true)
 }
+

--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -811,7 +811,7 @@ func TestUpdateResponseDelays(t *testing.T) {
 	testutil.Expect(t, rec.Code, http.StatusCreated)
 
 	// normal equality checking doesn't work on slices (!!)
-	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, delays), true)
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, &delays), true)
 }
 
 func TestInvalidJSONSyntaxUpdateResponseDelays(t *testing.T) {
@@ -833,8 +833,7 @@ func TestInvalidJSONSyntaxUpdateResponseDelays(t *testing.T) {
 	fmt.Println(dbClient.ResponseDelays)
 
 	// normal equality checking doesn't work on slices (!!)
-	var expd models.ResponseDelayList
-	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, expd), true)
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, &models.ResponseDelayList{}), true)
 }
 
 func TestInvalidJSONSemanticsUpdateResponseDelays(t *testing.T) {
@@ -856,8 +855,7 @@ func TestInvalidJSONSemanticsUpdateResponseDelays(t *testing.T) {
 	fmt.Println(dbClient.ResponseDelays)
 
 	// normal equality checking doesn't work on slices (!!)
-	var expd models.ResponseDelayList
-	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, expd), true)
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, &models.ResponseDelayList{}), true)
 }
 
 func TestJSONWithInvalidHostPatternUpdateResponseDelays(t *testing.T) {
@@ -880,8 +878,7 @@ func TestJSONWithInvalidHostPatternUpdateResponseDelays(t *testing.T) {
 	fmt.Println(dbClient.ResponseDelays)
 
 	// normal equality checking doesn't work on slices (!!)
-	var expd models.ResponseDelayList
-	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, expd), true)
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, &models.ResponseDelayList{}), true)
 }
 
 func TestJSONWithMissingFieldUpdateResponseDelays(t *testing.T) {
@@ -904,7 +901,6 @@ func TestJSONWithMissingFieldUpdateResponseDelays(t *testing.T) {
 	fmt.Println(dbClient.ResponseDelays)
 
 	// normal equality checking doesn't work on slices (!!)
-	var expd models.ResponseDelayList
-	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, expd), true)
+	testutil.Expect(t, reflect.DeepEqual(dbClient.ResponseDelays, &models.ResponseDelayList{}), true)
 }
 

--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -767,7 +767,7 @@ func TestDeleteAllResponseDelaysHandler(t *testing.T) {
 		Delay: 100,
 	}
 	delays := models.ResponseDelayList{delay}
-	dbClient.ResponseDelays = delays
+	dbClient.ResponseDelays = &delays
 	m := getBoneRouter(dbClient)
 
 
@@ -779,7 +779,7 @@ func TestDeleteAllResponseDelaysHandler(t *testing.T) {
 	m.ServeHTTP(rec, req)
 	testutil.Expect(t, rec.Code, http.StatusOK)
 
-	testutil.Expect(t, len(dbClient.ResponseDelays), 0)
+	testutil.Expect(t, dbClient.ResponseDelays.Len(), 0)
 }
 
 func TestUpdateResponseDelays(t *testing.T) {

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -1,6 +1,7 @@
 package hoverfly
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
@@ -9,12 +10,11 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/metrics"
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/rusenask/goproxy"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"regexp"
 	"sync"
-	"io/ioutil"
-	"bytes"
 	"time"
 )
 
@@ -65,9 +65,9 @@ func GetNewHoverfly(cfg *Configuration, requestCache, metadataCache cache.Cache,
 		HTTP: &http.Client{Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.TLSVerification},
 		}},
-		Cfg:     cfg,
-		Counter: metrics.NewModeCounter([]string{SimulateMode, SynthesizeMode, ModifyMode, CaptureMode}),
-		Hooks:   make(ActionTypeHooks),
+		Cfg:            cfg,
+		Counter:        metrics.NewModeCounter([]string{SimulateMode, SynthesizeMode, ModifyMode, CaptureMode}),
+		Hooks:          make(ActionTypeHooks),
 		ResponseDelays: &models.ResponseDelayList{},
 	}
 	return h
@@ -194,7 +194,7 @@ func (hf *Hoverfly) processRequest(req *http.Request) (*http.Request, *http.Resp
 		}).Info("synthetic response created successfuly")
 
 		respDelay := hf.ResponseDelays.GetDelay(req.URL.String(), req.Method)
-		if (respDelay != nil) {
+		if respDelay != nil {
 			respDelay.Execute()
 		}
 
@@ -217,7 +217,7 @@ func (hf *Hoverfly) processRequest(req *http.Request) (*http.Request, *http.Resp
 		}
 
 		respDelay := hf.ResponseDelays.GetDelay(req.URL.String(), req.Method)
-		if (respDelay != nil) {
+		if respDelay != nil {
 			respDelay.Execute()
 		}
 
@@ -416,7 +416,7 @@ func (hf *Hoverfly) getResponse(req *http.Request) *http.Response {
 		}).Info("Response found, returning")
 
 		respDelay := hf.ResponseDelays.GetDelay(req.URL.String(), req.Method)
-		if (respDelay != nil) {
+		if respDelay != nil {
 			respDelay.Execute()
 		}
 

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -227,11 +227,6 @@ func (hf *Hoverfly) processRequest(req *http.Request) (*http.Request, *http.Resp
 
 	newResponse := hf.getResponse(req)
 
-	respDelay := hf.ResponseDelays.GetDelay(req.URL.String(), req.Method)
-	if (respDelay != nil) {
-		respDelay.Execute()
-	}
-
 	return req, newResponse
 
 }
@@ -419,6 +414,11 @@ func (hf *Hoverfly) getResponse(req *http.Request) *http.Response {
 			"status":      payload.Response.Status,
 			"bodyLength":  response.ContentLength,
 		}).Info("Response found, returning")
+
+		respDelay := hf.ResponseDelays.GetDelay(req.URL.String(), req.Method)
+		if (respDelay != nil) {
+			respDelay.Execute()
+		}
 
 		return response
 

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -49,7 +49,7 @@ type Hoverfly struct {
 	Counter        *metrics.CounterByMode
 	Hooks          ActionTypeHooks
 
-	ResponseDelays models.ResponseDelayList
+	ResponseDelays models.ResponseDelays
 
 	Proxy *goproxy.ProxyHttpServer
 	SL    *StoppableListener
@@ -143,7 +143,7 @@ func (hf *Hoverfly) UpdateDestination(destination string) (err error) {
 }
 
 func (hf *Hoverfly) UpdateResponseDelays(responseDelays models.ResponseDelayList) {
-	hf.ResponseDelays = responseDelays
+	hf.ResponseDelays = &responseDelays
 	log.Info("Response delay config updated on hoverfly")
 }
 

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -68,6 +68,7 @@ func GetNewHoverfly(cfg *Configuration, requestCache, metadataCache cache.Cache,
 		Cfg:     cfg,
 		Counter: metrics.NewModeCounter([]string{SimulateMode, SynthesizeMode, ModifyMode, CaptureMode}),
 		Hooks:   make(ActionTypeHooks),
+		ResponseDelays: &models.ResponseDelayList{},
 	}
 	return h
 }

--- a/core/hoverfly_test.go
+++ b/core/hoverfly_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"net/url"
 )
 
 func TestGetNewHoverflyCheckConfig(t *testing.T) {
@@ -129,4 +130,14 @@ func TestProcessModifyRequest(t *testing.T) {
 	testutil.Refute(t, newResp, nil)
 
 	testutil.Expect(t, newResp.StatusCode, 202)
+}
+
+func TestURLToStringWorksAsExpected(t *testing.T) {
+	testUrl := url.URL {
+		Scheme: "http",
+		Host: "test.com",
+		Path: "/args/1",
+		RawQuery: "query=val",
+	}
+	testutil.Expect(t, testUrl.String(), "http://test.com/args/1?query=val")
 }

--- a/core/hoverfly_test.go
+++ b/core/hoverfly_test.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"github.com/SpectoLabs/hoverfly/core/authentication/backends"
 	"github.com/SpectoLabs/hoverfly/core/cache"
+	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/testutil"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"testing"
-	"net/url"
-	"github.com/SpectoLabs/hoverfly/core/models"
 )
 
 func TestGetNewHoverflyCheckConfig(t *testing.T) {
@@ -134,17 +134,17 @@ func TestProcessModifyRequest(t *testing.T) {
 }
 
 func TestURLToStringWorksAsExpected(t *testing.T) {
-	testUrl := url.URL {
-		Scheme: "http",
-		Host: "test.com",
-		Path: "/args/1",
+	testUrl := url.URL{
+		Scheme:   "http",
+		Host:     "test.com",
+		Path:     "/args/1",
 		RawQuery: "query=val",
 	}
 	testutil.Expect(t, testUrl.String(), "http://test.com/args/1?query=val")
 }
 
 type ResponseDelayListStub struct {
-	gotDelays int;
+	gotDelays int
 }
 
 func (this *ResponseDelayListStub) Json() []byte {
@@ -155,9 +155,9 @@ func (this *ResponseDelayListStub) Len() int {
 	return this.Len()
 }
 
-func (this *ResponseDelayListStub) GetDelay(urlPattern, httpMethod string) (*models.ResponseDelay){
-	this.gotDelays++;
-	return nil;
+func (this *ResponseDelayListStub) GetDelay(urlPattern, httpMethod string) *models.ResponseDelay {
+	this.gotDelays++
+	return nil
 }
 
 func TestDelayAppliedToSuccessfulSimulateRequest(t *testing.T) {

--- a/core/import.go
+++ b/core/import.go
@@ -172,7 +172,7 @@ func (hf *Hoverfly) ImportPayloads(payloads []models.PayloadView) error {
 				if hf.Cfg.Webserver {
 					err = hf.RequestCache.Set([]byte(pl.IdWithoutHost()), bts)
 				} else {
-  					err = hf.RequestCache.Set([]byte(pl.Id()), bts)
+					err = hf.RequestCache.Set([]byte(pl.Id()), bts)
 				}
 
 				if err == nil {

--- a/core/import_test.go
+++ b/core/import_test.go
@@ -240,7 +240,6 @@ func TestImportPayloads_CanImportASingleBase64EncodedPayload(t *testing.T) {
 	cfg := Configuration{Webserver: false}
 	hv := Hoverfly{RequestCache: cache, Cfg: &cfg}
 
-
 	RegisterTestingT(t)
 
 	encodedPayload := models.PayloadView{

--- a/core/models.go
+++ b/core/models.go
@@ -91,7 +91,6 @@ func getRequestDetails(req *http.Request) (requestObj models.RequestDetails, err
 	return
 }
 
-
 // ActionType - action type can be things such as "RequestCaptured", "GotResponse" - anything
 type ActionType string
 

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -10,13 +10,13 @@ import (
 )
 
 type ResponseDelay struct {
-	UrlPattern string
-	HttpMethod string
-	Delay      int
+	UrlPattern string `json:"urlpattern"`
+	HttpMethod string `json:"httpmethod"`
+	Delay      int `json:"delay"`
 }
 
 type ResponseDelayJson struct {
-	Data *ResponseDelayList
+	Data *ResponseDelayList `json:"data"`
 }
 
 type ResponseDelayList []ResponseDelay

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -6,24 +6,28 @@ import (
 	"time"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 type ResponseDelay struct {
-	HostPattern string
-	Delay int
+	UrlPattern string
+	HttpMethod string
+	Delay      int
 }
 
 type ResponseDelayJson struct {
-	Data *[]ResponseDelay
+	Data *ResponseDelayList
 }
 
+type ResponseDelayList []ResponseDelay
+
+
 func ValidateResponseDelayJson(j ResponseDelayJson) (err error) {
-	// filter any entries that don't meet the invariants
 	if j.Data != nil {
 		for _, delay := range *j.Data {
-			if delay.HostPattern != "" && delay.Delay != 0 {
-				if _, err := regexp.Compile(delay.HostPattern); err != nil {
-					return errors.New(fmt.Sprintf("Response delay entry skipped due to invalid pattern : %s", delay.HostPattern))
+			if delay.UrlPattern != "" && delay.Delay != 0 {
+				if _, err := regexp.Compile(delay.UrlPattern); err != nil {
+					return errors.New(fmt.Sprintf("Response delay entry skipped due to invalid pattern : %s", delay.UrlPattern))
 				}
 			} else {
 				return errors.New(fmt.Sprintf("Config error - Missing values found in: %v", delay))
@@ -40,3 +44,15 @@ func (this *ResponseDelay) Execute() {
 	log.Info("Response delay completed")
 }
 
+func (this *ResponseDelayList) GetDelay(url, httpMethod string) (*ResponseDelay) {
+	for _, val := range *this {
+		match := regexp.MustCompile(val.UrlPattern).MatchString(url)
+		if match {
+			if val.HttpMethod == "" || strings.EqualFold(val.HttpMethod, httpMethod) {
+				log.Info("Found response delay setting for this request host: ", val)
+				return &val
+			}
+		}
+	}
+	return nil
+}

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -72,5 +72,9 @@ func (this *ResponseDelayList) Json() []byte {
 }
 
 func (this *ResponseDelayList) Len() int {
-	return len(this)
+	list := []ResponseDelay{}
+	if this != nil {
+		list = append(list, *this...)
+	}
+	return len(list)
 }

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"encoding/json"
 )
 
 type ResponseDelay struct {
@@ -21,6 +22,11 @@ type ResponseDelayJson struct {
 
 type ResponseDelayList []ResponseDelay
 
+type ResponseDelays interface {
+	Json() []byte
+	GetDelay(url, httpMethod string) (*ResponseDelay)
+	Len() int
+}
 
 func ValidateResponseDelayJson(j ResponseDelayJson) (err error) {
 	if j.Data != nil {
@@ -55,4 +61,16 @@ func (this *ResponseDelayList) GetDelay(url, httpMethod string) (*ResponseDelay)
 		}
 	}
 	return nil
+}
+
+func (this *ResponseDelayList) Json() []byte {
+	resp := ResponseDelayJson{
+		Data: this,
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func (this *ResponseDelayList) Len() int {
+	return this.Len()
 }

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -72,5 +72,5 @@ func (this *ResponseDelayList) Json() []byte {
 }
 
 func (this *ResponseDelayList) Len() int {
-	return this.Len()
+	return len(this)
 }

--- a/core/models/delay_test.go
+++ b/core/models/delay_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	. "github.com/onsi/gomega"
 	"encoding/json"
+	"github.com/SpectoLabs/hoverfly/core/testutil"
+	"fmt"
 )
 
 func TestConvertJsonStringToResponseDelayConfig(t *testing.T) {
@@ -12,7 +14,7 @@ func TestConvertJsonStringToResponseDelayConfig(t *testing.T) {
 	jsonConf := `
 	{
 		"data": [{
-				"hostPattern": ".",
+				"urlPattern": ".",
 				"delay": 1
 			}]
 	}`
@@ -23,7 +25,7 @@ func TestConvertJsonStringToResponseDelayConfig(t *testing.T) {
 }
 
 
-func TestDelayIsIgnoredIfHostPatternNotSet(t *testing.T) {
+func TestErrorIfHostPatternNotSet(t *testing.T) {
 	RegisterTestingT(t)
 
 	jsonConf := `
@@ -38,13 +40,13 @@ func TestDelayIsIgnoredIfHostPatternNotSet(t *testing.T) {
 	Expect(err).To(Not(BeNil()))
 }
 
-func TestDelayIsIgnoredIfDelayNotSet(t *testing.T) {
+func TestErrprIfDelayNotSet(t *testing.T) {
 	RegisterTestingT(t)
 
 	jsonConf := `
 	{
 		"data": [{
-				"hostPattern": "."
+				"urlPattern": "."
 			}]
 	}`
 	var responseDelayJson ResponseDelayJson
@@ -59,7 +61,7 @@ func TestHostPatternMustBeAValidRegexPattern(t *testing.T) {
 	jsonConf := `
 	{
 		"data": [{
-				"hostPattern": "*",
+				"urlPattern": "*",
 				"delay": 1
 			}]
 	}`
@@ -67,4 +69,103 @@ func TestHostPatternMustBeAValidRegexPattern(t *testing.T) {
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayJson(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
+}
+
+func TestErrorIfHostPatternUsed(t *testing.T) {
+	RegisterTestingT(t)
+
+	jsonConf := `
+	{
+		"data": [{
+				"hostPattern": ".",
+				"delay": 1
+			}]
+	}`
+	var responseDelayJson ResponseDelayJson
+	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
+	err := ValidateResponseDelayJson(responseDelayJson)
+	Expect(err).To(Not(BeNil()))
+}
+
+func TestGetDelayWithRegexMatch(t *testing.T) {
+	delay := ResponseDelay{
+		UrlPattern: "example(.+)",
+		Delay:       100,
+	}
+	delays := ResponseDelayList{delay}
+
+	delayMatch := delays.GetDelay("delayexample.com", "method-dummy")
+	testutil.Expect(t, *delayMatch, delay)
+
+	var nilDelay *ResponseDelay
+	delayMatch = delays.GetDelay("nodelay.com", "method-dummy")
+	testutil.Expect(t, delayMatch, nilDelay)
+}
+
+func TestMultipleMatchingDelaysReturnsTheFirst(t *testing.T) {
+	delayOne := ResponseDelay{
+		UrlPattern: "example.com",
+		Delay:       100,
+	}
+	delayTwo := ResponseDelay{
+		UrlPattern: "example",
+		Delay:       100,
+	}
+	delays := ResponseDelayList{delayOne, delayTwo}
+
+	delayMatch := delays.GetDelay("delayexample.com", "method-dummy")
+	testutil.Expect(t, *delayMatch, delayOne)
+}
+
+func TestNoMatchIfMethodsDontMatch(t *testing.T) {
+	delay := ResponseDelay{
+		UrlPattern: "example.com",
+		Delay:       100,
+		HttpMethod: "PURPLE",
+	}
+	delays := ResponseDelayList{delay}
+
+	var nilDelay *ResponseDelay
+	delayMatch := delays.GetDelay("delayexample.com", "GET")
+	testutil.Expect(t, delayMatch, nilDelay)
+	if (delayMatch!=nil) {
+		t.Fail()
+	}
+}
+
+func TestReturnMatchIfMethodsMatch(t *testing.T) {
+	delay := ResponseDelay{
+		UrlPattern: "example.com",
+		Delay:       100,
+		HttpMethod: "GET",
+	}
+	delays := ResponseDelayList{delay}
+
+	delayMatch := delays.GetDelay("delayexample.com", "GET")
+	testutil.Expect(t, *delayMatch, delay)
+}
+
+func TestIfDelayMethodBlankThenMatchesAnyMethod(t *testing.T) {
+	delay := ResponseDelay{
+		UrlPattern: "example(.+)",
+		Delay:       100,
+	}
+	delays := ResponseDelayList{delay}
+
+	delayMatch := delays.GetDelay("delayexample.com", "method-dummy")
+	testutil.Expect(t, *delayMatch, delay)
+}
+
+func TestMarshalToJSONWorks(t *testing.T) {
+	delay := ResponseDelay{
+		UrlPattern: "example(.+)",
+		Delay:       100,
+	}
+	delays := ResponseDelayList{delay}
+
+	resp := ResponseDelayJson{
+		Data: &delays,
+	}
+	b, _ := json.Marshal(resp)
+	fmt.Print(string(b))
 }

--- a/core/settings.go
+++ b/core/settings.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/SpectoLabs/hoverfly/core/models"
-	"regexp"
 )
 
 // Configuration - initial structure of configuration
@@ -21,8 +19,6 @@ type Configuration struct {
 	Webserver    bool
 
 	TLSVerification bool
-
-	ResponseDelays []models.ResponseDelay
 
 	Verbose     bool
 	Development bool
@@ -49,17 +45,6 @@ func (c *Configuration) GetMode() (string) {
 	mode := c.Mode
 	c.mu.Unlock()
 	return mode
-}
-
-func (c *Configuration) GetDelay(host string) (delay *models.ResponseDelay) {
-	for _, val := range c.ResponseDelays {
-		match := regexp.MustCompile(val.HostPattern).MatchString(host)
-		if match {
-			log.Info("Found response delay setting for this request host: ", delay)
-			return &val
-		}
-	}
-	return delay
 }
 
 // DefaultPort - default proxy port

--- a/core/settings.go
+++ b/core/settings.go
@@ -40,7 +40,7 @@ func (c *Configuration) SetMode(mode string) {
 }
 
 // GetMode - provides safe way to get current mode
-func (c *Configuration) GetMode() (string) {
+func (c *Configuration) GetMode() string {
 	c.mu.Lock()
 	mode := c.Mode
 	c.mu.Unlock()

--- a/core/settings_test.go
+++ b/core/settings_test.go
@@ -1,7 +1,6 @@
 package hoverfly
 
 import (
-	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/testutil"
 	"os"
 	"testing"
@@ -61,38 +60,6 @@ func TestGetMode(t *testing.T) {
 	cfg := Configuration{Mode: "capture"}
 
 	testutil.Expect(t, cfg.GetMode(), "capture")
-}
-
-func TestGetDelayWithRegexMatch(t *testing.T) {
-	delay := models.ResponseDelay{
-		HostPattern: "example",
-		Delay:       100,
-	}
-	delays := []models.ResponseDelay{delay}
-	cfg := Configuration{ResponseDelays: delays}
-
-	delayMatch := cfg.GetDelay("delayexample.com")
-	testutil.Expect(t, *delayMatch, delay)
-
-	delayMatch = cfg.GetDelay("nodelay.com")
-	var nilDelay *models.ResponseDelay
-	testutil.Expect(t, delayMatch, nilDelay)
-}
-
-func TestMultipleMatchingDelaysReturnsTheFirst(t *testing.T) {
-	delayOne := models.ResponseDelay{
-		HostPattern: "example.com",
-		Delay:       100,
-	}
-	delayTwo := models.ResponseDelay{
-		HostPattern: "example",
-		Delay:       100,
-	}
-	delays := []models.ResponseDelay{delayOne, delayTwo}
-	cfg := Configuration{ResponseDelays: delays}
-
-	delayMatch := cfg.GetDelay("delayexample.com")
-	testutil.Expect(t, *delayMatch, delayOne)
 }
 
 func Test_InitSettings_SetsTheWebserverFieldToFalse(t *testing.T) {

--- a/core/test_tools.go
+++ b/core/test_tools.go
@@ -13,6 +13,7 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/cache"
 	"github.com/SpectoLabs/hoverfly/core/metrics"
 	"github.com/boltdb/bolt"
+	"github.com/SpectoLabs/hoverfly/core/models"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -62,6 +63,7 @@ func testTools(code int, body string) (*httptest.Server, *Hoverfly) {
 		Cfg:           cfg,
 		Counter:       metrics.NewModeCounter([]string{SimulateMode, SynthesizeMode, ModifyMode, CaptureMode}),
 		MetadataCache: metaCache,
+		ResponseDelays: &models.ResponseDelayList{},
 	}
 	return server, dbClient
 }

--- a/core/test_tools.go
+++ b/core/test_tools.go
@@ -12,8 +12,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/SpectoLabs/hoverfly/core/cache"
 	"github.com/SpectoLabs/hoverfly/core/metrics"
-	"github.com/boltdb/bolt"
 	"github.com/SpectoLabs/hoverfly/core/models"
+	"github.com/boltdb/bolt"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -58,11 +58,11 @@ func testTools(code int, body string) (*httptest.Server, *Hoverfly) {
 	cfg.AuthEnabled = false
 	// preparing client
 	dbClient := &Hoverfly{
-		HTTP:          &http.Client{Transport: tr},
-		RequestCache:  requestCache,
-		Cfg:           cfg,
-		Counter:       metrics.NewModeCounter([]string{SimulateMode, SynthesizeMode, ModifyMode, CaptureMode}),
-		MetadataCache: metaCache,
+		HTTP:           &http.Client{Transport: tr},
+		RequestCache:   requestCache,
+		Cfg:            cfg,
+		Counter:        metrics.NewModeCounter([]string{SimulateMode, SynthesizeMode, ModifyMode, CaptureMode}),
+		MetadataCache:  metaCache,
 		ResponseDelays: &models.ResponseDelayList{},
 	}
 	return server, dbClient

--- a/functional-tests/core/testdata/delays.json
+++ b/functional-tests/core/testdata/delays.json
@@ -1,11 +1,11 @@
 {
   "data": [
     {
-      "hostPattern": "virtual\\.com",
+      "urlPattern": "virtual\\.com",
       "delay": 100
     },
     {
-      "hostPattern": "virtual\\.com",
+      "urlPattern": "virtual\\.com",
       "delay": 110
     }
   ]

--- a/functional-tests/hoverctl/hoverfly_delays_test.go
+++ b/functional-tests/hoverctl/hoverfly_delays_test.go
@@ -57,9 +57,9 @@ var _ = Describe("When I use hoverfly-cli", func() {
 				output := strings.TrimSpace(string(out))
 				fmt.Println(output)
 				Expect(output).To(ContainSubstring("Response delays set in Hoverfly"))
-				Expect(output).To(ContainSubstring("HostPattern:host1"))
+				Expect(output).To(ContainSubstring("UrlPattern:host1"))
 				Expect(output).To(ContainSubstring("Delay:110"))
-				Expect(output).To(ContainSubstring("HostPattern:host2"))
+				Expect(output).To(ContainSubstring("UrlPattern:host2"))
 				Expect(output).To(ContainSubstring("Delay:100"))
 			})
 

--- a/functional-tests/hoverctl/hoverfly_delete_test.go
+++ b/functional-tests/hoverctl/hoverfly_delete_test.go
@@ -102,7 +102,7 @@ var _ = Describe("When I use hoverctl", func() {
 
 				resp := DoRequest(sling.New().Get(fmt.Sprintf("http://localhost:%v/api/delays", adminPort)))
 				bytes, _ := ioutil.ReadAll(resp.Body)
-				Expect(string(bytes)).To(Equal(`{"Data":[]}`))
+				Expect(string(bytes)).To(Equal(`{"data":[]}`))
 			})
 		})
 
@@ -161,7 +161,7 @@ var _ = Describe("When I use hoverctl", func() {
 
 					resp := DoRequest(sling.New().Get(fmt.Sprintf("http://localhost:%v/api/delays", adminPort)))
 					bytes, _ := ioutil.ReadAll(resp.Body)
-					Expect(string(bytes)).To(Equal(`{"Data":[]}`))
+					Expect(string(bytes)).To(Equal(`{"data":[]}`))
 
 					resp = DoRequest(sling.New().Get(fmt.Sprintf("http://localhost:%v/api/records", adminPort)))
 					bytes, _ = ioutil.ReadAll(resp.Body)

--- a/functional-tests/hoverctl/testdata/delays.json
+++ b/functional-tests/hoverctl/testdata/delays.json
@@ -1,11 +1,11 @@
 {
   "data": [
     {
-      "hostPattern": "host1",
+      "urlPattern": "host1",
       "delay": 100
     },
     {
-      "hostPattern": "host2",
+      "urlPattern": "host2",
       "delay": 110
     }
   ]

--- a/hoverctl/hoverfly.go
+++ b/hoverctl/hoverfly.go
@@ -21,12 +21,13 @@ type APIStateResponse struct {
 }
 
 type APIDelaysResponse struct {
-	Data []ResponseDelay
+	Data []ResponseDelay `json:"data"`
 }
 
 type ResponseDelay struct {
-	HostPattern string
-	Delay int
+	UrlPattern string `json:"urlpattern"`
+	Delay      int `json:"delay"`
+	HttpMethod string `json:"httpmethod"`
 }
 
 type Hoverfly struct {


### PR DESCRIPTION
Changed hostPattern in delay config to urlPattern, will now match on whole URL. Also added optional httpMethod parameter.

Cleanup up the code so theres now a ResponseDelays interface used by the hoverfly object directly, and its not part of the configuration struct as we decided that in this context delays aren't configuration. 

Added lots of tests and stuff. Changed router to take a pointer to the hoverfly object, so we can still inspect or make assertions on the object after the server starts