### PR TITLE
Fix image and clarify export file

### DIFF
--- a/docs/pages/tutorials/exportingsimulations/exportingsimulations.rst
+++ b/docs/pages/tutorials/exportingsimulations/exportingsimulations.rst
@@ -34,8 +34,8 @@ Stop hoverfly
 
     hoverctl stop
 
-You'll now see a requests.db file in your current working directory, which contains all your simulation data.
+You'll now see a simulation.json file in your current working directory, which contains all your simulation data.
 
 In case you are curious, the sequence diagram of this use case looks like so:
 
-.. figure:: exportsimulations.mermaid.png
+.. figure:: exportingsimulations.mermaid.png


### PR DESCRIPTION
Add some clarity to which file is created when exporting and fixed the image link on that page.