### PR TITLE
Duplicated a load of tests for the new ConvertTo functions

### DIFF
--- a/core/models/payload_test.go
+++ b/core/models/payload_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
+	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	. "github.com/SpectoLabs/hoverfly/core/util"
 	. "github.com/onsi/gomega"
 	"io/ioutil"
@@ -20,7 +21,25 @@ func TestResponseDetails_ConvertToV1ResponseDetailsView_WithPlainTextResponseDet
 
 	originalResp := ResponseDetails{Status: statusCode, Body: body, Headers: headers}
 
-	respView := originalResp.ConvertToV1ResponseDetailsView()
+	v1RespView := originalResp.ConvertToV1ResponseDetailsView()
+
+	Expect(v1RespView.Status).To(Equal(statusCode))
+	Expect(v1RespView.Headers).To(Equal(headers))
+
+	Expect(v1RespView.EncodedBody).To(Equal(false))
+	Expect(v1RespView.Body).To(Equal(body))
+}
+
+func TestResponseDetails_ConvertToResponseDetailsView_WithPlainTextResponseDetails(t *testing.T) {
+	RegisterTestingT(t)
+
+	statusCode := 200
+	body := "hello_world"
+	headers := map[string][]string{"test_header": []string{"true"}}
+
+	originalResp := ResponseDetails{Status: statusCode, Body: body, Headers: headers}
+
+	respView := originalResp.ConvertToResponseDetailsView()
 
 	Expect(respView.Status).To(Equal(statusCode))
 	Expect(respView.Headers).To(Equal(headers))
@@ -40,7 +59,32 @@ func TestResponseDetails_ConvertToV1ResponseDetailsView_WithGzipContentEncodedHe
 
 	originalResp := ResponseDetails{Status: statusCode, Body: body, Headers: headers}
 
-	respView := originalResp.ConvertToV1ResponseDetailsView()
+	v1RespView := originalResp.ConvertToV1ResponseDetailsView()
+
+	Expect(v1RespView.Status).To(Equal(statusCode))
+	Expect(v1RespView.Headers).To(Equal(headers))
+
+	Expect(v1RespView.EncodedBody).To(Equal(true))
+	Expect(v1RespView.Body).NotTo(Equal(body))
+	Expect(v1RespView.Body).NotTo(Equal(originalBody))
+
+	base64EncodedBody := "H4sIAAAJbogA/w=="
+
+	Expect(v1RespView.Body).To(Equal(base64EncodedBody))
+}
+
+func TestResponseDetails_ConvertToResponseDetailsView_WithGzipContentEncodedHeader(t *testing.T) {
+	RegisterTestingT(t)
+
+	originalBody := "hello_world"
+
+	statusCode := 200
+	body := GzipString(originalBody)
+	headers := map[string][]string{"Content-Encoding": []string{"gzip"}}
+
+	originalResp := ResponseDetails{Status: statusCode, Body: body, Headers: headers}
+
+	respView := originalResp.ConvertToResponseDetailsView()
 
 	Expect(respView.Status).To(Equal(statusCode))
 	Expect(respView.Headers).To(Equal(headers))
@@ -64,7 +108,30 @@ func TestResponseDetails_ConvertToV1ResponseDetailsView_WithDeflateContentEncode
 
 	originalResp := ResponseDetails{Status: statusCode, Body: originalBody, Headers: headers}
 
-	respView := originalResp.ConvertToV1ResponseDetailsView()
+	v1RespView := originalResp.ConvertToV1ResponseDetailsView()
+
+	Expect(v1RespView.Status).To(Equal(statusCode))
+	Expect(v1RespView.Headers).To(Equal(headers))
+
+	Expect(v1RespView.EncodedBody).To(Equal(true))
+	Expect(v1RespView.Body).NotTo(Equal(originalBody))
+
+	base64EncodedBody := "dGhpc19zaG91bGRfYmVfZW5jb2RlZF9idXRfaXRzX25vdF9pbXBvcnRhbnQ="
+
+	Expect(v1RespView.Body).To(Equal(base64EncodedBody))
+}
+
+func TestResponseDetails_ConvertToResponseDetailsView_WithDeflateContentEncodedHeader(t *testing.T) {
+	RegisterTestingT(t)
+
+	originalBody := "this_should_be_encoded_but_its_not_important"
+
+	statusCode := 200
+	headers := map[string][]string{"Content-Encoding": []string{"deflate"}}
+
+	originalResp := ResponseDetails{Status: statusCode, Body: originalBody, Headers: headers}
+
+	respView := originalResp.ConvertToResponseDetailsView()
 
 	Expect(respView.Status).To(Equal(statusCode))
 	Expect(respView.Headers).To(Equal(headers))
@@ -92,15 +159,41 @@ func TestResponseDetails_ConvertToV1ResponseDetailsView_WithImageBody(t *testing
 		Body:   string(originalImageBytes),
 	}
 
-	respView := originalResp.ConvertToV1ResponseDetailsView()
+	v1RespView := originalResp.ConvertToV1ResponseDetailsView()
 
 	base64EncodedBody := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGP6DwABBQECz6AuzQAAAABJRU5ErkJggg=="
-	Expect(respView).To(Equal(v1.ResponseDetailsView{
+	Expect(v1RespView).To(Equal(v1.ResponseDetailsView{
 		Status:      200,
 		Body:        base64EncodedBody,
 		EncodedBody: true,
 	}))
 }
+
+func TestResponseDetails_ConvertToResponseDetailsView_WithImageBody(t *testing.T) {
+	RegisterTestingT(t)
+
+	imageUri := "/testdata/1x1.png"
+
+	file, _ := os.Open("../../functional-tests/core" + imageUri)
+	defer file.Close()
+
+	originalImageBytes, _ := ioutil.ReadAll(file)
+
+	originalResp := ResponseDetails{
+		Status: 200,
+		Body:   string(originalImageBytes),
+	}
+
+	respView := originalResp.ConvertToResponseDetailsView()
+
+	base64EncodedBody := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGP6DwABBQECz6AuzQAAAABJRU5ErkJggg=="
+	Expect(respView).To(Equal(v2.ResponseDetailsView{
+		Status:      200,
+		Body:        base64EncodedBody,
+		EncodedBody: true,
+	}))
+}
+
 func TestRequestResponsePair_ConvertToV1RequestResponsePairView_WithPlainTextResponse(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -121,15 +214,55 @@ func TestRequestResponsePair_ConvertToV1RequestResponsePairView_WithPlainTextRes
 			Headers:     map[string][]string{"test_header": []string{"true"}}},
 	}
 
-	pairView := requestResponsePair.ConvertToV1RequestResponsePairView()
+	v1PairView := requestResponsePair.ConvertToV1RequestResponsePairView()
 
-	Expect(*pairView).To(Equal(v1.RequestResponsePairView{
+	Expect(*v1PairView).To(Equal(v1.RequestResponsePairView{
 		Response: v1.ResponseDetailsView{
 			Status:      200,
 			Body:        respBody,
 			Headers:     map[string][]string{"test_header": []string{"true"}},
 			EncodedBody: false},
 		Request: v1.RequestDetailsView{
+			RequestType: StringToPointer("recording"),
+			Path:        StringToPointer("/"),
+			Method:      StringToPointer("GET"),
+			Destination: StringToPointer("/"),
+			Scheme:      StringToPointer("scheme"),
+			Query:       StringToPointer(""),
+			Body:        StringToPointer(""),
+			Headers:     map[string][]string{"test_header": []string{"true"}}},
+	}))
+}
+
+func TestRequestResponsePair_ConvertToRequestResponsePairView_WithPlainTextResponse(t *testing.T) {
+	RegisterTestingT(t)
+
+	respBody := "hello_world"
+
+	requestResponsePair := RequestResponsePair{
+		Response: ResponseDetails{
+			Status:  200,
+			Body:    respBody,
+			Headers: map[string][]string{"test_header": []string{"true"}}},
+		Request: RequestDetails{
+			Path:        "/",
+			Method:      "GET",
+			Destination: "/",
+			Scheme:      "scheme",
+			Query:       "",
+			Body:        "",
+			Headers:     map[string][]string{"test_header": []string{"true"}}},
+	}
+
+	pairView := requestResponsePair.ConvertToRequestResponsePairView()
+
+	Expect(pairView).To(Equal(v2.RequestResponsePairView{
+		Response: v2.ResponseDetailsView{
+			Status:      200,
+			Body:        respBody,
+			Headers:     map[string][]string{"test_header": []string{"true"}},
+			EncodedBody: false},
+		Request: v2.RequestDetailsView{
 			RequestType: StringToPointer("recording"),
 			Path:        StringToPointer("/"),
 			Method:      StringToPointer("GET"),
@@ -160,15 +293,55 @@ func TestRequestResponsePair_ConvertToV1RequestResponsePairView_WithGzippedRespo
 		},
 	}
 
-	pairView := requestResponsePair.ConvertToV1RequestResponsePairView()
+	v1PairView := requestResponsePair.ConvertToV1RequestResponsePairView()
 
-	Expect(*pairView).To(Equal(v1.RequestResponsePairView{
+	Expect(*v1PairView).To(Equal(v1.RequestResponsePairView{
 		Response: v1.ResponseDetailsView{
 			Status:      200,
 			Body:        "H4sIAAAJbogA/w==",
 			Headers:     map[string][]string{"Content-Encoding": []string{"gzip"}},
 			EncodedBody: true},
 		Request: v1.RequestDetailsView{
+			RequestType: StringToPointer("recording"),
+			Path:        StringToPointer("/"),
+			Method:      StringToPointer("GET"),
+			Destination: StringToPointer("/"),
+			Scheme:      StringToPointer("scheme"),
+			Query:       StringToPointer(""),
+			Body:        StringToPointer(""),
+			Headers:     map[string][]string{"Content-Encoding": []string{"gzip"}},
+		},
+	}))
+}
+
+func TestRequestResponsePair_ConvertToRequestResponsePairView_WithGzippedResponse(t *testing.T) {
+	RegisterTestingT(t)
+
+	requestResponsePair := RequestResponsePair{
+		Response: ResponseDetails{
+			Status:  200,
+			Body:    GzipString("hello_world"),
+			Headers: map[string][]string{"Content-Encoding": []string{"gzip"}}},
+		Request: RequestDetails{
+			Path:        "/",
+			Method:      "GET",
+			Destination: "/",
+			Scheme:      "scheme",
+			Query:       "",
+			Body:        "",
+			Headers:     map[string][]string{"Content-Encoding": []string{"gzip"}},
+		},
+	}
+
+	pairView := requestResponsePair.ConvertToRequestResponsePairView()
+
+	Expect(pairView).To(Equal(v2.RequestResponsePairView{
+		Response: v2.ResponseDetailsView{
+			Status:      200,
+			Body:        "H4sIAAAJbogA/w==",
+			Headers:     map[string][]string{"Content-Encoding": []string{"gzip"}},
+			EncodedBody: true},
+		Request: v2.RequestDetailsView{
 			RequestType: StringToPointer("recording"),
 			Path:        StringToPointer("/"),
 			Method:      StringToPointer("GET"),
@@ -192,7 +365,28 @@ func TestRequestDetails_ConvertToV1RequestDetailsView(t *testing.T) {
 		Query:       "", Body: "",
 		Headers: map[string][]string{"Content-Encoding": []string{"gzip"}}}
 
-	requestDetailsView := requestDetails.ConvertToV1RequestDetailsView()
+	v1RequestDetailsView := requestDetails.ConvertToV1RequestDetailsView()
+
+	Expect(v1RequestDetailsView.Path).To(Equal(StringToPointer(requestDetails.Path)))
+	Expect(v1RequestDetailsView.Method).To(Equal(StringToPointer(requestDetails.Method)))
+	Expect(v1RequestDetailsView.Destination).To(Equal(StringToPointer(requestDetails.Destination)))
+	Expect(v1RequestDetailsView.Scheme).To(Equal(StringToPointer(requestDetails.Scheme)))
+	Expect(v1RequestDetailsView.Query).To(Equal(StringToPointer(requestDetails.Query)))
+	Expect(v1RequestDetailsView.Headers).To(Equal(requestDetails.Headers))
+}
+
+func TestRequestDetails_ConvertToRequestDetailsView(t *testing.T) {
+	RegisterTestingT(t)
+
+	requestDetails := RequestDetails{
+		Path:        "/",
+		Method:      "GET",
+		Destination: "/",
+		Scheme:      "scheme",
+		Query:       "", Body: "",
+		Headers: map[string][]string{"Content-Encoding": []string{"gzip"}}}
+
+	requestDetailsView := requestDetails.ConvertToRequestDetailsView()
 
 	Expect(requestDetailsView.Path).To(Equal(StringToPointer(requestDetails.Path)))
 	Expect(requestDetailsView.Method).To(Equal(StringToPointer(requestDetails.Method)))


### PR DESCRIPTION
These tests are pretty much a duplicate of the ones being used to test ConvertToV1*. The functionality of these functions are the same but return either a v1 or v2 view struct.