### PR TITLE
Using hoverctl, you can now specify which headers you want to capture

### DIFF
--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -59,7 +59,7 @@ func (this *Hoverfly) SetModeWithArguments(modeView v2.ModeView) error {
 
 	if this.Cfg.Webserver && modeView.Mode == modes.Capture {
 		log.Error("Can't change mode to when configured as a webserver")
-		return fmt.Errorf("Can't change mode to capture when configured as a webserver")
+		return fmt.Errorf("Cannot change the mode of Hoverfly to capture when running as a webserver")
 	}
 
 	for _, header := range modeView.Arguments.Headers {

--- a/functional-tests/hoverctl/hoverfly_modes_test.go
+++ b/functional-tests/hoverctl/hoverfly_modes_test.go
@@ -98,7 +98,7 @@ var _ = Describe("When I use hoverfly-cli", func() {
 			It("to capture mode and capture one request header", func() {
 				output := functional_tests.Run(hoverctlBinary, "mode", "capture", "--headers", "Content-Type")
 
-				Expect(output).To(ContainSubstring("Hoverfly has been set to capture mode and will capture Content-Type request header"))
+				Expect(output).To(ContainSubstring("Hoverfly has been set to capture mode and will capture the following request headers: [Content-Type]"))
 
 				output = functional_tests.Run(hoverctlBinary, "mode")
 
@@ -109,7 +109,7 @@ var _ = Describe("When I use hoverfly-cli", func() {
 			It("to capture mode and capture two request headers", func() {
 				output := functional_tests.Run(hoverctlBinary, "mode", "capture", "--headers", "Content-Type,User-Agent")
 
-				Expect(output).To(ContainSubstring("Hoverfly has been set to capture mode and will capture Content-Type,User-Agent request headers"))
+				Expect(output).To(ContainSubstring("Hoverfly has been set to capture mode and will capture the following request headers: [Content-Type User-Agent]"))
 
 				output = functional_tests.Run(hoverctlBinary, "mode")
 

--- a/functional-tests/hoverctl/hoverfly_modes_test.go
+++ b/functional-tests/hoverctl/hoverfly_modes_test.go
@@ -84,6 +84,45 @@ var _ = Describe("When I use hoverfly-cli", func() {
 				Expect(hoverfly.GetMode()).To(Equal(capture))
 			})
 
+			It("to capture mode and capture all request headers", func() {
+				output := functional_tests.Run(hoverctlBinary, "mode", "capture", "--all-headers")
+
+				Expect(output).To(ContainSubstring("Hoverfly has been set to capture mode and will capture all request headers"))
+
+				output = functional_tests.Run(hoverctlBinary, "mode")
+
+				Expect(output).To(ContainSubstring("Hoverfly is currently set to capture mode"))
+				Expect(hoverfly.GetMode()).To(Equal(capture))
+			})
+
+			It("to capture mode and capture one request header", func() {
+				output := functional_tests.Run(hoverctlBinary, "mode", "capture", "--headers", "Content-Type")
+
+				Expect(output).To(ContainSubstring("Hoverfly has been set to capture mode and will capture Content-Type request header"))
+
+				output = functional_tests.Run(hoverctlBinary, "mode")
+
+				Expect(output).To(ContainSubstring("Hoverfly is currently set to capture mode"))
+				Expect(hoverfly.GetMode()).To(Equal(capture))
+			})
+
+			It("to capture mode and capture two request headers", func() {
+				output := functional_tests.Run(hoverctlBinary, "mode", "capture", "--headers", "Content-Type,User-Agent")
+
+				Expect(output).To(ContainSubstring("Hoverfly has been set to capture mode and will capture Content-Type,User-Agent request headers"))
+
+				output = functional_tests.Run(hoverctlBinary, "mode")
+
+				Expect(output).To(ContainSubstring("Hoverfly is currently set to capture mode"))
+				Expect(hoverfly.GetMode()).To(Equal(capture))
+			})
+
+			It("to capture mode and error if one of the headers is an asterisk", func() {
+				output := functional_tests.Run(hoverctlBinary, "mode", "capture", "--headers", "Content-Type,*")
+
+				Expect(output).To(ContainSubstring("Must provide a list containing only an asterix, or a list containing only headers names"))
+			})
+
 			It("to synthesize mode", func() {
 				output := functional_tests.Run(hoverctlBinary, "mode", "synthesize")
 

--- a/hoverctl/cmd/mode.go
+++ b/hoverctl/cmd/mode.go
@@ -39,13 +39,10 @@ mode is shown.
 
 				headersMessage = "and will capture all request headers"
 			} else if len(specficHeaders) > 0 {
-				modeView.Arguments.Headers = append(modeView.Arguments.Headers, strings.Split(specficHeaders, ",")...)
+				splitHeaders := strings.Split(specficHeaders, ",")
+				modeView.Arguments.Headers = append(modeView.Arguments.Headers, splitHeaders...)
 
-				if strings.Contains(specficHeaders, ",") {
-					headersMessage = "and will capture " + specficHeaders + " request headers"
-				} else {
-					headersMessage = "and will capture " + specficHeaders + " request header"
-				}
+				headersMessage = fmt.Sprintln("and will capture the following request headers:", splitHeaders)
 			}
 
 			mode, err := hoverfly.SetModeWithArguments(modeView)
@@ -59,7 +56,7 @@ mode is shown.
 func init() {
 	RootCmd.AddCommand(modeCmd)
 	modeCmd.PersistentFlags().StringVar(&specficHeaders, "headers", "",
-		"?")
+		"A comma separated list of headers to record in capture mode `Content-Type,Authorization`")
 	modeCmd.PersistentFlags().BoolVar(&allHeaders, "all-headers", false,
-		"?")
+		"Record all headers in capture mode")
 }

--- a/hoverctl/wrapper/hoverfly.go
+++ b/hoverctl/wrapper/hoverfly.go
@@ -133,10 +133,7 @@ func (h *Hoverfly) SetModeWithArguments(modeView v2.ModeView) (string, error) {
 	}
 
 	if response.StatusCode == http.StatusBadRequest {
-		responseBody, _ := util.GetResponseBody(response)
-		var errorView handlers.ErrorView
-		json.Unmarshal([]byte(responseBody), &errorView)
-		return "", errors.New(errorView.Error)
+		return "", h.handlerError(response)
 	}
 
 	apiResponse := h.createAPIStateResponse(response)
@@ -522,4 +519,19 @@ func (h Hoverfly) doRequest(method, url, body string) (*http.Response, error) {
 	}
 
 	return response, nil
+}
+
+func (h Hoverfly) handlerError(response *http.Response) error {
+	responseBody, err := util.GetResponseBody(response)
+	if err != nil {
+		return errors.New("Error when communicating with Hoverfly")
+	}
+
+	var errorView handlers.ErrorView
+	err = json.Unmarshal([]byte(responseBody), &errorView)
+	if err != nil {
+		return errors.New("Error when communicating with Hoverfly")
+	}
+
+	return errors.New(errorView.Error)
 }


### PR DESCRIPTION
When using capture mode, capturing headers is now disabled by default. If you need to record headers you should either do
```
hoverctl mode capture --all-headers
```
or
```
hoverctl mode capture --headers "Content-Type,User-Agent"
```