### PR TITLE
Errors on the put method for v2 simulations now error properly

### DIFF
--- a/core/handlers/v2/simulation_handler.go
+++ b/core/handlers/v2/simulation_handler.go
@@ -42,6 +42,7 @@ func (this *SimulationHandler) Get(w http.ResponseWriter, req *http.Request, nex
 	simulationView, err := this.Hoverfly.GetSimulation()
 	if err != nil {
 		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	bytes, _ := json.Marshal(simulationView)
@@ -57,16 +58,19 @@ func (this *SimulationHandler) Put(w http.ResponseWriter, req *http.Request, nex
 	err := json.Unmarshal(body, &simulationView)
 	if err != nil {
 		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	err = this.Hoverfly.DeleteSimulation()
 	if err != nil {
 		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	err = this.Hoverfly.PutSimulation(simulationView)
 	if err != nil {
 		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	this.Get(w, req, next)
@@ -76,6 +80,7 @@ func (this *SimulationHandler) Delete(w http.ResponseWriter, req *http.Request, 
 	err := this.Hoverfly.DeleteSimulation()
 	if err != nil {
 		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	this.Get(w, req, next)

--- a/core/handlers/v2/simulation_handler.go
+++ b/core/handlers/v2/simulation_handler.go
@@ -59,7 +59,10 @@ func (this *SimulationHandler) Put(w http.ResponseWriter, req *http.Request, nex
 		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
 	}
 
-	this.Delete(w, req, next)
+	err = this.Hoverfly.DeleteSimulation()
+	if err != nil {
+		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+	}
 
 	err = this.Hoverfly.PutSimulation(simulationView)
 	if err != nil {

--- a/core/handlers/v2/simulation_handler.go
+++ b/core/handlers/v2/simulation_handler.go
@@ -14,7 +14,7 @@ import (
 type HoverflySimulation interface {
 	GetSimulation() (SimulationView, error)
 	PutSimulation(SimulationView) error
-	DeleteSimulation() error
+	DeleteSimulation()
 }
 
 type SimulationHandler struct {
@@ -61,11 +61,7 @@ func (this *SimulationHandler) Put(w http.ResponseWriter, req *http.Request, nex
 		return
 	}
 
-	err = this.Hoverfly.DeleteSimulation()
-	if err != nil {
-		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	this.Hoverfly.DeleteSimulation()
 
 	err = this.Hoverfly.PutSimulation(simulationView)
 	if err != nil {
@@ -77,11 +73,7 @@ func (this *SimulationHandler) Put(w http.ResponseWriter, req *http.Request, nex
 }
 
 func (this *SimulationHandler) Delete(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	err := this.Hoverfly.DeleteSimulation()
-	if err != nil {
-		handlers.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	this.Hoverfly.DeleteSimulation()
 
 	this.Get(w, req, next)
 }

--- a/core/handlers/v2/simulation_handler_test.go
+++ b/core/handlers/v2/simulation_handler_test.go
@@ -50,9 +50,8 @@ func (this HoverflySimulationStub) GetSimulation() (SimulationView, error) {
 	}, nil
 }
 
-func (this *HoverflySimulationStub) DeleteSimulation() error {
+func (this *HoverflySimulationStub) DeleteSimulation() {
 	this.Deleted = true
-	return nil
 }
 
 func (this *HoverflySimulationStub) PutSimulation(simulation SimulationView) error {
@@ -66,9 +65,7 @@ func (this HoverflySimulationErrorStub) GetSimulation() (SimulationView, error) 
 	return SimulationView{}, fmt.Errorf("error")
 }
 
-func (this *HoverflySimulationErrorStub) DeleteSimulation() error {
-	return fmt.Errorf("error")
-}
+func (this *HoverflySimulationErrorStub) DeleteSimulation() {}
 
 func (this *HoverflySimulationErrorStub) PutSimulation(simulation SimulationView) error {
 	return fmt.Errorf("error")

--- a/core/handlers/v2/simulation_handler_test.go
+++ b/core/handlers/v2/simulation_handler_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	"fmt"
+
 	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
 	"github.com/SpectoLabs/hoverfly/core/util"
 	. "github.com/onsi/gomega"
@@ -58,7 +60,21 @@ func (this *HoverflySimulationStub) PutSimulation(simulation SimulationView) err
 	return nil
 }
 
-func TestSimulationHandlerGetReturnsSimulation(t *testing.T) {
+type HoverflySimulationErrorStub struct{}
+
+func (this HoverflySimulationErrorStub) GetSimulation() (SimulationView, error) {
+	return SimulationView{}, fmt.Errorf("error")
+}
+
+func (this *HoverflySimulationErrorStub) DeleteSimulation() error {
+	return fmt.Errorf("error")
+}
+
+func (this *HoverflySimulationErrorStub) PutSimulation(simulation SimulationView) error {
+	return fmt.Errorf("error")
+}
+
+func TestSimulationHandler_Get_ReturnsSimulation(t *testing.T) {
 	RegisterTestingT(t)
 
 	stubHoverfly := &HoverflySimulationStub{}
@@ -90,7 +106,26 @@ func TestSimulationHandlerGetReturnsSimulation(t *testing.T) {
 	Expect(simulationView.MetaView.TimeExported).To(Equal("now"))
 }
 
-func TestSimulationHandlerDeleteCallsDelete(t *testing.T) {
+func TestSimulationHandler_Get_ReturnsErrorIfHoverflyErrors(t *testing.T) {
+	RegisterTestingT(t)
+
+	stubHoverfly := &HoverflySimulationErrorStub{}
+	unit := SimulationHandler{Hoverfly: stubHoverfly}
+
+	request, err := http.NewRequest("GET", "", nil)
+	Expect(err).To(BeNil())
+
+	response := makeRequestOnHandler(unit.Get, request)
+
+	Expect(response.Code).To(Equal(http.StatusInternalServerError))
+
+	errorView, err := unmarshalErrorView(response.Body)
+	Expect(err).To(BeNil())
+
+	Expect(errorView.Error).To(Equal("error"))
+}
+
+func TestSimulationHandler_Delete_CallsDelete(t *testing.T) {
 	RegisterTestingT(t)
 
 	stubHoverfly := &HoverflySimulationStub{}
@@ -135,6 +170,24 @@ func TestSimulationHandler_Delete_CallsGetAfterDelete(t *testing.T) {
 	Expect(simulationView.MetaView.SchemaVersion).To(Equal("v1"))
 	Expect(simulationView.MetaView.HoverflyVersion).To(Equal("test"))
 	Expect(simulationView.MetaView.TimeExported).To(Equal("now"))
+}
+
+func TestSimulationHandler_Delete_ErrorReturnsWithoutGet(t *testing.T) {
+	RegisterTestingT(t)
+
+	stubHoverfly := &HoverflySimulationErrorStub{}
+
+	unit := SimulationHandler{Hoverfly: stubHoverfly}
+
+	request, err := http.NewRequest("DELETE", "", nil)
+	Expect(err).To(BeNil())
+
+	response := makeRequestOnHandler(unit.Delete, request)
+
+	errorView, err := unmarshalErrorView(response.Body)
+	Expect(err).To(BeNil())
+
+	Expect(errorView.Error).To(Equal("error"))
 }
 
 func TestSimulationHandler_Put_PassesDataIntoHoverfly(t *testing.T) {
@@ -226,6 +279,26 @@ func TestSimulationHandler_Put_CallsDelete(t *testing.T) {
 
 	Expect(stubHoverfly.Deleted).To(BeTrue())
 }
+
+func TestSimulationHandler_Put_ReturnsErrorIfCannotParseRequestBody(t *testing.T) {
+	RegisterTestingT(t)
+
+	stubHoverfly := &HoverflySimulationErrorStub{}
+
+	unit := SimulationHandler{Hoverfly: stubHoverfly}
+
+	request, err := http.NewRequest("PUT", "", ioutil.NopCloser(bytes.NewBuffer([]byte(``))))
+	Expect(err).To(BeNil())
+
+	response := makeRequestOnHandler(unit.Put, request)
+
+	errorView, err := unmarshalErrorView(response.Body)
+	Expect(err).To(BeNil())
+
+	Expect(response.Result().StatusCode).To(Equal(500))
+	Expect(errorView.Error).To(Equal("unexpected end of JSON input"))
+}
+
 func unmarshalSimulationView(buffer *bytes.Buffer) (SimulationView, error) {
 	body, err := ioutil.ReadAll(buffer)
 	if err != nil {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -2,6 +2,9 @@ package hoverfly
 
 import (
 	"fmt"
+	"regexp"
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/SpectoLabs/hoverfly/core/cache"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
@@ -9,8 +12,6 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/interfaces"
 	"github.com/SpectoLabs/hoverfly/core/metrics"
 	"github.com/SpectoLabs/hoverfly/core/models"
-	"regexp"
-	"time"
 )
 
 func (this Hoverfly) GetDestination() string {
@@ -233,8 +234,8 @@ func (this *Hoverfly) PutSimulation(simulationView v2.SimulationView) error {
 	return nil
 }
 
-func (this *Hoverfly) DeleteSimulation() error {
+func (this *Hoverfly) DeleteSimulation() {
 	this.DeleteTemplateCache()
 	this.DeleteResponseDelays()
-	return this.DeleteRequestCache()
+	this.DeleteRequestCache()
 }


### PR DESCRIPTION
and the empty bucket error should no longer trigger an error on deleting.