### PR TITLE
GetAllEntries in memory cache not returning 'dest' as intented

### DIFF
--- a/core/cache/memory_cache.go
+++ b/core/cache/memory_cache.go
@@ -55,7 +55,7 @@ func (c *InMemoryCache) GetAllEntries() (map[string][]byte, error) {
 		dest[k] = v
 	}
 	c.RUnlock()
-	return c.elements, nil
+	return dest, nil
 }
 
 func (c *InMemoryCache) RecordsCount() (count int, err error) {


### PR DESCRIPTION
Hi Benji,

Not sure whether you should merge this in or not. But definitely worth investigating. Why are we creating this ``dest`` dict, yet not returning it? Moreover one has to wonder what it actually does? Is this a way create a copy? Sorry my level at go is still non-existent at this point.

Feel free not to merge this in. I'm really just creating this pull request to bring this to your attention.

Regards,

Shyal