### PR TITLE
Templates are now included in the GetSimulation

### DIFF
--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -193,6 +193,10 @@ func (hf Hoverfly) GetSimulation() (v2.SimulationView, error) {
 		}
 	}
 
+	for _, v := range hf.RequestMatcher.TemplateStore {
+		pairViews = append(pairViews, v.ConvertToRequestResponsePairView())
+	}
+
 	responseDelays := hf.ResponseDelays.ConvertToResponseDelayPayloadView()
 
 	return v2.SimulationView{

--- a/core/matching/request_template_store.go
+++ b/core/matching/request_template_store.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/SpectoLabs/hoverfly/core/util"
 	"github.com/ryanuber/go-glob"
 	"strings"
+	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 )
 
 type RequestTemplateStore []RequestTemplateResponsePair
@@ -161,6 +162,23 @@ func (this *RequestTemplateResponsePair) ConvertToV1RequestResponsePairView() v1
 			Headers:     this.RequestTemplate.Headers,
 		},
 		Response: this.Response.ConvertToV1ResponseDetailsView(),
+	}
+}
+
+func (this *RequestTemplateResponsePair) ConvertToRequestResponsePairView() v2.RequestResponsePairView {
+
+	return v2.RequestResponsePairView{
+		Request: v2.RequestDetailsView{
+			RequestType: StringToPointer("template"),
+			Path:        this.RequestTemplate.Path,
+			Method:      this.RequestTemplate.Method,
+			Destination: this.RequestTemplate.Destination,
+			Scheme:      this.RequestTemplate.Scheme,
+			Query:       this.RequestTemplate.Query,
+			Body:        this.RequestTemplate.Body,
+			Headers:     this.RequestTemplate.Headers,
+		},
+		Response: this.Response.ConvertToResponseDetailsView(),
 	}
 }
 

--- a/core/matching/request_template_store_test.go
+++ b/core/matching/request_template_store_test.go
@@ -657,3 +657,29 @@ func TestTemplatesCanUseGlobsOnHeadersAndBeMatched(t *testing.T) {
 
 	Expect(response.Body).To(Equal("template matched"))
 }
+
+func TestRequestTemplateResponsePair_ConvertToRequestResponsePairView_CanBeConvertedToARequestResponsePairView_WhileIncomplete(t *testing.T) {
+	RegisterTestingT(t)
+
+	method := "POST"
+
+	requestTemplateResponsePair := RequestTemplateResponsePair{
+		RequestTemplate: RequestTemplate{
+			Method: &method,
+		},
+		Response: models.ResponseDetails{
+			Body: "template matched",
+		},
+	}
+
+	pairView := requestTemplateResponsePair.ConvertToRequestResponsePairView()
+
+	Expect(pairView.Request.RequestType).To(Equal(StringToPointer("template")))
+	Expect(pairView.Request.Method).To(Equal(StringToPointer("POST")))
+	Expect(pairView.Request.Destination).To(BeNil())
+	Expect(pairView.Request.Path).To(BeNil())
+	Expect(pairView.Request.Scheme).To(BeNil())
+	Expect(pairView.Request.Query).To(BeNil())
+
+	Expect(pairView.Response.Body).To(Equal("template matched"))
+}


### PR DESCRIPTION
Beforehand, I had only included recordings into the new simulation endpoint. The reason for this is that it required more refactoring to include in the templates in a nice way.