### PR TITLE
Bypass RequestMatcher and use TemplateMatcher directly

### DIFF
--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -162,22 +162,7 @@ func (hf Hoverfly) GetStats() metrics.Stats {
 }
 
 func (hf Hoverfly) GetSimulation() (v2.SimulationView, error) {
-	records, err := hf.RequestCache.GetAllEntries()
-	if err != nil {
-		return v2.SimulationView{}, err
-	}
-
 	pairViews := make([]v2.RequestResponsePairView, 0)
-
-	for _, v := range records {
-		if pair, err := models.NewRequestResponsePairFromBytes(v); err == nil {
-			pairView := pair.ConvertToRequestResponsePairView()
-			pairViews = append(pairViews, pairView)
-		} else {
-			log.Error(err)
-			return v2.SimulationView{}, err
-		}
-	}
 
 	for _, v := range hf.Simulation.Templates {
 		pairViews = append(pairViews, v.ConvertToRequestResponsePairView())

--- a/core/hoverfly_service_test.go
+++ b/core/hoverfly_service_test.go
@@ -61,42 +61,6 @@ func TestHoverflyGetSimulationReturnsBlankSimulation_ifThereIsNoData(t *testing.
 	Expect(simulation.MetaView.TimeExported).ToNot(BeNil())
 }
 
-func TestHoverfly_GetSimulation_ReturnsASingleRequestResponsePairRecording(t *testing.T) {
-	RegisterTestingT(t)
-
-	server, unit := testTools(201, `{'message': 'here'}`)
-	defer server.Close()
-
-	recording := models.RequestResponsePair{
-		Request: models.RequestDetails{
-			Destination: "testhost.com",
-			Path:        "/test",
-		},
-		Response: models.ResponseDetails{
-			Status: 200,
-			Body:   "test",
-		},
-	}
-
-	recordingBytes, err := recording.Encode()
-	Expect(err).To(BeNil())
-
-	unit.RequestCache.Set([]byte("key"), recordingBytes)
-
-	simulation, err := unit.GetSimulation()
-	Expect(err).To(BeNil())
-
-	Expect(simulation.DataView.RequestResponsePairs).To(HaveLen(1))
-
-	Expect(*simulation.DataView.RequestResponsePairs[0].Request.Destination).To(Equal("testhost.com"))
-	Expect(*simulation.DataView.RequestResponsePairs[0].Request.Path).To(Equal("/test"))
-
-	Expect(simulation.DataView.RequestResponsePairs[0].Response.Status).To(Equal(200))
-	Expect(simulation.DataView.RequestResponsePairs[0].Response.Body).To(Equal("test"))
-
-	Expect(nil).To(BeNil())
-}
-
 func TestHoverfly_GetSimulation_ReturnsASingleRequestResponsePairTemplate(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -133,28 +97,33 @@ func TestHoverfly_GetSimulation_ReturnsASingleRequestResponsePairTemplate(t *tes
 	Expect(nil).To(BeNil())
 }
 
-func TestHoverflyGetSimulationReturnsMultipleRequestResponsePairs(t *testing.T) {
+func Test_Hoverfly_GetSimulation_ReturnsMultipleRequestResponsePairs(t *testing.T) {
 	RegisterTestingT(t)
 
 	server, unit := testTools(201, `{'message': 'here'}`)
 	defer server.Close()
 
-	recording := models.RequestResponsePair{
-		Request: models.RequestDetails{
-			Destination: "testhost.com",
-			Path:        "/test",
+	unit.Simulation.Templates = append(unit.Simulation.Templates, models.RequestTemplateResponsePair{
+		RequestTemplate: models.RequestTemplate{
+			Destination: util.StringToPointer("testhost.com"),
+			Path:        util.StringToPointer("/test"),
 		},
 		Response: models.ResponseDetails{
 			Status: 200,
 			Body:   "test",
 		},
-	}
+	})
 
-	recordingBytes, err := recording.Encode()
-	Expect(err).To(BeNil())
-
-	unit.RequestCache.Set([]byte("key"), recordingBytes)
-	unit.RequestCache.Set([]byte("key2"), recordingBytes)
+	unit.Simulation.Templates = append(unit.Simulation.Templates, models.RequestTemplateResponsePair{
+		RequestTemplate: models.RequestTemplate{
+			Destination: util.StringToPointer("testhost.com"),
+			Path:        util.StringToPointer("/test"),
+		},
+		Response: models.ResponseDetails{
+			Status: 200,
+			Body:   "test",
+		},
+	})
 
 	simulation, err := unit.GetSimulation()
 	Expect(err).To(BeNil())

--- a/core/hoverfly_test.go
+++ b/core/hoverfly_test.go
@@ -57,7 +57,6 @@ func Test_Hoverfly_processRequest_CaptureModeReturnsResponseAndSavesIt(t *testin
 
 	server, dbClient := testTools(201, `{'message': 'here'}`)
 	defer server.Close()
-	defer dbClient.RequestCache.DeleteData()
 
 	r, err := http.NewRequest("GET", "http://somehost.com", nil)
 	Expect(err).To(BeNil())
@@ -77,7 +76,6 @@ func Test_Hoverfly_processRequest_CanSimulateRequest(t *testing.T) {
 
 	server, dbClient := testTools(201, `{'message': 'here'}`)
 	defer server.Close()
-	defer dbClient.RequestCache.DeleteData()
 
 	r, err := http.NewRequest("GET", "http://somehost.com", nil)
 	Expect(err).To(BeNil())
@@ -102,7 +100,6 @@ func Test_Hoverfly_processRequest_CanUseMiddlewareToSynthesizeRequest(t *testing
 
 	server, dbClient := testTools(201, `{'message': 'here'}`)
 	defer server.Close()
-	defer dbClient.RequestCache.DeleteData()
 
 	// getting reflect middleware
 	err := dbClient.Cfg.Middleware.SetBinary("python")
@@ -175,7 +172,6 @@ func TestDelayAppliedToSuccessfulSimulateRequest(t *testing.T) {
 
 	server, dbClient := testTools(201, `{'message': 'here'}`)
 	defer server.Close()
-	defer dbClient.RequestCache.DeleteData()
 
 	r, err := http.NewRequest("GET", "http://somehost.com", nil)
 	Expect(err).To(BeNil())
@@ -226,7 +222,6 @@ func TestDelayNotAppliedToCaptureRequest(t *testing.T) {
 
 	server, dbClient := testTools(201, `{'message': 'here'}`)
 	defer server.Close()
-	defer dbClient.RequestCache.DeleteData()
 
 	r, err := http.NewRequest("GET", "http://somehost.com", nil)
 	Expect(err).To(BeNil())
@@ -248,7 +243,6 @@ func TestDelayAppliedToSynthesizeRequest(t *testing.T) {
 
 	server, dbClient := testTools(201, `{'message': 'here'}`)
 	defer server.Close()
-	defer dbClient.RequestCache.DeleteData()
 
 	err := dbClient.Cfg.Middleware.SetBinary("python")
 	Expect(err).To(BeNil())
@@ -277,7 +271,6 @@ func TestDelayNotAppliedToFailedSynthesizeRequest(t *testing.T) {
 
 	server, dbClient := testTools(201, `{'message': 'here'}`)
 	defer server.Close()
-	defer dbClient.RequestCache.DeleteData()
 
 	err := dbClient.Cfg.Middleware.SetBinary("python")
 	Expect(err).To(BeNil())

--- a/core/matching/matcher.go
+++ b/core/matching/matcher.go
@@ -11,7 +11,6 @@ import (
 type RequestMatcher struct {
 	RequestCache cache.Cache
 	Webserver    *bool
-	Simulation   *models.Simulation
 }
 
 // getResponse returns stored response from cache
@@ -37,30 +36,10 @@ func (this *RequestMatcher) GetResponse(req *models.RequestDetails) (*models.Res
 			"method":      req.Method,
 		}).Warn("Failed to retrieve response from cache")
 
-		response, err := TemplateMatcher{}.Match(*req, *this.Webserver, this.Simulation)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"key":         key,
-				"error":       err.Error(),
-				"query":       req.Query,
-				"path":        req.Path,
-				"destination": req.Destination,
-				"method":      req.Method,
-			}).Warn("Failed to find matching request template from template store")
-
-			return nil, &MatchingError{
-				StatusCode:  412,
-				Description: "Could not find recorded request, please record it first!",
-			}
+		return nil, &MatchingError{
+			StatusCode:  412,
+			Description: "Could not find recorded request, please record it first!",
 		}
-		log.WithFields(log.Fields{
-			"key":         key,
-			"query":       req.Query,
-			"path":        req.Path,
-			"destination": req.Destination,
-			"method":      req.Method,
-		}).Info("Found template matching request from template store")
-		return response, nil
 	}
 
 	// getting cache response


### PR DESCRIPTION
This is the first part of the work of changing the key value store from being a datastore for request recordings to becoming a cache for templates.

Template matching moves out of the RequestMatcher as this will in the future transform into wrapper around the cache when it is reimplemented.