### PR TITLE
Added application/json header to outgoing remote middleware requests

### DIFF
--- a/core/middleware.go
+++ b/core/middleware.go
@@ -227,6 +227,7 @@ func (this Middleware) executeMiddlewareRemotely(pair models.RequestResponsePair
 	}
 
 	req, err := http.NewRequest("POST", this.Remote, bytes.NewBuffer(pairViewBytes))
+	req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err.Error(),


### PR DESCRIPTION
Unfortunately, Spring Boot defaults a missing Content-Type header to application/octet-stream. This should add an outgoing Content-Type: application/json header to every middleware requests.