### PR TITLE
Tidy up and removing views from ResponseDelays

### DIFF
--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -934,7 +934,7 @@ func TestGetResponseDelays(t *testing.T) {
 	}
 	delays := []v1.ResponseDelayView{delay}
 
-	delaysPayload := v1.ResponseDelayPayload{
+	delaysPayload := v1.ResponseDelayPayloadView{
 		Data: &delays,
 	}
 

--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -935,7 +935,7 @@ func TestGetResponseDelays(t *testing.T) {
 	delays := []v1.ResponseDelayView{delay}
 
 	delaysPayload := v1.ResponseDelayPayloadView{
-		Data: &delays,
+		Data: delays,
 	}
 
 	dbClient.SetResponseDelays(delaysPayload)

--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/views"
 	. "github.com/onsi/gomega"
@@ -11,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
 )
 
 var adminApi = AdminApi{}
@@ -927,13 +927,18 @@ func TestGetResponseDelays(t *testing.T) {
 	defer server.Close()
 	defer dbClient.RequestCache.DeleteData()
 
-	delay := models.ResponseDelay{
+	delay := v1.ResponseDelayView{
 		UrlPattern: ".",
+		HttpMethod: "GET",
 		Delay:      100,
 	}
-	delays := models.ResponseDelayList{delay}
+	delays := []v1.ResponseDelayView{delay}
 
-	dbClient.SetResponseDelays(models.ResponseDelayPayload{Data: &delays})
+	delaysPayload := v1.ResponseDelayPayload{
+		Data: &delays,
+	}
+
+	dbClient.SetResponseDelays(delaysPayload)
 
 	m := adminApi.getBoneRouter(dbClient)
 
@@ -951,7 +956,8 @@ func TestGetResponseDelays(t *testing.T) {
 	err = json.Unmarshal(body, &sr)
 
 	// normal equality checking doesn't work on slices (!!)
-	Expect(*sr.Data).To(Equal(delays))
+	delayList := models.ResponseDelayList{{UrlPattern: ".", HttpMethod: "GET", Delay: 100}}
+	Expect(*sr.Data).To(Equal(delayList))
 }
 
 func TestDeleteAllResponseDelaysHandler(t *testing.T) {

--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -932,7 +932,8 @@ func TestGetResponseDelays(t *testing.T) {
 		Delay:      100,
 	}
 	delays := models.ResponseDelayList{delay}
-	dbClient.UpdateResponseDelays(delays)
+
+	dbClient.SetResponseDelays(models.ResponseDelayPayload{Data: &delays})
 
 	m := adminApi.getBoneRouter(dbClient)
 

--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -952,12 +952,12 @@ func TestGetResponseDelays(t *testing.T) {
 
 	body, err := ioutil.ReadAll(rec.Body)
 
-	sr := models.ResponseDelayPayload{}
+	sr := v1.ResponseDelayPayloadView{}
 	err = json.Unmarshal(body, &sr)
 
 	// normal equality checking doesn't work on slices (!!)
-	delayList := models.ResponseDelayList{{UrlPattern: ".", HttpMethod: "GET", Delay: 100}}
-	Expect(*sr.Data).To(Equal(delayList))
+	delayList := []v1.ResponseDelayView{{UrlPattern: ".", HttpMethod: "GET", Delay: 100}}
+	Expect(sr.Data).To(Equal(delayList))
 }
 
 func TestDeleteAllResponseDelaysHandler(t *testing.T) {
@@ -993,16 +993,16 @@ func TestUpdateResponseDelays(t *testing.T) {
 	defer dbClient.RequestCache.DeleteData()
 	m := adminApi.getBoneRouter(dbClient)
 
-	delayOne := models.ResponseDelay{
+	delayOne := v1.ResponseDelayView{
 		UrlPattern: ".",
 		Delay:      100,
 	}
-	delayTwo := models.ResponseDelay{
+	delayTwo := v1.ResponseDelayView{
 		UrlPattern: "example",
 		Delay:      100,
 	}
-	delays := models.ResponseDelayList{delayOne, delayTwo}
-	delayJson := models.ResponseDelayPayload{Data: &delays}
+	delays := []v1.ResponseDelayView{delayOne, delayTwo}
+	delayJson := v1.ResponseDelayPayloadView{Data: delays}
 	delayJsonBytes, err := json.Marshal(&delayJson)
 	Expect(err).To(BeNil())
 
@@ -1015,8 +1015,7 @@ func TestUpdateResponseDelays(t *testing.T) {
 	m.ServeHTTP(rec, req)
 	Expect(rec.Code).To(Equal(http.StatusCreated))
 
-	// normal equality checking doesn't work on slices (!!)
-	Expect(dbClient.ResponseDelays).To(Equal(&delays))
+	Expect(dbClient.ResponseDelays.ConvertToResponseDelayPayloadView()).To(Equal(delayJson))
 }
 
 func TestInvalidJSONSyntaxUpdateResponseDelays(t *testing.T) {

--- a/core/handlers/v1/count_handler.go
+++ b/core/handlers/v1/count_handler.go
@@ -9,8 +9,12 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/handlers"
 )
 
+type HoverflyCount interface {
+	GetRequestCacheCount() (int, error)
+}
+
 type CountHandler struct {
-	Hoverfly HoverflyRecords
+	Hoverfly HoverflyCount
 }
 
 func (this *CountHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandler) {
@@ -22,7 +26,7 @@ func (this *CountHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandler
 
 // RecordsCount returns number of captured requests as a JSON payload
 func (this *CountHandler) Get(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	count, err := this.Hoverfly.GetRequestCache().RecordsCount()
+	count, err := this.Hoverfly.GetRequestCacheCount()
 
 	if err == nil {
 

--- a/core/handlers/v1/delays_handler.go
+++ b/core/handlers/v1/delays_handler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/SpectoLabs/hoverfly/core/handlers"
-	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/codegangsta/negroni"
 	"github.com/go-zoo/bone"
 	"io/ioutil"
@@ -15,7 +14,7 @@ import (
 
 type HoverflyDelays interface {
 	GetResponseDelays() []byte
-	SetResponseDelays(models.ResponseDelayPayload) error
+	SetResponseDelays(ResponseDelayPayload) error
 	DeleteResponseDelays()
 }
 
@@ -47,7 +46,7 @@ func (this *DelaysHandler) Get(w http.ResponseWriter, req *http.Request, next ht
 }
 
 func (this *DelaysHandler) Put(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	var responseDelaysView models.ResponseDelayPayload
+	var responseDelaysView ResponseDelayPayload
 	var mr MessageResponse
 
 	if req.Body == nil {

--- a/core/handlers/v1/delays_handler.go
+++ b/core/handlers/v1/delays_handler.go
@@ -14,7 +14,7 @@ import (
 
 type HoverflyDelays interface {
 	GetResponseDelays() []byte
-	SetResponseDelays(ResponseDelayPayload) error
+	SetResponseDelays(ResponseDelayPayloadView) error
 	DeleteResponseDelays()
 }
 
@@ -46,7 +46,7 @@ func (this *DelaysHandler) Get(w http.ResponseWriter, req *http.Request, next ht
 }
 
 func (this *DelaysHandler) Put(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	var responseDelaysView ResponseDelayPayload
+	var responseDelaysView ResponseDelayPayloadView
 	var mr MessageResponse
 
 	if req.Body == nil {

--- a/core/handlers/v1/delays_handler.go
+++ b/core/handlers/v1/delays_handler.go
@@ -13,7 +13,7 @@ import (
 )
 
 type HoverflyDelays interface {
-	GetResponseDelays() []byte
+	GetResponseDelays() ResponseDelayPayloadView
 	SetResponseDelays(ResponseDelayPayloadView) error
 	DeleteResponseDelays()
 }
@@ -40,9 +40,14 @@ func (this *DelaysHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandle
 }
 
 func (this *DelaysHandler) Get(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	b := this.Hoverfly.GetResponseDelays()
+	payloadView := this.Hoverfly.GetResponseDelays()
+	bytes, err := json.Marshal(payloadView)
+	if err != nil {
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.Write(b)
+	w.Write(bytes)
 }
 
 func (this *DelaysHandler) Put(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {

--- a/core/handlers/v1/delays_handler.go
+++ b/core/handlers/v1/delays_handler.go
@@ -14,7 +14,7 @@ import (
 )
 
 type HoverflyDelays interface {
-	GetResponseDelays() models.ResponseDelays
+	GetResponseDelays() []byte
 	SetResponseDelays(models.ResponseDelayPayload) error
 	DeleteResponseDelays()
 }
@@ -41,7 +41,7 @@ func (this *DelaysHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandle
 }
 
 func (this *DelaysHandler) Get(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	b := this.Hoverfly.GetResponseDelays().Json()
+	b := this.Hoverfly.GetResponseDelays()
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.Write(b)
 }

--- a/core/handlers/v1/records_handler.go
+++ b/core/handlers/v1/records_handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
-	"github.com/SpectoLabs/hoverfly/core/cache"
 	"github.com/SpectoLabs/hoverfly/core/handlers"
 	"github.com/SpectoLabs/hoverfly/core/views"
 	"github.com/codegangsta/negroni"
@@ -14,7 +13,7 @@ import (
 )
 
 type HoverflyRecords interface {
-	GetRequestCache() cache.Cache
+	DeleteRequestCache() error
 	GetRecords() ([]views.RequestResponsePairView, error)
 	ImportRequestResponsePairViews(pairViews []views.RequestResponsePairView) error
 }
@@ -121,7 +120,7 @@ func (this *RecordsHandler) Post(w http.ResponseWriter, req *http.Request, next 
 
 // DeleteAllRecordsHandler - deletes all captured requests
 func (this *RecordsHandler) Delete(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	err := this.Hoverfly.GetRequestCache().DeleteData()
+	err := this.Hoverfly.DeleteRequestCache()
 
 	w.Header().Set("Content-Type", "application/json")
 

--- a/core/handlers/v1/state_handler.go
+++ b/core/handlers/v1/state_handler.go
@@ -5,18 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/SpectoLabs/hoverfly/core/handlers"
 	"github.com/codegangsta/negroni"
 	"github.com/go-zoo/bone"
 	"io/ioutil"
 	"net/http"
-	"github.com/SpectoLabs/hoverfly/core/handlers"
 )
 
 type HoverflyState interface {
 	GetMode() string
 	SetMode(string) error
 	GetDestination() string
-	UpdateDestination(string) error
+	SetDestination(string) error
 }
 
 type StateHandler struct {
@@ -105,7 +105,7 @@ func (this *StateHandler) Post(w http.ResponseWriter, r *http.Request, next http
 
 	// checking whether we should update destination
 	if sr.Destination != "" {
-		err := this.Hoverfly.UpdateDestination(sr.Destination)
+		err := this.Hoverfly.SetDestination(sr.Destination)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error while updating destination: %s", err.Error()), 500)
 			return

--- a/core/handlers/v1/stats_handler.go
+++ b/core/handlers/v1/stats_handler.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"encoding/json"
 	log "github.com/Sirupsen/logrus"
-	"github.com/SpectoLabs/hoverfly/core/cache"
 	"github.com/SpectoLabs/hoverfly/core/metrics"
 	"github.com/codegangsta/negroni"
 	"github.com/go-zoo/bone"
@@ -16,7 +15,7 @@ import (
 
 type HoverflyStats interface {
 	GetStats() metrics.Stats
-	GetRequestCache() cache.Cache
+	GetRequestCacheCount() (int, error)
 }
 
 type StatsHandler struct {
@@ -36,7 +35,7 @@ func (this *StatsHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandler
 func (this *StatsHandler) Get(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	stats := this.Hoverfly.GetStats()
 
-	count, err := this.Hoverfly.GetRequestCache().RecordsCount()
+	count, err := this.Hoverfly.GetRequestCacheCount()
 
 	if err != nil {
 		log.Error(err)
@@ -93,7 +92,7 @@ func (this *StatsHandler) GetWS(w http.ResponseWriter, r *http.Request) {
 		}).Info("Got message...")
 
 		for _ = range time.Tick(1 * time.Second) {
-			count, err := this.Hoverfly.GetRequestCache().RecordsCount()
+			count, err := this.Hoverfly.GetRequestCacheCount()
 			if err != nil {
 				log.WithFields(log.Fields{
 					"message": p,

--- a/core/handlers/v1/views.go
+++ b/core/handlers/v1/views.go
@@ -67,3 +67,13 @@ type RequestTemplateView struct {
 	Body        *string             `json:"body"`
 	Headers     map[string][]string `json:"headers"`
 }
+
+type ResponseDelay struct {
+	UrlPattern string `json:"urlPattern"`
+	HttpMethod string `json:"httpMethod"`
+	Delay      int    `json:"delay"`
+}
+
+type ResponseDelayPayload struct {
+	Data *[]RequestTemplateView `json:"data"`
+}

--- a/core/handlers/v1/views.go
+++ b/core/handlers/v1/views.go
@@ -74,6 +74,6 @@ type ResponseDelayView struct {
 	Delay      int    `json:"delay"`
 }
 
-type ResponseDelayPayload struct {
+type ResponseDelayPayloadView struct {
 	Data *[]ResponseDelayView `json:"data"`
 }

--- a/core/handlers/v1/views.go
+++ b/core/handlers/v1/views.go
@@ -75,5 +75,5 @@ type ResponseDelayView struct {
 }
 
 type ResponseDelayPayloadView struct {
-	Data *[]ResponseDelayView `json:"data"`
+	Data []ResponseDelayView `json:"data"`
 }

--- a/core/handlers/v1/views.go
+++ b/core/handlers/v1/views.go
@@ -68,12 +68,12 @@ type RequestTemplateView struct {
 	Headers     map[string][]string `json:"headers"`
 }
 
-type ResponseDelay struct {
+type ResponseDelayView struct {
 	UrlPattern string `json:"urlPattern"`
 	HttpMethod string `json:"httpMethod"`
 	Delay      int    `json:"delay"`
 }
 
 type ResponseDelayPayload struct {
-	Data *[]RequestTemplateView `json:"data"`
+	Data *[]ResponseDelayView `json:"data"`
 }

--- a/core/handlers/v2/hoverfly_destination_handler.go
+++ b/core/handlers/v2/hoverfly_destination_handler.go
@@ -5,13 +5,13 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/handlers"
 	"github.com/codegangsta/negroni"
 	"github.com/go-zoo/bone"
-	"net/http"
 	"io/ioutil"
+	"net/http"
 )
 
 type HoverflyDestination interface {
 	GetDestination() string
-	UpdateDestination(string) error
+	SetDestination(string) error
 }
 
 type HoverflyDestinationHandler struct {
@@ -52,7 +52,7 @@ func (this *HoverflyDestinationHandler) Put(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	err = this.Hoverfly.UpdateDestination(destinationView.Destination)
+	err = this.Hoverfly.SetDestination(destinationView.Destination)
 	if err != nil {
 		handlers.WriteErrorResponse(w, err.Error(), 422)
 		return

--- a/core/handlers/v2/hoverfly_destination_handler_test.go
+++ b/core/handlers/v2/hoverfly_destination_handler_test.go
@@ -18,7 +18,7 @@ func (this HoverflyDestinationStub) GetDestination() string {
 	return this.Destination
 }
 
-func (this *HoverflyDestinationStub) UpdateDestination(destination string) error {
+func (this *HoverflyDestinationStub) SetDestination(destination string) error {
 	this.Destination = destination
 	if destination == "error" {
 		return fmt.Errorf("error")

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -7,16 +7,13 @@ import (
 	log "github.com/Sirupsen/logrus"
 	authBackend "github.com/SpectoLabs/hoverfly/core/authentication/backends"
 	"github.com/SpectoLabs/hoverfly/core/cache"
-	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
 	"github.com/SpectoLabs/hoverfly/core/matching"
 	"github.com/SpectoLabs/hoverfly/core/metrics"
 	"github.com/SpectoLabs/hoverfly/core/models"
-	"github.com/SpectoLabs/hoverfly/core/views"
 	"github.com/rusenask/goproxy"
 	"io/ioutil"
 	"net"
 	"net/http"
-	"regexp"
 	"sync"
 	"time"
 )
@@ -143,153 +140,6 @@ func (hf *Hoverfly) StartProxy() error {
 func (hf *Hoverfly) StopProxy() {
 	hf.SL.Stop()
 	hf.Cfg.ProxyControlWG.Wait()
-}
-
-// UpdateDestination - updates proxy with new destination regexp
-func (hf *Hoverfly) UpdateDestination(destination string) (err error) {
-	_, err = regexp.Compile(destination)
-	if err != nil {
-		return fmt.Errorf("destination is not a valid regular expression string")
-	}
-
-	hf.mu.Lock()
-	hf.StopProxy()
-	hf.Cfg.Destination = destination
-	err = hf.StartProxy()
-	hf.mu.Unlock()
-	return
-}
-
-func (hf Hoverfly) GetRequestCache() cache.Cache {
-	return hf.RequestCache
-}
-
-func (this Hoverfly) GetMetadataCache() cache.Cache {
-	return this.MetadataCache
-}
-
-func (this Hoverfly) GetTemplateCache() matching.RequestTemplateStore {
-	return this.RequestMatcher.TemplateStore
-}
-
-func (this Hoverfly) GetTemplates() v1.RequestTemplateResponsePairPayload {
-	return this.RequestMatcher.TemplateStore.GetPayload()
-}
-
-func (this *Hoverfly) DeleteTemplateCache() {
-	this.RequestMatcher.TemplateStore.Wipe()
-}
-
-func (this *Hoverfly) ImportTemplates(pairPayload v1.RequestTemplateResponsePairPayload) error {
-	return this.RequestMatcher.TemplateStore.ImportPayloads(pairPayload)
-}
-
-func (hf Hoverfly) GetMiddleware() string {
-	return hf.Cfg.Middleware
-}
-
-func (hf Hoverfly) SetMiddleware(middleware string) error {
-	if middleware == "" {
-		hf.Cfg.Middleware = middleware
-		return nil
-	}
-	originalPair := models.RequestResponsePair{
-		Request: models.RequestDetails{
-			Path:        "/",
-			Method:      "GET",
-			Destination: "www.test.com",
-			Scheme:      "",
-			Query:       "",
-			Body:        "",
-			Headers:     map[string][]string{"test_header": []string{"true"}},
-		},
-		Response: models.ResponseDetails{
-			Status:  200,
-			Body:    "ok",
-			Headers: map[string][]string{"test_header": []string{"true"}},
-		},
-	}
-	c := NewConstructor(nil, originalPair)
-	err := c.ApplyMiddleware(middleware)
-	if err != nil {
-		return err
-	}
-
-	hf.Cfg.Middleware = middleware
-	return nil
-}
-
-func (this Hoverfly) GetMode() string {
-	return this.Cfg.Mode
-}
-
-func (this *Hoverfly) SetMode(mode string) error {
-	availableModes := map[string]bool{
-		"simulate":   true,
-		"capture":    true,
-		"modify":     true,
-		"synthesize": true,
-	}
-
-	if mode == "" || !availableModes[mode] {
-		log.Error("Can't change mode to \"%d\"", mode)
-		return fmt.Errorf("Not a valid mode")
-	}
-
-	if this.Cfg.Webserver {
-		log.Error("Can't change state when configured as a webserver ")
-		return fmt.Errorf("Can't change state when configured as a webserver")
-	}
-	this.Cfg.SetMode(mode)
-	return nil
-}
-
-func (this Hoverfly) GetDestination() string {
-	return this.Cfg.Destination
-}
-
-func (hf *Hoverfly) UpdateResponseDelays(responseDelays models.ResponseDelayList) {
-	hf.ResponseDelays = &responseDelays
-	log.Info("Response delay config updated on hoverfly")
-}
-
-func (hf *Hoverfly) GetResponseDelays() models.ResponseDelays {
-	return hf.ResponseDelays
-}
-
-func (hf *Hoverfly) DeleteResponseDelays() {
-	hf.ResponseDelays = &models.ResponseDelayList{}
-}
-
-func (hf Hoverfly) GetStats() metrics.Stats {
-	return hf.Counter.Flush()
-}
-
-func (hf Hoverfly) GetRecords() ([]views.RequestResponsePairView, error) {
-	records, err := hf.RequestCache.GetAllEntries()
-	if err != nil {
-		return nil, err
-	}
-
-	var pairViews []views.RequestResponsePairView
-
-	for _, v := range records {
-		if pair, err := models.NewRequestResponsePairFromBytes(v); err == nil {
-			pairView := pair.ConvertToRequestResponsePairView()
-			pairViews = append(pairViews, *pairView)
-		} else {
-			log.Error(err)
-			return nil, err
-		}
-	}
-
-	for _, v := range hf.RequestMatcher.TemplateStore {
-		pairView := v.ConvertToRequestResponsePairView()
-		pairViews = append(pairViews, pairView)
-	}
-
-	return pairViews, nil
-
 }
 
 func hoverflyError(req *http.Request, err error, msg string, statusCode int) *http.Response {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -126,7 +126,7 @@ func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayloadView) e
 
 	var responseDelays models.ResponseDelayList
 
-	for _, responseDelayView := range *payloadView.Data {
+	for _, responseDelayView := range payloadView.Data {
 		responseDelays = append(responseDelays, models.ResponseDelay{
 			UrlPattern: responseDelayView.UrlPattern,
 			HttpMethod: responseDelayView.HttpMethod,

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -114,8 +114,8 @@ func (this *Hoverfly) DeleteTemplateCache() {
 	this.RequestMatcher.TemplateStore.Wipe()
 }
 
-func (hf *Hoverfly) GetResponseDelays() models.ResponseDelays {
-	return hf.ResponseDelays
+func (hf *Hoverfly) GetResponseDelays() []byte {
+	return hf.ResponseDelays.Json()
 }
 
 func (hf *Hoverfly) SetResponseDelays(payload models.ResponseDelayPayload) error {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -1,0 +1,155 @@
+package hoverfly
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/SpectoLabs/hoverfly/core/cache"
+	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
+	"github.com/SpectoLabs/hoverfly/core/metrics"
+	"github.com/SpectoLabs/hoverfly/core/models"
+	"github.com/SpectoLabs/hoverfly/core/views"
+	"regexp"
+)
+
+// UpdateDestination - updates proxy with new destination regexp
+func (hf *Hoverfly) UpdateDestination(destination string) (err error) {
+	_, err = regexp.Compile(destination)
+	if err != nil {
+		return fmt.Errorf("destination is not a valid regular expression string")
+	}
+
+	hf.mu.Lock()
+	hf.StopProxy()
+	hf.Cfg.Destination = destination
+	err = hf.StartProxy()
+	hf.mu.Unlock()
+	return
+}
+
+func (hf Hoverfly) GetRequestCache() cache.Cache {
+	return hf.RequestCache
+}
+
+func (this Hoverfly) GetMetadataCache() cache.Cache {
+	return this.MetadataCache
+}
+
+func (this Hoverfly) GetTemplates() v1.RequestTemplateResponsePairPayload {
+	return this.RequestMatcher.TemplateStore.GetPayload()
+}
+
+func (this *Hoverfly) DeleteTemplateCache() {
+	this.RequestMatcher.TemplateStore.Wipe()
+}
+
+func (this *Hoverfly) ImportTemplates(pairPayload v1.RequestTemplateResponsePairPayload) error {
+	return this.RequestMatcher.TemplateStore.ImportPayloads(pairPayload)
+}
+
+func (hf Hoverfly) GetMiddleware() string {
+	return hf.Cfg.Middleware
+}
+
+func (hf Hoverfly) SetMiddleware(middleware string) error {
+	if middleware == "" {
+		hf.Cfg.Middleware = middleware
+		return nil
+	}
+	originalPair := models.RequestResponsePair{
+		Request: models.RequestDetails{
+			Path:        "/",
+			Method:      "GET",
+			Destination: "www.test.com",
+			Scheme:      "",
+			Query:       "",
+			Body:        "",
+			Headers:     map[string][]string{"test_header": []string{"true"}},
+		},
+		Response: models.ResponseDetails{
+			Status:  200,
+			Body:    "ok",
+			Headers: map[string][]string{"test_header": []string{"true"}},
+		},
+	}
+	c := NewConstructor(nil, originalPair)
+	err := c.ApplyMiddleware(middleware)
+	if err != nil {
+		return err
+	}
+
+	hf.Cfg.Middleware = middleware
+	return nil
+}
+
+func (this Hoverfly) GetMode() string {
+	return this.Cfg.Mode
+}
+
+func (this *Hoverfly) SetMode(mode string) error {
+	availableModes := map[string]bool{
+		"simulate":   true,
+		"capture":    true,
+		"modify":     true,
+		"synthesize": true,
+	}
+
+	if mode == "" || !availableModes[mode] {
+		log.Error("Can't change mode to \"%d\"", mode)
+		return fmt.Errorf("Not a valid mode")
+	}
+
+	if this.Cfg.Webserver {
+		log.Error("Can't change state when configured as a webserver ")
+		return fmt.Errorf("Can't change state when configured as a webserver")
+	}
+	this.Cfg.SetMode(mode)
+	return nil
+}
+
+func (this Hoverfly) GetDestination() string {
+	return this.Cfg.Destination
+}
+
+func (hf *Hoverfly) UpdateResponseDelays(responseDelays models.ResponseDelayList) {
+	hf.ResponseDelays = &responseDelays
+	log.Info("Response delay config updated on hoverfly")
+}
+
+func (hf *Hoverfly) GetResponseDelays() models.ResponseDelays {
+	return hf.ResponseDelays
+}
+
+func (hf *Hoverfly) DeleteResponseDelays() {
+	hf.ResponseDelays = &models.ResponseDelayList{}
+}
+
+func (hf Hoverfly) GetStats() metrics.Stats {
+	return hf.Counter.Flush()
+}
+
+func (hf Hoverfly) GetRecords() ([]views.RequestResponsePairView, error) {
+	records, err := hf.RequestCache.GetAllEntries()
+	if err != nil {
+		return nil, err
+	}
+
+	var pairViews []views.RequestResponsePairView
+
+	for _, v := range records {
+		if pair, err := models.NewRequestResponsePairFromBytes(v); err == nil {
+			pairView := pair.ConvertToRequestResponsePairView()
+			pairViews = append(pairViews, *pairView)
+		} else {
+			log.Error(err)
+			return nil, err
+		}
+	}
+
+	for _, v := range hf.RequestMatcher.TemplateStore {
+		pairView := v.ConvertToRequestResponsePairView()
+		pairViews = append(pairViews, pairView)
+	}
+
+	return pairViews, nil
+
+}

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -119,7 +119,7 @@ func (hf *Hoverfly) GetResponseDelays() []byte {
 }
 
 func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayload) error {
-	err := models.ValidateResponseDelayJson(payloadView)
+	err := models.ValidateResponseDelayPayload(payloadView)
 	if err != nil {
 		return err
 	}

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -118,7 +118,21 @@ func (hf *Hoverfly) GetResponseDelays() []byte {
 	return hf.ResponseDelays.Json()
 }
 
-func (hf *Hoverfly) SetResponseDelays(payload models.ResponseDelayPayload) error {
+func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayload) error {
+	var responseDelays models.ResponseDelayList
+
+	for _, responseDelayView := range *payloadView.Data {
+		responseDelays = append(responseDelays, models.ResponseDelay{
+			UrlPattern: responseDelayView.UrlPattern,
+			HttpMethod: responseDelayView.HttpMethod,
+			Delay:      responseDelayView.Delay,
+		})
+	}
+
+	payload := models.ResponseDelayPayload{
+		Data: &responseDelays,
+	}
+
 	err := models.ValidateResponseDelayJson(payload)
 	if err != nil {
 		return err

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -134,11 +134,7 @@ func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayloadView) e
 		})
 	}
 
-	payload := models.ResponseDelayPayload{
-		Data: &responseDelays,
-	}
-
-	hf.ResponseDelays = payload.Data
+	hf.ResponseDelays = &responseDelays
 	return nil
 }
 

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -118,7 +118,7 @@ func (hf *Hoverfly) GetResponseDelays() []byte {
 	return hf.ResponseDelays.Json()
 }
 
-func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayload) error {
+func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayloadView) error {
 	err := models.ValidateResponseDelayPayload(payloadView)
 	if err != nil {
 		return err

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -12,7 +12,7 @@ import (
 )
 
 // UpdateDestination - updates proxy with new destination regexp
-func (hf *Hoverfly) UpdateDestination(destination string) (err error) {
+func (hf *Hoverfly) SetDestination(destination string) (err error) {
 	_, err = regexp.Compile(destination)
 	if err != nil {
 		return fmt.Errorf("destination is not a valid regular expression string")

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -11,6 +11,10 @@ import (
 	"regexp"
 )
 
+func (this Hoverfly) GetDestination() string {
+	return this.Cfg.Destination
+}
+
 // UpdateDestination - updates proxy with new destination regexp
 func (hf *Hoverfly) SetDestination(destination string) (err error) {
 	_, err = regexp.Compile(destination)
@@ -26,28 +30,29 @@ func (hf *Hoverfly) SetDestination(destination string) (err error) {
 	return
 }
 
-func (hf Hoverfly) DeleteRequestCache() error {
-	return hf.RequestCache.DeleteData()
+func (this Hoverfly) GetMode() string {
+	return this.Cfg.Mode
 }
 
-func (hf Hoverfly) GetRequestCacheCount() (int, error) {
-	return hf.RequestCache.RecordsCount()
-}
+func (this *Hoverfly) SetMode(mode string) error {
+	availableModes := map[string]bool{
+		"simulate":   true,
+		"capture":    true,
+		"modify":     true,
+		"synthesize": true,
+	}
 
-func (this Hoverfly) GetMetadataCache() cache.Cache {
-	return this.MetadataCache
-}
+	if mode == "" || !availableModes[mode] {
+		log.Error("Can't change mode to \"%d\"", mode)
+		return fmt.Errorf("Not a valid mode")
+	}
 
-func (this Hoverfly) GetTemplates() v1.RequestTemplateResponsePairPayload {
-	return this.RequestMatcher.TemplateStore.GetPayload()
-}
-
-func (this *Hoverfly) DeleteTemplateCache() {
-	this.RequestMatcher.TemplateStore.Wipe()
-}
-
-func (this *Hoverfly) ImportTemplates(pairPayload v1.RequestTemplateResponsePairPayload) error {
-	return this.RequestMatcher.TemplateStore.ImportPayloads(pairPayload)
+	if this.Cfg.Webserver {
+		log.Error("Can't change state when configured as a webserver ")
+		return fmt.Errorf("Can't change state when configured as a webserver")
+	}
+	this.Cfg.SetMode(mode)
+	return nil
 }
 
 func (hf Hoverfly) GetMiddleware() string {
@@ -85,42 +90,37 @@ func (hf Hoverfly) SetMiddleware(middleware string) error {
 	return nil
 }
 
-func (this Hoverfly) GetMode() string {
-	return this.Cfg.Mode
+func (hf Hoverfly) GetRequestCacheCount() (int, error) {
+	return hf.RequestCache.RecordsCount()
 }
 
-func (this *Hoverfly) SetMode(mode string) error {
-	availableModes := map[string]bool{
-		"simulate":   true,
-		"capture":    true,
-		"modify":     true,
-		"synthesize": true,
-	}
-
-	if mode == "" || !availableModes[mode] {
-		log.Error("Can't change mode to \"%d\"", mode)
-		return fmt.Errorf("Not a valid mode")
-	}
-
-	if this.Cfg.Webserver {
-		log.Error("Can't change state when configured as a webserver ")
-		return fmt.Errorf("Can't change state when configured as a webserver")
-	}
-	this.Cfg.SetMode(mode)
-	return nil
+func (this Hoverfly) GetMetadataCache() cache.Cache {
+	return this.MetadataCache
 }
 
-func (this Hoverfly) GetDestination() string {
-	return this.Cfg.Destination
+func (hf Hoverfly) DeleteRequestCache() error {
+	return hf.RequestCache.DeleteData()
+}
+
+func (this Hoverfly) GetTemplates() v1.RequestTemplateResponsePairPayload {
+	return this.RequestMatcher.TemplateStore.GetPayload()
+}
+
+func (this *Hoverfly) ImportTemplates(pairPayload v1.RequestTemplateResponsePairPayload) error {
+	return this.RequestMatcher.TemplateStore.ImportPayloads(pairPayload)
+}
+
+func (this *Hoverfly) DeleteTemplateCache() {
+	this.RequestMatcher.TemplateStore.Wipe()
+}
+
+func (hf *Hoverfly) GetResponseDelays() models.ResponseDelays {
+	return hf.ResponseDelays
 }
 
 func (hf *Hoverfly) UpdateResponseDelays(responseDelays models.ResponseDelayList) {
 	hf.ResponseDelays = &responseDelays
 	log.Info("Response delay config updated on hoverfly")
-}
-
-func (hf *Hoverfly) GetResponseDelays() models.ResponseDelays {
-	return hf.ResponseDelays
 }
 
 func (hf *Hoverfly) DeleteResponseDelays() {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -114,8 +114,8 @@ func (this *Hoverfly) DeleteTemplateCache() {
 	this.RequestMatcher.TemplateStore.Wipe()
 }
 
-func (hf *Hoverfly) GetResponseDelays() []byte {
-	return hf.ResponseDelays.Json()
+func (hf *Hoverfly) GetResponseDelays() v1.ResponseDelayPayloadView {
+	return hf.ResponseDelays.ConvertToResponseDelayPayloadView()
 }
 
 func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayloadView) error {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -118,9 +118,14 @@ func (hf *Hoverfly) GetResponseDelays() models.ResponseDelays {
 	return hf.ResponseDelays
 }
 
-func (hf *Hoverfly) UpdateResponseDelays(responseDelays models.ResponseDelayList) {
-	hf.ResponseDelays = &responseDelays
-	log.Info("Response delay config updated on hoverfly")
+func (hf *Hoverfly) SetResponseDelays(payload models.ResponseDelayPayload) error {
+	err := models.ValidateResponseDelayJson(payload)
+	if err != nil {
+		return err
+	}
+
+	hf.ResponseDelays = payload.Data
+	return nil
 }
 
 func (hf *Hoverfly) DeleteResponseDelays() {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -26,8 +26,12 @@ func (hf *Hoverfly) UpdateDestination(destination string) (err error) {
 	return
 }
 
-func (hf Hoverfly) GetRequestCache() cache.Cache {
-	return hf.RequestCache
+func (hf Hoverfly) DeleteRequestCache() error {
+	return hf.RequestCache.DeleteData()
+}
+
+func (hf Hoverfly) GetRequestCacheCount() (int, error) {
+	return hf.RequestCache.RecordsCount()
 }
 
 func (this Hoverfly) GetMetadataCache() cache.Cache {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -119,6 +119,11 @@ func (hf *Hoverfly) GetResponseDelays() []byte {
 }
 
 func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayload) error {
+	err := models.ValidateResponseDelayJson(payloadView)
+	if err != nil {
+		return err
+	}
+
 	var responseDelays models.ResponseDelayList
 
 	for _, responseDelayView := range *payloadView.Data {
@@ -131,11 +136,6 @@ func (hf *Hoverfly) SetResponseDelays(payloadView v1.ResponseDelayPayload) error
 
 	payload := models.ResponseDelayPayload{
 		Data: &responseDelays,
-	}
-
-	err := models.ValidateResponseDelayJson(payload)
-	if err != nil {
-		return err
 	}
 
 	hf.ResponseDelays = payload.Data

--- a/core/hoverfly_test.go
+++ b/core/hoverfly_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
 )
 
 func TestGetNewHoverflyCheckConfig(t *testing.T) {
@@ -166,6 +167,10 @@ func (this *ResponseDelayListStub) Len() int {
 func (this *ResponseDelayListStub) GetDelay(request models.RequestDetails) *models.ResponseDelay {
 	this.gotDelays++
 	return nil
+}
+
+func (this ResponseDelayListStub) ConvertToResponseDelayPayloadView() v1.ResponseDelayPayloadView {
+	return v1.ResponseDelayPayloadView{}
 }
 
 func TestDelayAppliedToSuccessfulSimulateRequest(t *testing.T) {

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
 	"regexp"
 	"strings"
 	"time"
@@ -28,7 +29,7 @@ type ResponseDelays interface {
 	Len() int
 }
 
-func ValidateResponseDelayJson(j ResponseDelayPayload) (err error) {
+func ValidateResponseDelayJson(j v1.ResponseDelayPayload) (err error) {
 	if j.Data != nil {
 		for _, delay := range *j.Data {
 			if delay.UrlPattern != "" && delay.Delay != 0 {

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -16,10 +16,6 @@ type ResponseDelay struct {
 	Delay      int    `json:"delay"`
 }
 
-type ResponseDelayPayload struct {
-	Data *ResponseDelayList `json:"data"`
-}
-
 type ResponseDelayList []ResponseDelay
 
 type ResponseDelays interface {

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -27,6 +27,7 @@ type ResponseDelays interface {
 	Json() []byte
 	GetDelay(request RequestDetails) *ResponseDelay
 	Len() int
+	ConvertToResponseDelayPayloadView() v1.ResponseDelayPayloadView
 }
 
 func ValidateResponseDelayPayload(j v1.ResponseDelayPayloadView) (err error) {
@@ -62,6 +63,24 @@ func (this *ResponseDelayList) GetDelay(request RequestDetails) *ResponseDelay {
 		}
 	}
 	return nil
+}
+
+func (this ResponseDelayList) ConvertToResponseDelayPayloadView() v1.ResponseDelayPayloadView {
+	payloadView := v1.ResponseDelayPayloadView{
+		Data: []v1.ResponseDelayView{},
+	}
+
+	for _, responseDelay := range this {
+		responseDelayView := v1.ResponseDelayView{
+			UrlPattern: responseDelay.UrlPattern,
+			HttpMethod: responseDelay.HttpMethod,
+			Delay: responseDelay.Delay,
+		}
+
+		payloadView.Data = append(payloadView.Data, responseDelayView)
+	}
+
+	return payloadView
 }
 
 func (this *ResponseDelayList) Json() []byte {

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -29,7 +29,7 @@ type ResponseDelays interface {
 	Len() int
 }
 
-func ValidateResponseDelayPayload(j v1.ResponseDelayPayload) (err error) {
+func ValidateResponseDelayPayload(j v1.ResponseDelayPayloadView) (err error) {
 	if j.Data != nil {
 		for _, delay := range *j.Data {
 			if delay.UrlPattern != "" && delay.Delay != 0 {

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -29,7 +29,7 @@ type ResponseDelays interface {
 	Len() int
 }
 
-func ValidateResponseDelayJson(j v1.ResponseDelayPayload) (err error) {
+func ValidateResponseDelayPayload(j v1.ResponseDelayPayload) (err error) {
 	if j.Data != nil {
 		for _, delay := range *j.Data {
 			if delay.UrlPattern != "" && delay.Delay != 0 {

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
@@ -24,7 +23,6 @@ type ResponseDelayPayload struct {
 type ResponseDelayList []ResponseDelay
 
 type ResponseDelays interface {
-	Json() []byte
 	GetDelay(request RequestDetails) *ResponseDelay
 	Len() int
 	ConvertToResponseDelayPayloadView() v1.ResponseDelayPayloadView
@@ -81,14 +79,6 @@ func (this ResponseDelayList) ConvertToResponseDelayPayloadView() v1.ResponseDel
 	}
 
 	return payloadView
-}
-
-func (this *ResponseDelayList) Json() []byte {
-	resp := ResponseDelayPayload{
-		Data: this,
-	}
-	b, _ := json.Marshal(resp)
-	return b
 }
 
 func (this *ResponseDelayList) Len() int {

--- a/core/models/delay.go
+++ b/core/models/delay.go
@@ -31,7 +31,7 @@ type ResponseDelays interface {
 
 func ValidateResponseDelayPayload(j v1.ResponseDelayPayloadView) (err error) {
 	if j.Data != nil {
-		for _, delay := range *j.Data {
+		for _, delay := range j.Data {
 			if delay.UrlPattern != "" && delay.Delay != 0 {
 				if _, err := regexp.Compile(delay.UrlPattern); err != nil {
 					return errors.New(fmt.Sprintf("Response delay entry skipped due to invalid pattern : %s", delay.UrlPattern))

--- a/core/models/delay_test.go
+++ b/core/models/delay_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
 	. "github.com/onsi/gomega"
 	"testing"
 )
@@ -16,7 +17,7 @@ func TestConvertJsonStringToResponseDelayConfig(t *testing.T) {
 				"delay": 1
 			}]
 	}`
-	var responseDelayJson ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayJson(responseDelayJson)
 	Expect(err).To(BeNil())
@@ -31,7 +32,7 @@ func TestErrorIfHostPatternNotSet(t *testing.T) {
 				"delay": 2
 			}]
 	}`
-	var responseDelayJson ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayJson(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
@@ -46,7 +47,7 @@ func TestErrprIfDelayNotSet(t *testing.T) {
 				"urlPattern": "."
 			}]
 	}`
-	var responseDelayJson ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayJson(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
@@ -62,7 +63,7 @@ func TestHostPatternMustBeAValidRegexPattern(t *testing.T) {
 				"delay": 1
 			}]
 	}`
-	var responseDelayJson ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayJson(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
@@ -78,7 +79,7 @@ func TestErrorIfHostPatternUsed(t *testing.T) {
 				"delay": 1
 			}]
 	}`
-	var responseDelayJson ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayJson(responseDelayJson)
 	Expect(err).To(Not(BeNil()))

--- a/core/models/delay_test.go
+++ b/core/models/delay_test.go
@@ -17,7 +17,7 @@ func TestConvertJsonStringToResponseDelayConfig(t *testing.T) {
 				"delay": 1
 			}]
 	}`
-	var responseDelayJson v1.ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayloadView
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(BeNil())
@@ -32,7 +32,7 @@ func TestErrorIfHostPatternNotSet(t *testing.T) {
 				"delay": 2
 			}]
 	}`
-	var responseDelayJson v1.ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayloadView
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
@@ -47,7 +47,7 @@ func TestErrprIfDelayNotSet(t *testing.T) {
 				"urlPattern": "."
 			}]
 	}`
-	var responseDelayJson v1.ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayloadView
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
@@ -63,7 +63,7 @@ func TestHostPatternMustBeAValidRegexPattern(t *testing.T) {
 				"delay": 1
 			}]
 	}`
-	var responseDelayJson v1.ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayloadView
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
@@ -79,7 +79,7 @@ func TestErrorIfHostPatternUsed(t *testing.T) {
 				"delay": 1
 			}]
 	}`
-	var responseDelayJson v1.ResponseDelayPayload
+	var responseDelayJson v1.ResponseDelayPayloadView
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
 	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(Not(BeNil()))

--- a/core/models/delay_test.go
+++ b/core/models/delay_test.go
@@ -188,3 +188,19 @@ func TestIfDelayMethodBlankThenMatchesAnyMethod(t *testing.T) {
 	delayMatch := delays.GetDelay(request)
 	Expect(*delayMatch).To(Equal(delay))
 }
+
+func TestResponseDelayList_ConvertToPayloadView(t *testing.T) {
+	RegisterTestingT(t)
+
+	delay := ResponseDelay{
+		UrlPattern: "example(.+)",
+		Delay:      100,
+	}
+	delays := ResponseDelayList{delay}
+
+	payloadView := delays.ConvertToResponseDelayPayloadView()
+
+	Expect(payloadView.Data[0].UrlPattern).To(Equal("example(.+)"))
+	Expect(payloadView.Data[0].Delay).To(Equal(100))
+
+}

--- a/core/models/delay_test.go
+++ b/core/models/delay_test.go
@@ -19,7 +19,7 @@ func TestConvertJsonStringToResponseDelayConfig(t *testing.T) {
 	}`
 	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
-	err := ValidateResponseDelayJson(responseDelayJson)
+	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(BeNil())
 }
 
@@ -34,7 +34,7 @@ func TestErrorIfHostPatternNotSet(t *testing.T) {
 	}`
 	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
-	err := ValidateResponseDelayJson(responseDelayJson)
+	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
 }
 
@@ -49,7 +49,7 @@ func TestErrprIfDelayNotSet(t *testing.T) {
 	}`
 	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
-	err := ValidateResponseDelayJson(responseDelayJson)
+	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
 }
 
@@ -65,7 +65,7 @@ func TestHostPatternMustBeAValidRegexPattern(t *testing.T) {
 	}`
 	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
-	err := ValidateResponseDelayJson(responseDelayJson)
+	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
 }
 
@@ -81,7 +81,7 @@ func TestErrorIfHostPatternUsed(t *testing.T) {
 	}`
 	var responseDelayJson v1.ResponseDelayPayload
 	json.Unmarshal([]byte(jsonConf), &responseDelayJson)
-	err := ValidateResponseDelayJson(responseDelayJson)
+	err := ValidateResponseDelayPayload(responseDelayJson)
 	Expect(err).To(Not(BeNil()))
 }
 

--- a/core/models_test.go
+++ b/core/models_test.go
@@ -413,7 +413,7 @@ func TestStartProxyWOPort(t *testing.T) {
 	Expect(err).ToNot(BeNil())
 }
 
-func TestUpdateDestination(t *testing.T) {
+func TestSetDestination(t *testing.T) {
 	RegisterTestingT(t)
 
 	server, dbClient := testTools(200, `{'message': 'here'}`)
@@ -422,7 +422,7 @@ func TestUpdateDestination(t *testing.T) {
 	dbClient.Cfg.ProxyPort = "5556"
 	err := dbClient.StartProxy()
 	Expect(err).To(BeNil())
-	dbClient.UpdateDestination("newdest")
+	dbClient.SetDestination("newdest")
 
 	Expect(dbClient.Cfg.Destination).To(Equal("newdest"))
 }
@@ -435,7 +435,7 @@ func TestUpdateDestinationEmpty(t *testing.T) {
 	server.Close()
 	dbClient.Cfg.ProxyPort = "5557"
 	dbClient.StartProxy()
-	err := dbClient.UpdateDestination("e^^**#")
+	err := dbClient.SetDestination("e^^**#")
 	Expect(err).ToNot(BeNil())
 }
 


### PR DESCRIPTION
For sanity's sake, I moved all of the new interface implementations which are used by the handlers into their own file called hoverfly_services.go. This isn't permanent, but we need to trim down Hoverfly before I can move them in again.

Also, removed the view code form ResponseDelay so now they are clearly separated so that I can ensure that the views for the /v1 endpoints don't change.