### PR TITLE
Fixed a bug where redirects where not saved

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,14 @@ machine:
 
   environment:
     GOPATH: /home/ubuntu/.go_workspace
+    GODIST: "go1.7.linux-amd64.tar.gz"
+    IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 
+  post:
+    - mkdir -p download
+    - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
+    - sudo rm -rf /usr/local/go
+    - sudo tar -C /usr/local -xzf download/$GODIST
 checkout:
   post:
     - mkdir -p $GOPATH/src/github.com/SpectoLabs/hoverfly || echo "project dir already exists"

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -65,11 +65,14 @@ func GetNewHoverfly(cfg *Configuration, requestCache, metadataCache cache.Cache,
 		TemplateStore: matching.RequestTemplateStore{},
 		Webserver:     &cfg.Webserver,
 	}
+
 	h := &Hoverfly{
 		RequestCache:   requestCache,
 		MetadataCache:  metadataCache,
 		Authentication: authentication,
-		HTTP: &http.Client{Transport: &http.Transport{
+		HTTP: &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}, Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.TLSVerification},
 		}},
 		Cfg:            cfg,

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -269,7 +269,6 @@ func (hf *Hoverfly) processRequest(req *http.Request) *http.Response {
 	}
 
 	return response
-
 }
 
 // AddHook - adds a hook to DBClient

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -269,10 +269,6 @@ func (hf *Hoverfly) processRequest(req *http.Request) *http.Response {
 	}
 
 	return response
-<<<<<<< 99237bc17a6478da8a9ac0eb598e683e08e56688
-=======
-
->>>>>>> Refactored the hoverfly.processRequest to not return the request as the modified request is never returned
 }
 
 // AddHook - adds a hook to DBClient

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -269,6 +269,10 @@ func (hf *Hoverfly) processRequest(req *http.Request) *http.Response {
 	}
 
 	return response
+<<<<<<< 99237bc17a6478da8a9ac0eb598e683e08e56688
+=======
+
+>>>>>>> Refactored the hoverfly.processRequest to not return the request as the modified request is never returned
 }
 
 // AddHook - adds a hook to DBClient

--- a/functional-tests/core/ft_suite_test.go
+++ b/functional-tests/core/ft_suite_test.go
@@ -166,7 +166,7 @@ func DoRequestThroughProxy(r *sling.Sling) *http.Response {
 	Expect(err).To(BeNil())
 
 	proxy, err := url.Parse(hoverflyProxyUrl)
-	proxyHttpClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxy)}}
+	proxyHttpClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxy)}, CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
 	response, err := proxyHttpClient.Do(req)
 
 	Expect(err).To(BeNil())


### PR DESCRIPTION
What was happening was the default HTTP client in Golang would resolve redirects by default. This meant that anyone trying to capture redirects using Hoverfly would instead, only capture the response after being redirected.

This is now changed so that the redirect is served up so that Hoverfly will now capture the redirect and the response after redirection, but will now let an external client act on the redirect.