### PR TITLE
Circle load tests + Docker hub publish

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,9 +10,6 @@ checkout:
     - mkdir -p $GOPATH/src/github.com/SpectoLabs/hoverfly || echo "project dir already exists"
     - "rsync -az --delete ./ $GOPATH/src/github.com/SpectoLabs/hoverfly" 
     - "echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/gcloud-service-key.json"
-    - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update"
-    - "sudo /opt/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json"
-    - "sudo /opt/google-cloud-sdk/bin/gcloud config set project $GCLOUD_PROJECT"
 
 dependencies:
   pre:
@@ -21,6 +18,13 @@ dependencies:
     - sudo apt-get install -y glide
     - go get github.com/aktau/github-release
     - go get github.com/mitchellh/gox
+    - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update"
+    - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update kubectl"
+    - "sudo /opt/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json"
+    - "sudo /opt/google-cloud-sdk/bin/gcloud config set project $GCLOUD_PROJECT"
+    - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet config set container/cluster $CLUSTER_NAME"
+    - "sudo /opt/google-cloud-sdk/bin/gcloud config set compute/zone ${CLOUDSDK_COMPUTE_ZONE}"
+    - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet container clusters get-credentials $CLUSTER_NAME"
           
 test:
   override:
@@ -29,6 +33,7 @@ test:
   post:
     - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && docker build -t eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM  -f core/Dockerfile ."
     - "sudo /opt/google-cloud-sdk/bin/gcloud docker push eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM"
+    - "git clone https://github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && ./load-test.sh
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ test:
   post:
     - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && docker build -t eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM  -f core/Dockerfile ."
     - "sudo /opt/google-cloud-sdk/bin/gcloud docker push eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM"
-    - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && sudo load-test.sh"
+    - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && sudo \"PATH=$PATH\" ./load-test.sh"
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ test:
   post:
     - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && docker build -t eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM  -f core/Dockerfile ."
     - "sudo /opt/google-cloud-sdk/bin/gcloud docker push eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM"
-    - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && ./load-test.sh"
+    - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && sudo load-test.sh"
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,8 @@ test:
   post:
     - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && docker build -t eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM  -f core/Dockerfile ."
     - "sudo /opt/google-cloud-sdk/bin/gcloud docker push eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM"
+    - "docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS"
+    - "docker tag eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM benjvi/hoverfly:latest && docker push benjvi/hoverfly:latest"
     - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && sudo \"PATH=$PATH\" ./load-test.sh"
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,7 @@ dependencies:
     - go get github.com/mitchellh/gox
     - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update"
     - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update kubectl"
+    - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update alpha"
     - "sudo /opt/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json"
     - "sudo /opt/google-cloud-sdk/bin/gcloud config set project $GCLOUD_PROJECT"
     - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet config set container/cluster $CLUSTER_NAME"

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ test:
   post:
     - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && docker build -t eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM  -f core/Dockerfile ."
     - "sudo /opt/google-cloud-sdk/bin/gcloud docker push eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM"
-    - "git clone https://github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && ./load-test.sh"
+    - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && ./load-test.sh"
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -34,13 +34,16 @@ test:
   post:
     - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && docker build -t eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM  -f core/Dockerfile ."
     - "sudo /opt/google-cloud-sdk/bin/gcloud docker push eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM"
-    - "docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS"
-    - "docker tag eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM benjvi/hoverfly:latest && docker push benjvi/hoverfly:latest"
-    - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && sudo \"PATH=$PATH\" ./load-test.sh"
-
 deployment:
+  loadtest:
+    tag: /load-test/
+    commands:
+      - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && sudo \"PATH=$PATH\" ./load-test.sh"
   production:
     tag: /v[0-9]+(\.[0-9]+)*/
     commands:
+      - "docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS"
+      - "docker tag eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM spectolabs/hoverfly:latest && docker push spectolabs/hoverfly:latest"
+      - "git clone https://${GITHUB_TOKEN}@github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && sudo \"PATH=$PATH\" ./load-test.sh"
       - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && make build-release GIT_TAG_NAME=$CIRCLE_TAG SHELL=/bin/bash"
       - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly/target && for f in hover*;do github-release upload  --user SpectoLabs --repo hoverfly --tag \"$CIRCLE_TAG\" --name \"$f\" --file \"$f\"; done" 

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ test:
   post:
     - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && docker build -t eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM  -f core/Dockerfile ."
     - "sudo /opt/google-cloud-sdk/bin/gcloud docker push eu.gcr.io/specto-sandbox/hoverfly:$CIRCLE_BUILD_NUM"
-    - "git clone https://github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && ./load-test.sh
+    - "git clone https://github.com/SpectoLabs/hoverfly-load-testing && cd hoverfly-load-testing && ./load-test.sh"
 
 deployment:
   production:


### PR DESCRIPTION
Added commands in circle.yml and variables in circleci to support load testing and pushing to docker hub when the appropriate release tags are added to the repo (also can load test only by adding a 'load'test' tag)