### PR TITLE
hoverctl will now only print the first 5 lines of middleware scripts …

### DIFF
--- a/functional-tests/hoverctl/hoverfly_middleware_test.go
+++ b/functional-tests/hoverctl/hoverfly_middleware_test.go
@@ -41,13 +41,25 @@ var _ = Describe("When I use hoverctl", func() {
 				"\n# encoding: utf-8" +
 				"\nwhile payload = STDIN.gets" +
 				"\nnext unless payload" +
-
-				"\n\nSTDOUT.puts payload" +
-				"\nend"))
+				"\n" +
+				"\n..."))
 		})
 
 		It("I can set the hoverfly's middleware with a binary and a script", func() {
 			output := functional_tests.Run(hoverctlBinary, "middleware", "--binary", "python", "--script", "testdata/add_random_delay.py")
+
+			Expect(output).To(ContainSubstring("Hoverfly middleware configuration has been set to"))
+			Expect(output).To(ContainSubstring("Binary: python"))
+			Expect(output).To(ContainSubstring("Script: #!/usr/bin/env python" +
+				"\nimport sys" +
+				"\nimport logging" +
+				"\nimport random" +
+				"\nfrom time import sleep" +
+				"\n..."))
+		})
+
+		It("prints the full script when in verbose", func() {
+			output := functional_tests.Run(hoverctlBinary, "middleware", "-v", "--binary", "python", "--script", "testdata/add_random_delay.py")
 
 			Expect(output).To(ContainSubstring("Hoverfly middleware configuration has been set to"))
 			Expect(output).To(ContainSubstring("Binary: python"))

--- a/hoverctl/cmd/middleware.go
+++ b/hoverctl/cmd/middleware.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	"github.com/SpectoLabs/hoverfly/hoverctl/wrapper"
@@ -54,7 +55,16 @@ configuration will be shown.
 		}
 
 		if middleware.Script != "" {
-			fmt.Println("Script: " + middleware.Script)
+			middlewareScript := strings.Split(middleware.Script, "\n")
+			if verbose || len(middlewareScript) < 5 {
+				fmt.Println("Script: " + middleware.Script)
+			}
+			fmt.Println("Script: " + middlewareScript[0] + "\n" +
+				middlewareScript[1] + "\n" +
+				middlewareScript[2] + "\n" +
+				middlewareScript[3] + "\n" +
+				middlewareScript[4] + "\n" +
+				"...")
 		}
 
 		if middleware.Remote != "" {


### PR DESCRIPTION
…unless in verbose