### PR TITLE
Capture will now not record request headers by default

### DIFF
--- a/core/admin_test.go
+++ b/core/admin_test.go
@@ -54,7 +54,7 @@ func TestGetRecordsCountWRecords(t *testing.T) {
 			Query:       fmt.Sprintf("q=%d", i),
 		}
 
-		unit.Save(req, &models.ResponseDetails{})
+		unit.Save(req, &models.ResponseDetails{}, nil)
 	}
 	// performing query
 	m := adminApi.getBoneRouter(unit)
@@ -420,7 +420,7 @@ func TestStatsHandlerRecordCountMetrics(t *testing.T) {
 		resp := &http.Response{}
 		resp.Body = ioutil.NopCloser(bytes.NewBuffer([]byte("")))
 
-		unit.Save(req, &models.ResponseDetails{})
+		unit.Save(req, &models.ResponseDetails{}, nil)
 	}
 
 	req, err := http.NewRequest("GET", "/api/stats", nil)

--- a/core/db_client_test.go
+++ b/core/db_client_test.go
@@ -129,7 +129,7 @@ func TestGetMultipleRecords(t *testing.T) {
 		}, &models.ResponseDetails{
 			Status: 201,
 			Body:   "ok",
-		})
+		}, nil)
 	}
 
 	// getting requests

--- a/core/handlers/v1/state_handler.go
+++ b/core/handlers/v1/state_handler.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/SpectoLabs/hoverfly/core/handlers"
 	"github.com/codegangsta/negroni"
 	"github.com/go-zoo/bone"
