### PR TITLE
Headers in webserver mode

### DIFF
--- a/core/proxy.go
+++ b/core/proxy.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 // Creates goproxy.ProxyHttpServer and configures it to be used as a proxy for Hoverfly
@@ -99,8 +100,18 @@ func NewWebserverProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 			w.WriteHeader(500)
 			return
 		}
+
+		for name, values := range resp.Header {
+			name = strings.ToLower(name)
+
+			for _, value := range values {
+				w.Header().Add(name, value)
+			}
+		}
+
 		w.Header().Set("Req", req.RequestURI)
 		w.Header().Set("Resp", resp.Header.Get("Content-Length"))
+
 		w.WriteHeader(resp.StatusCode)
 		w.Write(body)
 	})

--- a/functional-tests/core/ft_modes_test.go
+++ b/functional-tests/core/ft_modes_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Running Hoverfly in various modes", func() {
 		)
 
 		BeforeEach(func() {
-			jsonPayload = bytes.NewBufferString(`{"data":[{"request": {"path": "/path1", "method": "GET", "destination": "www.virtual.com", "scheme": "http", "query": "", "body": "", "headers": {"Header": ["value1"]}}, "response": {"status": 201, "encodedBody": false, "body": "body1", "headers": {"Header": ["value1"]}}}, {"request": {"path": "/path2", "method": "GET", "destination": "www.virtual.com", "scheme": "http", "query": "", "body": "", "headers": {"Header": ["value2"]}}, "response": {"status": 202, "body": "body2", "headers": {"Header": ["value2"]}}}]}`)
+			jsonPayload = bytes.NewBufferString(`{"data":[{"request": {"path": "/path1", "method": "GET", "destination": "www.virtual.com", "scheme": "http", "query": "", "body": "", "headers": {"Header": ["value1"]}}, "response": {"status": 201, "encodedBody": false, "body": "body1", "headers": {"Header": ["value1", "value2"]}}}, {"request": {"path": "/path2", "method": "GET", "destination": "www.virtual.com", "scheme": "http", "query": "", "body": "", "headers": {"Header": ["value2"]}}, "response": {"status": 202, "body": "body2", "headers": {"Header": ["value2"]}}}]}`)
 		})
 
 		Context("without middleware", func() {
@@ -192,7 +192,7 @@ var _ = Describe("Running Hoverfly in various modes", func() {
 				body, err := ioutil.ReadAll(resp.Body)
 				Expect(err).To(BeNil())
 				Expect(string(body)).To(Equal("body1"))
-				Expect(resp.Header).To(HaveKeyWithValue("Header", []string{"value1"}))
+				Expect(resp.Header).To(HaveKeyWithValue("Header", []string{"value1", "value2"}))
 			})
 		})
 

--- a/functional-tests/core/ft_webserver_test.go
+++ b/functional-tests/core/ft_webserver_test.go
@@ -25,7 +25,7 @@ var _ = Describe("When running Hoverfly as a webserver", func() {
 
 		BeforeEach(func() {
 			hoverflyCmd = startHoverflyWebServer(adminPort, proxyPort)
-			getPayload1 := bytes.NewBufferString(`{"data":[{"request": {"path": "/path1", "method": "GET", "destination": "destination1", "scheme": "", "query": "", "body": "", "headers": {"Header": ["value1"]}}, "response": {"status": 201, "encodedBody": false, "body": "body1", "headers": {"Header": ["value1"]}}}]}`)
+			getPayload1 := bytes.NewBufferString(`{"data":[{"request": {"path": "/path1", "method": "GET", "destination": "destination1", "scheme": "", "query": "", "body": "", "headers": {"Header": ["value1"]}}, "response": {"status": 201, "encodedBody": false, "body": "body1", "headers": {"Header": ["value1", "value2"]}}}]}`)
 			getPayload2 := bytes.NewBufferString(`{"data":[{"request": {"path": "/path1/resource", "method": "GET", "destination": "another-destination.com", "scheme": "", "query": "", "body": "", "headers": {"Header": ["value1"]}}, "response": {"status": 201, "encodedBody": false, "body": "another-host.com body1", "headers": {"Header": ["value1"]}}}]}`)
 			postPayload1 := bytes.NewBufferString(`{"data":[{"request": {"path": "/path2", "method": "POST", "destination": "destination1", "scheme": "", "query": "", "body": "", "headers": {"Header": ["value1"]}}, "response": {"status": 201, "encodedBody": false, "body": "body2", "headers": {"Header": ["value1"]}}}]}`)
 			postPayload2 := bytes.NewBufferString(`{"data":[{"request": {"path": "/path2/resource", "method": "POST", "destination": "another-destination.com", "scheme": "", "query": "", "body": "", "headers": {"Header": ["value1"]}}, "response": {"status": 201, "encodedBody": false, "body": "another-host.com body2", "headers": {"Header": ["value1"]}}}]}`)
@@ -51,6 +51,14 @@ var _ = Describe("When running Hoverfly as a webserver", func() {
 					Expect(err).To(BeNil())
 
 					Expect(string(responseBody)).To(Equal("body1"))
+				})
+
+				It("and it should return the correct headers on the response", func() {
+					request := sling.New().Get("http://localhost:" + proxyPortAsString + "/path1")
+
+					response := DoRequest(request)
+
+					Expect(response.Header).To(HaveKeyWithValue("Header", []string{"value1", "value2"}))
 				})
 			})
 


### PR DESCRIPTION
@paprende discovered a bug with webserver mode.

When using webserver mode, the responses that it serve don't have the headers that are stored in the cache.

This branch fixes this by iterating through the headers on the generated response and then adds them to the response being written in the webserver.