### PR TITLE
Use docker EXEC entrypoint and not SHELL type 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ ENV GO15VENDOREXPERIMENT 1
 
 RUN go install github.com/SpectoLabs/hoverfly/cmd/hoverfly/
 
-ENTRYPOINT /go/bin/hoverfly
+ENTRYPOINT ["/go/bin/hoverfly"]
 
 EXPOSE 8500 8888


### PR DESCRIPTION
passing '-db-path' to the docker container was not used by hoverfly. 

When using the SHELL form of ENTRYPOINT the command run by docker is "/bin/sh -c /go/bin/hoverfly"
Using EXEC form means the hoverfly binary is run itself and not as a child process of /bin/sh

Arguments passed to the container were not properly being used by / passed to hoverfly

https://docs.docker.com/engine/reference/builder/#/entrypoint