-	"io/ioutil"
-	"net/http"
 )
 
 type HoverflyState interface {

--- a/core/handlers/v2/hoverfly_mode_handler.go
+++ b/core/handlers/v2/hoverfly_mode_handler.go
@@ -11,8 +11,7 @@ import (
 
 type HoverflyMode interface {
 	GetMode() string
-	SetMode(string) error
-	SetModeArguments(ModeArgumentsView)
+	SetModeWithArguments(ModeView) error
 }
 
 type HoverflyModeHandler struct {
@@ -47,12 +46,11 @@ func (this *HoverflyModeHandler) Put(w http.ResponseWriter, r *http.Request, nex
 		return
 	}
 
-	err = this.Hoverfly.SetMode(modeView.Mode)
+	err = this.Hoverfly.SetModeWithArguments(modeView)
 	if err != nil {
 		handlers.WriteErrorResponse(w, err.Error(), 422)
 		return
 	}
-	this.Hoverfly.SetModeArguments(modeView.Arguments)
 
 	this.Get(w, r, next)
 }

--- a/core/handlers/v2/hoverfly_mode_handler.go
+++ b/core/handlers/v2/hoverfly_mode_handler.go
@@ -12,7 +12,7 @@ import (
 type HoverflyMode interface {
 	GetMode() string
 	SetMode(string) error
-	SetModeArguments(map[string]string)
+	SetModeArguments(ModeArgumentsView)
 }
 
 type HoverflyModeHandler struct {
@@ -52,7 +52,6 @@ func (this *HoverflyModeHandler) Put(w http.ResponseWriter, r *http.Request, nex
 		handlers.WriteErrorResponse(w, err.Error(), 422)
 		return
 	}
-
 	this.Hoverfly.SetModeArguments(modeView.Arguments)
 
 	this.Get(w, r, next)

--- a/core/handlers/v2/hoverfly_mode_handler.go
+++ b/core/handlers/v2/hoverfly_mode_handler.go
@@ -48,7 +48,7 @@ func (this *HoverflyModeHandler) Put(w http.ResponseWriter, r *http.Request, nex
 
 	err = this.Hoverfly.SetModeWithArguments(modeView)
 	if err != nil {
-		handlers.WriteErrorResponse(w, err.Error(), 422)
+		handlers.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/core/handlers/v2/hoverfly_mode_handler_test.go
+++ b/core/handlers/v2/hoverfly_mode_handler_test.go
@@ -12,31 +12,29 @@ import (
 )
 
 type HoverflyModeStub struct {
-	Mode      string
-	Arguments ModeArgumentsView
+	ModeView ModeView
 }
 
 func (this HoverflyModeStub) GetMode() string {
-	return this.Mode
+	return this.ModeView.Mode
 }
 
-func (this *HoverflyModeStub) SetMode(mode string) error {
-	this.Mode = mode
-	if mode == "error" {
+func (this *HoverflyModeStub) SetModeWithArguments(modeView ModeView) error {
+	this.ModeView = modeView
+	if modeView.Mode == "error" {
 		return fmt.Errorf("This is an error")
 	}
 
 	return nil
 }
 
-func (this *HoverflyModeStub) SetModeArguments(arguments ModeArgumentsView) {
-	this.Arguments = arguments
-}
-
 func TestGetReturnsTheCorrectModeAndArguments(t *testing.T) {
 	RegisterTestingT(t)
 
-	stubHoverfly := &HoverflyModeStub{Mode: "test-mode"}
+	stubHoverfly := &HoverflyModeStub{ModeView{
+		Mode: "test-mode",
+	}}
+
 	unit := HoverflyModeHandler{Hoverfly: stubHoverfly}
 
 	request, err := http.NewRequest("GET", "/api/v2/hoverfly/mode", nil)
@@ -54,7 +52,9 @@ func TestGetReturnsTheCorrectModeAndArguments(t *testing.T) {
 func TestPutSetsTheNewModeAndReplacesTheTestMode(t *testing.T) {
 	RegisterTestingT(t)
 
-	stubHoverfly := &HoverflyModeStub{Mode: "test-mode"}
+	stubHoverfly := &HoverflyModeStub{ModeView{
+		Mode: "test-mode",
+	}}
 	unit := HoverflyModeHandler{Hoverfly: stubHoverfly}
 
 	modeView := &ModeView{Mode: "new-mode"}
@@ -67,7 +67,7 @@ func TestPutSetsTheNewModeAndReplacesTheTestMode(t *testing.T) {
 
 	response := makeRequestOnHandler(unit.Put, request)
 	Expect(response.Code).To(Equal(http.StatusOK))
-	Expect(stubHoverfly.Mode).To(Equal("new-mode"))
+	Expect(stubHoverfly.ModeView.Mode).To(Equal("new-mode"))
 
 	modeViewResponse, err := unmarshalModeView(response.Body)
 	Expect(err).To(BeNil())
@@ -78,7 +78,10 @@ func TestPutSetsTheNewModeAndReplacesTheTestMode(t *testing.T) {
 func TestPutSetsTheArguments(t *testing.T) {
 	RegisterTestingT(t)
 
-	stubHoverfly := &HoverflyModeStub{Mode: "test-mode"}
+	stubHoverfly := &HoverflyModeStub{ModeView{
+		Mode: "test-mode",
+	}}
+
 	unit := HoverflyModeHandler{Hoverfly: stubHoverfly}
 
 	modeView := &ModeView{Arguments: ModeArgumentsView{
@@ -97,13 +100,16 @@ func TestPutSetsTheArguments(t *testing.T) {
 	_, err = unmarshalModeView(response.Body)
 	Expect(err).To(BeNil())
 
-	Expect(stubHoverfly.Arguments.Headers).To(ContainElement("argument"))
+	Expect(stubHoverfly.ModeView.Arguments.Headers).To(ContainElement("argument"))
 }
 
 func TestPutResetsTheArgumentsWhenNotSet(t *testing.T) {
 	RegisterTestingT(t)
 
-	stubHoverfly := &HoverflyModeStub{Mode: "test-mode"}
+	stubHoverfly := &HoverflyModeStub{ModeView{
+		Mode: "test-mode",
+	}}
+
 	unit := HoverflyModeHandler{Hoverfly: stubHoverfly}
 
 	modeView := &ModeView{Arguments: ModeArgumentsView{
@@ -132,7 +138,7 @@ func TestPutResetsTheArgumentsWhenNotSet(t *testing.T) {
 	_, err = unmarshalModeView(response.Body)
 	Expect(err).To(BeNil())
 
-	Expect(stubHoverfly.Arguments).To(Equal(ModeArgumentsView{}))
+	Expect(stubHoverfly.ModeView.Arguments).To(Equal(ModeArgumentsView{}))
 }
 
 func TestPutWill422ErrorIfHoverflyErrors(t *testing.T) {

--- a/core/handlers/v2/hoverfly_mode_handler_test.go
+++ b/core/handlers/v2/hoverfly_mode_handler_test.go
@@ -156,7 +156,7 @@ func TestPutWill422ErrorIfHoverflyErrors(t *testing.T) {
 	Expect(err).To(BeNil())
 
 	response := makeRequestOnHandler(unit.Put, request)
-	Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+	Expect(response.Code).To(Equal(http.StatusBadRequest))
 
 	errorViewResponse, err := unmarshalErrorView(response.Body)
 	Expect(err).To(BeNil())

--- a/core/handlers/v2/hoverfly_mode_handler_test.go
+++ b/core/handlers/v2/hoverfly_mode_handler_test.go
@@ -13,7 +13,7 @@ import (
 
 type HoverflyModeStub struct {
 	Mode      string
-	Arguments map[string]string
+	Arguments ModeArgumentsView
 }
 
 func (this HoverflyModeStub) GetMode() string {
@@ -29,7 +29,7 @@ func (this *HoverflyModeStub) SetMode(mode string) error {
 	return nil
 }
 
-func (this *HoverflyModeStub) SetModeArguments(arguments map[string]string) {
+func (this *HoverflyModeStub) SetModeArguments(arguments ModeArgumentsView) {
 	this.Arguments = arguments
 }
 
@@ -81,8 +81,8 @@ func TestPutSetsTheArguments(t *testing.T) {
 	stubHoverfly := &HoverflyModeStub{Mode: "test-mode"}
 	unit := HoverflyModeHandler{Hoverfly: stubHoverfly}
 
-	modeView := &ModeView{Arguments: map[string]string{
-		"test": "argument",
+	modeView := &ModeView{Arguments: ModeArgumentsView{
+		Headers: []string{"argument"},
 	}}
 
 	bodyBytes, err := json.Marshal(modeView)
@@ -97,7 +97,7 @@ func TestPutSetsTheArguments(t *testing.T) {
 	_, err = unmarshalModeView(response.Body)
 	Expect(err).To(BeNil())
 
-	Expect(stubHoverfly.Arguments).To(HaveKeyWithValue("test", "argument"))
+	Expect(stubHoverfly.Arguments.Headers).To(ContainElement("argument"))
 }
 
 func TestPutResetsTheArgumentsWhenNotSet(t *testing.T) {
@@ -106,8 +106,8 @@ func TestPutResetsTheArgumentsWhenNotSet(t *testing.T) {
 	stubHoverfly := &HoverflyModeStub{Mode: "test-mode"}
 	unit := HoverflyModeHandler{Hoverfly: stubHoverfly}
 
-	modeView := &ModeView{Arguments: map[string]string{
-		"test": "argument",
+	modeView := &ModeView{Arguments: ModeArgumentsView{
+		Headers: []string{"argument"},
 	}}
 
 	bodyBytes, err := json.Marshal(modeView)
@@ -119,7 +119,7 @@ func TestPutResetsTheArgumentsWhenNotSet(t *testing.T) {
 	response := makeRequestOnHandler(unit.Put, request)
 	Expect(response.Code).To(Equal(http.StatusOK))
 
-	modeView.Arguments = nil
+	modeView.Arguments = ModeArgumentsView{}
 	bodyBytes, err = json.Marshal(modeView)
 	Expect(err).To(BeNil())
 
@@ -132,7 +132,7 @@ func TestPutResetsTheArgumentsWhenNotSet(t *testing.T) {
 	_, err = unmarshalModeView(response.Body)
 	Expect(err).To(BeNil())
 
-	Expect(stubHoverfly.Arguments).To(BeEmpty())
+	Expect(stubHoverfly.Arguments).To(Equal(ModeArgumentsView{}))
 }
 
 func TestPutWill422ErrorIfHoverflyErrors(t *testing.T) {

--- a/core/handlers/v2/views.go
+++ b/core/handlers/v2/views.go
@@ -20,7 +20,11 @@ type MiddlewareView struct {
 
 type ModeView struct {
 	Mode      string            `json:"mode"`
-	Arguments map[string]string `json:"arguments,omitempty"`
+	Arguments ModeArgumentsView `json:"arguments,omitempty"`
+}
+
+type ModeArgumentsView struct {
+	Headers []string `json:"headersWhitelist,omitempty"`
 }
 
 type VersionView struct {

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -292,7 +292,7 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 }
 
 // save gets request fingerprint, extracts request body, status code and headers, then saves it to cache
-func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.ResponseDetails) error {
+func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.ResponseDetails, headersToSave []string) error {
 	body := &models.RequestFieldMatchers{
 		ExactMatch: util.StringToPointer(request.Body),
 	}

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -292,7 +292,7 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 }
 
 // save gets request fingerprint, extracts request body, status code and headers, then saves it to cache
-func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.ResponseDetails, headersToSave []string) error {
+func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.ResponseDetails, headersWhitelist []string) error {
 	body := &models.RequestFieldMatchers{
 		ExactMatch: util.StringToPointer(request.Body),
 	}
@@ -308,12 +308,15 @@ func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.Respon
 	}
 
 	var headers map[string][]string
+	if headersWhitelist == nil {
+		headersWhitelist = []string{}
+	}
 
-	if headersToSave != nil && len(headersToSave) == 0 {
+	if len(headersWhitelist) >= 1 && headersWhitelist[0] == "*" {
 		headers = request.Headers
-	} else if len(headersToSave) > 0 {
+	} else {
 		headers = map[string][]string{}
-		for _, header := range headersToSave {
+		for _, header := range headersWhitelist {
 			headerValues := request.Headers[header]
 			if len(headerValues) > 0 {
 				headers[header] = headerValues

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -307,6 +307,20 @@ func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.Respon
 		}
 	}
 
+	var headers map[string][]string
+
+	if headersToSave != nil && len(headersToSave) == 0 {
+		headers = request.Headers
+	} else if len(headersToSave) > 0 {
+		headers = map[string][]string{}
+		for _, header := range headersToSave {
+			headerValues := request.Headers[header]
+			if len(headerValues) > 0 {
+				headers[header] = headerValues
+			}
+		}
+	}
+
 	pair := models.RequestTemplateResponsePair{
 		RequestTemplate: models.RequestTemplate{
 			Path: &models.RequestFieldMatchers{
@@ -325,7 +339,7 @@ func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.Respon
 				ExactMatch: util.StringToPointer(request.Query),
 			},
 			Body:    body,
-			Headers: request.Headers,
+			Headers: headers,
 		},
 		Response: *response,
 	}

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -62,13 +62,17 @@ func (this *Hoverfly) SetModeWithArguments(modeView v2.ModeView) error {
 		return fmt.Errorf("Can't change mode to capture when configured as a webserver")
 	}
 
+	for _, header := range modeView.Arguments.Headers {
+		if header == "*" {
+			if len(modeView.Arguments.Headers) > 1 {
+				return errors.New("Must provide a list containing only an asterix, or a list containing only headers names")
+			}
+		}
+	}
+
 	this.Cfg.SetMode(modeView.Mode)
 	if this.Cfg.GetMode() == "capture" {
 		this.CacheMatcher.FlushCache()
-	}
-
-	if len(modeView.Arguments.Headers) > 1 && modeView.Arguments.Headers[0] == "*" {
-		return errors.New("Must provide a list containing only an asterix, or a list containing only headers names")
 	}
 
 	modeArguments := modes.ModeArguments{

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -62,8 +62,12 @@ func (this *Hoverfly) SetMode(mode string) error {
 	return nil
 }
 
-func (hf *Hoverfly) SetModeArguments(arguments map[string]string) {
-	hf.modeMap[hf.Cfg.GetMode()].SetArguments(arguments)
+func (hf *Hoverfly) SetModeArguments(argumentsView v2.ModeArgumentsView) {
+	modeArguments := modes.ModeArguments{
+		Headers: argumentsView.Headers,
+	}
+
+	hf.modeMap[hf.Cfg.GetMode()].SetArguments(modeArguments)
 }
 
 func (hf Hoverfly) GetMiddleware() (string, string, string) {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -37,6 +37,13 @@ func (this Hoverfly) GetMode() string {
 }
 
 func (this *Hoverfly) SetMode(mode string) error {
+	return this.SetModeWithArguments(v2.ModeView{
+		Mode: mode,
+	})
+}
+
+func (this *Hoverfly) SetModeWithArguments(modeView v2.ModeView) error {
+
 	availableModes := map[string]bool{
 		modes.Simulate:   true,
 		modes.Capture:    true,
@@ -44,30 +51,27 @@ func (this *Hoverfly) SetMode(mode string) error {
 		modes.Synthesize: true,
 	}
 
-	if mode == "" || !availableModes[mode] {
-		log.Error("Can't change mode to \"%d\"", mode)
+	if modeView.Mode == "" || !availableModes[modeView.Mode] {
+		log.Error("Can't change mode to \"%d\"", modeView.Mode)
 		return fmt.Errorf("Not a valid mode")
 	}
 
-	if this.Cfg.Webserver && mode == modes.Capture {
+	if this.Cfg.Webserver && modeView.Mode == modes.Capture {
 		log.Error("Can't change mode to when configured as a webserver")
 		return fmt.Errorf("Can't change mode to capture when configured as a webserver")
 	}
 
-	this.Cfg.SetMode(mode)
+	this.Cfg.SetMode(modeView.Mode)
 	if this.Cfg.GetMode() == "capture" {
 		this.CacheMatcher.FlushCache()
 	}
 
-	return nil
-}
-
-func (hf *Hoverfly) SetModeArguments(argumentsView v2.ModeArgumentsView) {
 	modeArguments := modes.ModeArguments{
-		Headers: argumentsView.Headers,
+		Headers: modeView.Arguments.Headers,
 	}
 
-	hf.modeMap[hf.Cfg.GetMode()].SetArguments(modeArguments)
+	this.modeMap[this.Cfg.GetMode()].SetArguments(modeArguments)
+	return nil
 }
 
 func (hf Hoverfly) GetMiddleware() (string, string, string) {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -1,6 +1,7 @@
 package hoverfly
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -64,6 +65,10 @@ func (this *Hoverfly) SetModeWithArguments(modeView v2.ModeView) error {
 	this.Cfg.SetMode(modeView.Mode)
 	if this.Cfg.GetMode() == "capture" {
 		this.CacheMatcher.FlushCache()
+	}
+
+	if len(modeView.Arguments.Headers) > 1 && modeView.Arguments.Headers[0] == "*" {
+		return errors.New("Must provide a list containing only an asterix, or a list containing only headers names")
 	}
 
 	modeArguments := modes.ModeArguments{

--- a/core/hoverfly_service_test.go
+++ b/core/hoverfly_service_test.go
@@ -576,3 +576,27 @@ func Test_Hoverfly_SetMode_SettingModeToCaptureWipesCache(t *testing.T) {
 	values, _ := unit.CacheMatcher.RequestCache.GetAllValues()
 	Expect(values).To(HaveLen(0))
 }
+
+func Test_Hoverfly_SetModeWithARguments_AsteriskCanOnlyBeValidAsTheOnlyHeader(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewHoverflyWithConfiguration(&Configuration{})
+
+	unit.CacheMatcher.RequestCache.Set([]byte("test"), []byte("test_bytes"))
+
+	Expect(unit.SetMode("capture")).To(BeNil())
+	Expect(unit.Cfg.Mode).To(Equal("capture"))
+
+	Expect(unit.SetModeWithArguments(v2.ModeView{
+		Arguments: v2.ModeArgumentsView{
+			Headers: []string{"Content-Type", "*"},
+		},
+	})).ToNot(Succeed())
+
+	Expect(unit.SetModeWithArguments(v2.ModeView{
+		Arguments: v2.ModeArgumentsView{
+			Headers: []string{"*"},
+		},
+	})).ToNot(Succeed())
+
+}

--- a/core/hoverfly_test.go
+++ b/core/hoverfly_test.go
@@ -569,7 +569,7 @@ func Test_Hoverfly_Save_DoesNotSaveRequestHeadersWhenGivenHeadersArrayIsNil(t *t
 	Expect(unit.Simulation.Templates[0].RequestTemplate.Headers).To(BeEmpty())
 }
 
-func Test_Hoverfly_Save_SavesAllRequestHeadersWhenGivenEmptyHeadersArray(t *testing.T) {
+func Test_Hoverfly_Save_SavesAllRequestHeadersWhenGivenAnAsterisk(t *testing.T) {
 	RegisterTestingT(t)
 
 	unit := NewHoverflyWithConfiguration(&Configuration{})
@@ -583,7 +583,7 @@ func Test_Hoverfly_Save_SavesAllRequestHeadersWhenGivenEmptyHeadersArray(t *test
 		Body:    "testresponsebody",
 		Headers: map[string][]string{"testheader": []string{"testvalue"}},
 		Status:  200,
-	}, []string{})
+	}, []string{"*"})
 
 	Expect(unit.Simulation.Templates[0].RequestTemplate.Headers).To(HaveLen(2))
 	Expect(unit.Simulation.Templates[0].RequestTemplate.Headers).To(HaveKeyWithValue("testheader", []string{"testvalue"}))

--- a/core/hoverfly_test.go
+++ b/core/hoverfly_test.go
@@ -537,7 +537,7 @@ func Test_Hoverfly_Save_SavesRequestAndResponseToSimulation(t *testing.T) {
 		Body:    "testresponsebody",
 		Headers: map[string][]string{"testheader": []string{"testvalue"}},
 		Status:  200,
-	})
+	}, nil)
 
 	Expect(unit.Simulation.Templates).To(HaveLen(1))
 
@@ -565,7 +565,7 @@ func Test_Hoverfly_Save_SavesIncompleteRequestAndResponseToSimulation(t *testing
 		Body:    "testresponsebody",
 		Headers: map[string][]string{"testheader": []string{"testvalue"}},
 		Status:  200,
-	})
+	}, nil)
 
 	Expect(unit.Simulation.Templates).To(HaveLen(1))
 
@@ -592,7 +592,7 @@ func Test_Hoverfly_Save_SavesRequestBodyAsJsonPathIfContentTypeIsJson(t *testing
 		Headers: map[string][]string{
 			"Content-Type": []string{"application/json"},
 		},
-	}, &models.ResponseDetails{})
+	}, &models.ResponseDetails{}, nil)
 
 	Expect(unit.Simulation.Templates).To(HaveLen(1))
 
@@ -609,7 +609,7 @@ func Test_Hoverfly_Save_SavesRequestBodyAsXmlPathIfContentTypeIsXml(t *testing.T
 		Headers: map[string][]string{
 			"Content-Type": []string{"application/xml"},
 		},
-	}, &models.ResponseDetails{})
+	}, &models.ResponseDetails{}, nil)
 
 	Expect(unit.Simulation.Templates).To(HaveLen(1))
 

--- a/core/models_test.go
+++ b/core/models_test.go
@@ -81,7 +81,7 @@ func TestMatchOnRequestBody(t *testing.T) {
 			Body:   fmt.Sprintf("body here, number=%d", i),
 		}
 
-		dbClient.Save(req, resp)
+		dbClient.Save(req, resp, nil)
 	}
 
 	// now getting responses

--- a/core/modes/capture_mode.go
+++ b/core/modes/capture_mode.go
@@ -56,7 +56,7 @@ func (this CaptureMode) Process(request *http.Request, details models.RequestDet
 	}
 
 	// saving response body with request/response meta to cache
-	err = this.Hoverfly.Save(&pair.Request, responseObj, nil)
+	err = this.Hoverfly.Save(&pair.Request, responseObj, []string{})
 	if err != nil {
 		return ReturnErrorAndLog(request, err, &pair, "There was an error when saving request and response", Capture)
 	}

--- a/core/modes/capture_mode.go
+++ b/core/modes/capture_mode.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -55,8 +56,15 @@ func (this CaptureMode) Process(request *http.Request, details models.RequestDet
 		Headers: response.Header,
 	}
 
+	var headersToSave []string
+	if this.Arguments["headers"] == "*" {
+		headersToSave = []string{}
+	} else if this.Arguments["headers"] != "" {
+		headersToSave = strings.Split(this.Arguments["headers"], ",")
+	}
+
 	// saving response body with request/response meta to cache
-	err = this.Hoverfly.Save(&pair.Request, responseObj, []string{})
+	err = this.Hoverfly.Save(&pair.Request, responseObj, headersToSave)
 	if err != nil {
 		return ReturnErrorAndLog(request, err, &pair, "There was an error when saving request and response", Capture)
 	}

--- a/core/modes/capture_mode.go
+++ b/core/modes/capture_mode.go
@@ -14,7 +14,7 @@ import (
 type HoverflyCapture interface {
 	ApplyMiddleware(models.RequestResponsePair) (models.RequestResponsePair, error)
 	DoRequest(*http.Request) (*http.Response, error)
-	Save(*models.RequestDetails, *models.ResponseDetails) error
+	Save(*models.RequestDetails, *models.ResponseDetails, []string) error
 }
 
 type CaptureMode struct {
@@ -56,7 +56,7 @@ func (this CaptureMode) Process(request *http.Request, details models.RequestDet
 	}
 
 	// saving response body with request/response meta to cache
-	err = this.Hoverfly.Save(&pair.Request, responseObj)
+	err = this.Hoverfly.Save(&pair.Request, responseObj, nil)
 	if err != nil {
 		return ReturnErrorAndLog(request, err, &pair, "There was an error when saving request and response", Capture)
 	}

--- a/core/modes/capture_mode.go
+++ b/core/modes/capture_mode.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -20,10 +19,10 @@ type HoverflyCapture interface {
 
 type CaptureMode struct {
 	Hoverfly  HoverflyCapture
-	Arguments map[string]string
+	Arguments ModeArguments
 }
 
-func (this *CaptureMode) SetArguments(arguments map[string]string) {
+func (this *CaptureMode) SetArguments(arguments ModeArguments) {
 	this.Arguments = arguments
 }
 
@@ -56,10 +55,12 @@ func (this CaptureMode) Process(request *http.Request, details models.RequestDet
 		Headers: response.Header,
 	}
 
-	headersToSave := strings.Split(this.Arguments["headers"], ",")
+	if this.Arguments.Headers == nil {
+		this.Arguments.Headers = []string{}
+	}
 
 	// saving response body with request/response meta to cache
-	err = this.Hoverfly.Save(&pair.Request, responseObj, headersToSave)
+	err = this.Hoverfly.Save(&pair.Request, responseObj, this.Arguments.Headers)
 	if err != nil {
 		return ReturnErrorAndLog(request, err, &pair, "There was an error when saving request and response", Capture)
 	}

--- a/core/modes/capture_mode.go
+++ b/core/modes/capture_mode.go
@@ -56,12 +56,7 @@ func (this CaptureMode) Process(request *http.Request, details models.RequestDet
 		Headers: response.Header,
 	}
 
-	var headersToSave []string
-	if this.Arguments["headers"] == "*" {
-		headersToSave = []string{}
-	} else if this.Arguments["headers"] != "" {
-		headersToSave = strings.Split(this.Arguments["headers"], ",")
-	}
+	headersToSave := strings.Split(this.Arguments["headers"], ",")
 
 	// saving response body with request/response meta to cache
 	err = this.Hoverfly.Save(&pair.Request, responseObj, headersToSave)

--- a/core/modes/capture_mode_test.go
+++ b/core/modes/capture_mode_test.go
@@ -91,6 +91,77 @@ func Test_CaptureMode_WhenGivenARequestItWillMakeTheRequestAndSaveIt(t *testing.
 	Expect(hoverflyStub.SavedResponse.Body).To(Equal("test"))
 }
 
+func Test_CaptureMode_IfHeadersArgumentNotSet_CallsSaveWithNilList(t *testing.T) {
+	RegisterTestingT(t)
+
+	hoverflyStub := &hoverflyCaptureStub{}
+
+	unit := &modes.CaptureMode{
+		Hoverfly: hoverflyStub,
+	}
+
+	requestDetails := models.RequestDetails{
+		Scheme:      "http",
+		Destination: "positive-match.com",
+	}
+
+	request, _ := http.NewRequest("GET", "http://positive-match.com", nil)
+
+	_, err := unit.Process(request, requestDetails)
+	Expect(err).To(BeNil())
+
+	Expect(hoverflyStub.SavedHeaders).To(BeNil())
+}
+
+func Test_CaptureMode_IfHeadersArgumentSetToAll_CallsSaveWithEmptyList(t *testing.T) {
+	RegisterTestingT(t)
+
+	hoverflyStub := &hoverflyCaptureStub{}
+
+	unit := &modes.CaptureMode{
+		Hoverfly: hoverflyStub,
+	}
+
+	requestDetails := models.RequestDetails{
+		Scheme:      "http",
+		Destination: "positive-match.com",
+	}
+
+	unit.SetArguments(map[string]string{"headers": "*"})
+
+	request, _ := http.NewRequest("GET", "http://positive-match.com", nil)
+
+	_, err := unit.Process(request, requestDetails)
+	Expect(err).To(BeNil())
+
+	Expect(hoverflyStub.SavedHeaders).To(HaveLen(0))
+}
+
+func Test_CaptureMode_IfHeadersArgumentSetToOneHeaders_CallsSaveWithOneHeaderList(t *testing.T) {
+	RegisterTestingT(t)
+
+	hoverflyStub := &hoverflyCaptureStub{}
+
+	unit := &modes.CaptureMode{
+		Hoverfly: hoverflyStub,
+	}
+
+	requestDetails := models.RequestDetails{
+		Scheme:      "http",
+		Destination: "positive-match.com",
+	}
+
+	unit.SetArguments(map[string]string{"headers": "Content-Type"})
+
+	request, _ := http.NewRequest("GET", "http://positive-match.com", nil)
+
+	_, err := unit.Process(request, requestDetails)
+	Expect(err).To(BeNil())
+
+	Expect(hoverflyStub.SavedHeaders).To(HaveLen(1))
+	Expect(hoverflyStub.SavedHeaders).To(ContainElement("Content-Type"))
+}
+
 func Test_CaptureMode_WhenGivenABadRequestItWillError(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/modes/capture_mode_test.go
+++ b/core/modes/capture_mode_test.go
@@ -15,6 +15,7 @@ import (
 type hoverflyCaptureStub struct {
 	SavedRequest  *models.RequestDetails
 	SavedResponse *models.ResponseDetails
+	SavedHeaders  []string
 	MiddlewareSet bool
 }
 
@@ -37,9 +38,10 @@ func (this hoverflyCaptureStub) DoRequest(request *http.Request) (*http.Response
 }
 
 // Save - Stub implementation of modes.HoverflyCapture interface
-func (this *hoverflyCaptureStub) Save(request *models.RequestDetails, response *models.ResponseDetails) error {
+func (this *hoverflyCaptureStub) Save(request *models.RequestDetails, response *models.ResponseDetails, headersToSave []string) error {
 	this.SavedRequest = request
 	this.SavedResponse = response
+	this.SavedHeaders = headersToSave
 
 	return nil
 }

--- a/core/modes/capture_mode_test.go
+++ b/core/modes/capture_mode_test.go
@@ -110,7 +110,8 @@ func Test_CaptureMode_IfHeadersArgumentNotSet_CallsSaveWithNilList(t *testing.T)
 	_, err := unit.Process(request, requestDetails)
 	Expect(err).To(BeNil())
 
-	Expect(hoverflyStub.SavedHeaders).To(BeNil())
+	Expect(hoverflyStub.SavedHeaders).To(HaveLen(1))
+	Expect(hoverflyStub.SavedHeaders).To(ContainElement(""))
 }
 
 func Test_CaptureMode_IfHeadersArgumentSetToAll_CallsSaveWithEmptyList(t *testing.T) {
@@ -134,7 +135,8 @@ func Test_CaptureMode_IfHeadersArgumentSetToAll_CallsSaveWithEmptyList(t *testin
 	_, err := unit.Process(request, requestDetails)
 	Expect(err).To(BeNil())
 
-	Expect(hoverflyStub.SavedHeaders).To(HaveLen(0))
+	Expect(hoverflyStub.SavedHeaders).To(HaveLen(1))
+	Expect(hoverflyStub.SavedHeaders).To(ContainElement("*"))
 }
 
 func Test_CaptureMode_IfHeadersArgumentSetToOneHeaders_CallsSaveWithOneHeaderList(t *testing.T) {

--- a/core/modes/capture_mode_test.go
+++ b/core/modes/capture_mode_test.go
@@ -53,11 +53,12 @@ func Test_CaptureMode_CanSetArguments(t *testing.T) {
 		Hoverfly: &hoverflyCaptureStub{},
 	}
 
-	unit.SetArguments(map[string]string{
-		"test": "value",
+	unit.SetArguments(modes.ModeArguments{
+		Headers: []string{"value", "two"},
 	})
 
-	Expect(unit.Arguments).To(HaveKeyWithValue("test", "value"))
+	Expect(unit.Arguments.Headers).To(ContainElement("value"))
+	Expect(unit.Arguments.Headers).To(ContainElement("two"))
 }
 
 func Test_CaptureMode_WhenGivenARequestItWillMakeTheRequestAndSaveIt(t *testing.T) {
@@ -91,7 +92,7 @@ func Test_CaptureMode_WhenGivenARequestItWillMakeTheRequestAndSaveIt(t *testing.
 	Expect(hoverflyStub.SavedResponse.Body).To(Equal("test"))
 }
 
-func Test_CaptureMode_IfHeadersArgumentNotSet_CallsSaveWithNilList(t *testing.T) {
+func Test_CaptureMode_IfHeadersArgumentNotSet_CallsSaveWithEmptyList(t *testing.T) {
 	RegisterTestingT(t)
 
 	hoverflyStub := &hoverflyCaptureStub{}
@@ -110,8 +111,7 @@ func Test_CaptureMode_IfHeadersArgumentNotSet_CallsSaveWithNilList(t *testing.T)
 	_, err := unit.Process(request, requestDetails)
 	Expect(err).To(BeNil())
 
-	Expect(hoverflyStub.SavedHeaders).To(HaveLen(1))
-	Expect(hoverflyStub.SavedHeaders).To(ContainElement(""))
+	Expect(hoverflyStub.SavedHeaders).To(HaveLen(0))
 }
 
 func Test_CaptureMode_IfHeadersArgumentSetToAll_CallsSaveWithEmptyList(t *testing.T) {
@@ -128,7 +128,9 @@ func Test_CaptureMode_IfHeadersArgumentSetToAll_CallsSaveWithEmptyList(t *testin
 		Destination: "positive-match.com",
 	}
 
-	unit.SetArguments(map[string]string{"headers": "*"})
+	unit.SetArguments(modes.ModeArguments{
+		Headers: []string{"*"},
+	})
 
 	request, _ := http.NewRequest("GET", "http://positive-match.com", nil)
 
@@ -153,7 +155,9 @@ func Test_CaptureMode_IfHeadersArgumentSetToOneHeaders_CallsSaveWithOneHeaderLis
 		Destination: "positive-match.com",
 	}
 
-	unit.SetArguments(map[string]string{"headers": "Content-Type"})
+	unit.SetArguments(modes.ModeArguments{
+		Headers: []string{"Content-Type"},
+	})
 
 	request, _ := http.NewRequest("GET", "http://positive-match.com", nil)
 

--- a/core/modes/modes.go
+++ b/core/modes/modes.go
@@ -28,7 +28,7 @@ const Capture = "capture"
 
 type Mode interface {
 	Process(*http.Request, models.RequestDetails) (*http.Response, error)
-	SetArguments(arguments map[string]string)
+	SetArguments(arguments ModeArguments)
 }
 
 type Hoverfly interface {
@@ -37,6 +37,10 @@ type Hoverfly interface {
 	DoRequest(*http.Request) (*http.Response, error)
 	IsMiddlewareSet() bool
 	Save(*models.RequestDetails, *models.ResponseDetails)
+}
+
+type ModeArguments struct {
+	Headers []string
 }
 
 // ReconstructRequest replaces original request with details provided in Constructor Payload.Request

--- a/core/modes/modify_mode.go
+++ b/core/modes/modify_mode.go
@@ -13,13 +13,10 @@ type HoverflyModify interface {
 }
 
 type ModifyMode struct {
-	Hoverfly  HoverflyModify
-	Arguments map[string]string
+	Hoverfly HoverflyModify
 }
 
-func (this *ModifyMode) SetArguments(arguments map[string]string) {
-	this.Arguments = arguments
-}
+func (this *ModifyMode) SetArguments(arguments map[string]string) {}
 
 func (this ModifyMode) Process(request *http.Request, details models.RequestDetails) (*http.Response, error) {
 	pair, err := this.Hoverfly.ApplyMiddleware(models.RequestResponsePair{Request: details})

--- a/core/modes/modify_mode.go
+++ b/core/modes/modify_mode.go
@@ -16,7 +16,7 @@ type ModifyMode struct {
 	Hoverfly HoverflyModify
 }
 
-func (this *ModifyMode) SetArguments(arguments map[string]string) {}
+func (this *ModifyMode) SetArguments(arguments ModeArguments) {}
 
 func (this ModifyMode) Process(request *http.Request, details models.RequestDetails) (*http.Response, error) {
 	pair, err := this.Hoverfly.ApplyMiddleware(models.RequestResponsePair{Request: details})

--- a/core/modes/modify_mode_test.go
+++ b/core/modes/modify_mode_test.go
@@ -36,20 +36,6 @@ func (this hoverflyModifyStub) ApplyMiddleware(pair models.RequestResponsePair) 
 	return pair, nil
 }
 
-func Test_ModifyMode_CanSetArguments(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := &modes.ModifyMode{
-		Hoverfly: hoverflyModifyStub{},
-	}
-
-	unit.SetArguments(map[string]string{
-		"test": "value",
-	})
-
-	Expect(unit.Arguments).To(HaveKeyWithValue("test", "value"))
-}
-
 func Test_ModifyMode_WhenGivenARequestItWillModifyTheRequestAndExecuteIt(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/modes/simulate_mode.go
+++ b/core/modes/simulate_mode.go
@@ -13,13 +13,10 @@ type HoverflySimulate interface {
 }
 
 type SimulateMode struct {
-	Hoverfly  HoverflySimulate
-	Arguments map[string]string
+	Hoverfly HoverflySimulate
 }
 
-func (this *SimulateMode) SetArguments(arguments map[string]string) {
-	this.Arguments = arguments
-}
+func (this *SimulateMode) SetArguments(arguments map[string]string) {}
 
 func (this SimulateMode) Process(request *http.Request, details models.RequestDetails) (*http.Response, error) {
 	pair := models.RequestResponsePair{

--- a/core/modes/simulate_mode.go
+++ b/core/modes/simulate_mode.go
@@ -16,7 +16,7 @@ type SimulateMode struct {
 	Hoverfly HoverflySimulate
 }
 
-func (this *SimulateMode) SetArguments(arguments map[string]string) {}
+func (this *SimulateMode) SetArguments(arguments ModeArguments) {}
 
 func (this SimulateMode) Process(request *http.Request, details models.RequestDetails) (*http.Response, error) {
 	pair := models.RequestResponsePair{

--- a/core/modes/simulate_mode_test.go
+++ b/core/modes/simulate_mode_test.go
@@ -34,20 +34,6 @@ func (this hoverflySimulateStub) ApplyMiddleware(pair models.RequestResponsePair
 	return pair, nil
 }
 
-func Test_SimulateMode_CanSetArguments(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := &modes.SimulateMode{
-		Hoverfly: hoverflySimulateStub{},
-	}
-
-	unit.SetArguments(map[string]string{
-		"test": "value",
-	})
-
-	Expect(unit.Arguments).To(HaveKeyWithValue("test", "value"))
-}
-
 func Test_SimulateMode_WhenGivenAMatchingRequestItReturnsTheCorrectResponse(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/modes/synthesize_mode.go
+++ b/core/modes/synthesize_mode.go
@@ -15,13 +15,10 @@ type HoverflySynthesize interface {
 }
 
 type SynthesizeMode struct {
-	Hoverfly  HoverflySynthesize
-	Arguments map[string]string
+	Hoverfly HoverflySynthesize
 }
 
-func (this *SynthesizeMode) SetArguments(arguments map[string]string) {
-	this.Arguments = arguments
-}
+func (this *SynthesizeMode) SetArguments(arguments map[string]string) {}
 
 func (this SynthesizeMode) Process(request *http.Request, details models.RequestDetails) (*http.Response, error) {
 	pair := models.RequestResponsePair{Request: details}

--- a/core/modes/synthesize_mode.go
+++ b/core/modes/synthesize_mode.go
@@ -18,7 +18,7 @@ type SynthesizeMode struct {
 	Hoverfly HoverflySynthesize
 }
 
-func (this *SynthesizeMode) SetArguments(arguments map[string]string) {}
+func (this *SynthesizeMode) SetArguments(arguments ModeArguments) {}
 
 func (this SynthesizeMode) Process(request *http.Request, details models.RequestDetails) (*http.Response, error) {
 	pair := models.RequestResponsePair{Request: details}

--- a/core/modes/synthesize_mode_test.go
+++ b/core/modes/synthesize_mode_test.go
@@ -28,20 +28,6 @@ func (this hoverflySynthesizeStub) IsMiddlewareSet() bool {
 	return this.MiddlewareSet
 }
 
-func Test_SynthesizeMode_CanSetArguments(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := &modes.SynthesizeMode{
-		Hoverfly: hoverflySynthesizeStub{},
-	}
-
-	unit.SetArguments(map[string]string{
-		"test": "value",
-	})
-
-	Expect(unit.Arguments).To(HaveKeyWithValue("test", "value"))
-}
-
 func Test_SynthesizeMode_WhenGivenARequestItWillUseMiddlewareToGenerateAResponse(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/functional-tests/core/ft_api_test.go
+++ b/functional-tests/core/ft_api_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Interacting with the API", func() {
 			Expect(res.StatusCode).To(Equal(200))
 			modeJson, err := ioutil.ReadAll(res.Body)
 			Expect(err).To(BeNil())
-			Expect(modeJson).To(Equal([]byte(`{"mode":"simulate"}`)))
+			Expect(modeJson).To(Equal([]byte(`{"mode":"simulate","arguments":{}}`)))
 		})
 	})
 
@@ -92,13 +92,13 @@ var _ = Describe("Interacting with the API", func() {
 			Expect(res.StatusCode).To(Equal(200))
 			modeJson, err := ioutil.ReadAll(res.Body)
 			Expect(err).To(BeNil())
-			Expect(modeJson).To(Equal([]byte(`{"mode":"capture"}`)))
+			Expect(modeJson).To(Equal([]byte(`{"mode":"capture","arguments":{}}`)))
 
 			req = sling.New().Get(hoverflyAdminUrl + "/api/v2/hoverfly/mode")
 			res = functional_tests.DoRequest(req)
 			modeJson, err = ioutil.ReadAll(res.Body)
 			Expect(err).To(BeNil())
-			Expect(modeJson).To(Equal([]byte(`{"mode":"capture"}`)))
+			Expect(modeJson).To(Equal([]byte(`{"mode":"capture","arguments":{}}`)))
 		})
 
 	})

--- a/functional-tests/core/ft_api_test.go
+++ b/functional-tests/core/ft_api_test.go
@@ -101,6 +101,23 @@ var _ = Describe("Interacting with the API", func() {
 			Expect(modeJson).To(Equal([]byte(`{"mode":"capture","arguments":{}}`)))
 		})
 
+		It("Should error when header arguments use an asterisk and a header", func() {
+			req := sling.New().Put(hoverflyAdminUrl + "/api/v2/hoverfly/mode")
+			req.BodyJSON(map[string]interface{}{
+				"mode": "mode",
+				"arguments": map[string][]string{
+					"headersWhitelist": []string{"*", "Content-Type"},
+				},
+			})
+			res := functional_tests.DoRequest(req)
+			Expect(res.StatusCode).To(Equal(400))
+			errorJson, err := ioutil.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			Expect(string(errorJson)).To(Equal(`{"error":"Not a valid mode"}`))
+
+		})
+
 	})
 
 	Context("GET /api/v2/hoverfly/middleware", func() {

--- a/functional-tests/core/ft_capture_mode_test.go
+++ b/functional-tests/core/ft_capture_mode_test.go
@@ -98,8 +98,8 @@ var _ = Describe("When I run Hoverfly", func() {
 			})
 
 			It("Should capture all request headers if argument is set to *", func() {
-				hoverfly.SetModeWithArgs("capture", map[string]string{
-					"headers": "*",
+				hoverfly.SetModeWithArgs("capture", v2.ModeArgumentsView{
+					Headers: []string{"*"},
 				})
 
 				fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -130,8 +130,8 @@ var _ = Describe("When I run Hoverfly", func() {
 			})
 
 			It("Should capture User-Agent request headers if argument is set to User-Agent", func() {
-				hoverfly.SetModeWithArgs("capture", map[string]string{
-					"headers": "User-Agent",
+				hoverfly.SetModeWithArgs("capture", v2.ModeArgumentsView{
+					Headers: []string{"User-Agent"},
 				})
 
 				fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -161,8 +161,8 @@ var _ = Describe("When I run Hoverfly", func() {
 			})
 
 			It("Should capture User-Agent and Test request headers if argument is set to User-Agent,Test", func() {
-				hoverfly.SetModeWithArgs("capture", map[string]string{
-					"headers": "User-Agent,Test",
+				hoverfly.SetModeWithArgs("capture", v2.ModeArgumentsView{
+					Headers: []string{"User-Agent", "Test"},
 				})
 
 				fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/functional-tests/core/ft_capture_mode_test.go
+++ b/functional-tests/core/ft_capture_mode_test.go
@@ -82,10 +82,6 @@ var _ = Describe("When I run Hoverfly", func() {
 					Body: &v2.RequestFieldMatchersView{
 						ExactMatch: util.StringToPointer(""),
 					},
-					Headers: map[string][]string{
-						"Accept-Encoding": []string{"gzip"},
-						"User-Agent":      []string{"Go-http-client/1.1"},
-					},
 				}))
 
 				Expect(payload.RequestResponsePairs[0].Response).To(Equal(v2.ResponseDetailsView{

--- a/functional-tests/functional_tests.go
+++ b/functional-tests/functional_tests.go
@@ -73,9 +73,15 @@ func (this Hoverfly) GetMode() string {
 
 	return currentState.Mode
 }
+
 func (this Hoverfly) SetMode(mode string) {
+	this.SetModeWithArgs(mode, nil)
+}
+
+func (this Hoverfly) SetModeWithArgs(mode string, arguments map[string]string) {
 	newMode := &v2.ModeView{
-		Mode: mode,
+		Mode:      mode,
+		Arguments: arguments,
 	}
 
 	DoRequest(sling.New().Put(this.adminUrl + "/api/v2/hoverfly/mode").BodyJSON(newMode))

--- a/functional-tests/functional_tests.go
+++ b/functional-tests/functional_tests.go
@@ -75,10 +75,10 @@ func (this Hoverfly) GetMode() string {
 }
 
 func (this Hoverfly) SetMode(mode string) {
-	this.SetModeWithArgs(mode, nil)
+	this.SetModeWithArgs(mode, v2.ModeArgumentsView{})
 }
 
-func (this Hoverfly) SetModeWithArgs(mode string, arguments map[string]string) {
+func (this Hoverfly) SetModeWithArgs(mode string, arguments v2.ModeArgumentsView) {
 	newMode := &v2.ModeView{
 		Mode:      mode,
 		Arguments: arguments,

--- a/hoverctl/wrapper/hoverfly.go
+++ b/hoverctl/wrapper/hoverfly.go
@@ -125,7 +125,7 @@ func (h *Hoverfly) SetMode(mode string) (string, error) {
 		return "", err
 	}
 
-	if response.StatusCode == 422 {
+	if response.StatusCode == http.StatusBadRequest {
 		return "", errors.New("Cannot change the mode of Hoverfly to capture when running as a webserver")
 	}
 


### PR DESCRIPTION
If you want to capture headers, you will now need to provide an argument when setting the mode.

*For all request headers, provide a headers argument with the value of an asterik*
```
{
    "mode": "capture",
    "arguments: {
        "headers": "*"
    }
}
```

*For specific request headers, provide the header name (comma separated list)*
```
{
    "mode": "capture",
    "arguments: {
        "headers": "Content-Type"
    }
}
```