### PR TITLE
The first steps in adding the target to hoverctl

### DIFF
--- a/functional-tests/hoverctl/targets_test.go
+++ b/functional-tests/hoverctl/targets_test.go
@@ -1,0 +1,74 @@
+package hoverctl_suite
+
+import (
+	"github.com/SpectoLabs/hoverfly/functional-tests"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("When using the `targets` command", func() {
+
+	Context("viewing targets", func() {
+		Context("with no targets", func() {
+
+			It("should fail nicely", func() {
+				output := functional_tests.Run(hoverctlBinary, "targets")
+
+				Expect(output).To(ContainSubstring("No targets registered"))
+			})
+		})
+
+		Context("with targets", func() {
+
+			BeforeEach(func() {
+				functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", "1234")
+			})
+
+			It("print targets", func() {
+				output := functional_tests.Run(hoverctlBinary, "targets")
+
+				Expect(output).To(ContainSubstring("TARGET NAME | ADMIN PORT "))
+				Expect(output).To(ContainSubstring("default"))
+				Expect(output).To(ContainSubstring("1234"))
+			})
+		})
+	})
+
+	Context("creating targets", func() {
+
+		It("should create the target and print it", func() {
+			output := functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", "1234")
+
+			Expect(output).To(ContainSubstring("TARGET NAME | ADMIN PORT "))
+			Expect(output).To(ContainSubstring("default"))
+			Expect(output).To(ContainSubstring("1234"))
+		})
+
+		It("should fail nicely if no target name is provided", func() {
+			output := functional_tests.Run(hoverctlBinary, "targets", "create")
+
+			Expect(output).To(ContainSubstring("Cannot create a target without a name"))
+		})
+
+	})
+
+	Context("deleting targets", func() {
+
+		BeforeEach(func() {
+			functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", "1234")
+		})
+
+		It("should delete targets and print nice empty message", func() {
+			output := functional_tests.Run(hoverctlBinary, "targets", "delete", "--target", "default", "--force")
+
+			Expect(output).To(ContainSubstring("No targets registered"))
+		})
+
+		It("should fail nicely if no target name is provided", func() {
+			output := functional_tests.Run(hoverctlBinary, "targets", "delete")
+
+			Expect(output).To(ContainSubstring("Cannot delete a target without a name"))
+		})
+	})
+
+})

--- a/hoverctl/cmd/delete.go
+++ b/hoverctl/cmd/delete.go
@@ -14,10 +14,8 @@ Deletes simulation data from the Hoverfly instance.
 `,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		if !force {
-			if !askForConfirmation("Are you sure you want to delete the current simulation?") {
-				return
-			}
+		if !askForConfirmation("Are you sure you want to delete the current simulation?") {
+			return
 		}
 		err := hoverfly.DeleteSimulations()
 		handleIfError(err)
@@ -28,6 +26,4 @@ Deletes simulation data from the Hoverfly instance.
 
 func init() {
 	RootCmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().BoolVar(&force, "force", false,
-		"Delete the simulation without prompting for confirmation")
 }

--- a/hoverctl/cmd/flush.go
+++ b/hoverctl/cmd/flush.go
@@ -15,10 +15,8 @@ TBC
 	`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		if !force {
-			if !askForConfirmation("Are you sure you want to flush the cache?") {
-				return
-			}
+		if !askForConfirmation("Are you sure you want to flush the cache?") {
+			return
 		}
 
 		err := hoverfly.FlushCache()
@@ -30,6 +28,4 @@ TBC
 
 func init() {
 	RootCmd.AddCommand(flushCmd)
-	flushCmd.Flags().BoolVar(&force, "force", false,
-		"Flush the cache without prompting for confirmation")
 }

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var adminPort, proxyPort, host, certificate, key, database, upstreamProxy string
+var targetName, adminPort, proxyPort, host, certificate, key, database, upstreamProxy string
 var disableTls, verbose bool
 
 var force bool
@@ -22,6 +22,7 @@ var cacheDisable bool
 var hoverfly wrapper.Hoverfly
 var hoverflyDirectory wrapper.HoverflyDirectory
 var config *wrapper.Config
+var target *wrapper.TargetHoverfly
 
 var version string
 
@@ -43,6 +44,8 @@ func Execute(hoverctlVersion string) {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	RootCmd.PersistentFlags().StringVar(&targetName, "target", "default",
+		"A name for an instance of Hoverfly you are trying to communicate with. Overrides the default target (default)")
 	RootCmd.PersistentFlags().StringVar(&adminPort, "admin-port", "",
 		"A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	RootCmd.PersistentFlags().StringVar(&proxyPort, "proxy-port", "",
@@ -64,6 +67,7 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Verbose logging from hoverctl")
 	RootCmd.Flag("verbose").Shorthand = "v"
+	RootCmd.Flag("target").Shorthand = "t"
 }
 
 func initConfig() {
@@ -88,6 +92,11 @@ func initConfig() {
 	config = config.SetDbType(database)
 	config = config.SetUpstreamProxy(upstreamProxy)
 	config = config.DisableCache(cacheDisable)
+
+	target = config.GetTarget(targetName)
+	if verbose && target != nil {
+		fmt.Println("Current target: " + target.Name + "\n")
+	}
 
 	var err error
 	hoverflyDirectory, err = wrapper.NewHoverflyDirectory(*config)

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -44,6 +44,10 @@ func Execute(hoverctlVersion string) {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	RootCmd.PersistentFlags().BoolVar(&force, "force", false,
+		"Bypass any confirmation when using hoverctl")
+	RootCmd.Flag("force").Shorthand = "f"
+
 	RootCmd.PersistentFlags().StringVar(&targetName, "target", "",
 		"A name for an instance of Hoverfly you are trying to communicate with. Overrides the default target (default)")
 	RootCmd.PersistentFlags().StringVar(&adminPort, "admin-port", "",
@@ -121,6 +125,9 @@ func checkArgAndExit(args []string, message, command string) {
 }
 
 func askForConfirmation(message string) bool {
+	if force {
+		return true
+	}
 	reader := bufio.NewReader(os.Stdin)
 
 	for {

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -139,9 +139,12 @@ func askForConfirmation(message string) bool {
 	}
 }
 
-func drawTable(data [][]string) {
+func drawTable(data [][]string, header bool) {
 	table := tablewriter.NewWriter(os.Stdout)
-	// table.SetHeader([]string{"Name", "Sign", "Rating"})
+	if header {
+		table.SetHeader(data[0])
+		data = data[1:]
+	}
 
 	for _, v := range data {
 		table.Append(v)

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -44,7 +44,7 @@ func Execute(hoverctlVersion string) {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	RootCmd.PersistentFlags().StringVar(&targetName, "target", "default",
+	RootCmd.PersistentFlags().StringVar(&targetName, "target", "",
 		"A name for an instance of Hoverfly you are trying to communicate with. Overrides the default target (default)")
 	RootCmd.PersistentFlags().StringVar(&adminPort, "admin-port", "",
 		"A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -41,7 +41,7 @@ port and proxy port.
 			data = append(data, []string{"proxy-port", config.HoverflyProxyPort})
 		}
 
-		drawTable(data)
+		drawTable(data, false)
 
 	},
 }

--- a/hoverctl/cmd/targets.go
+++ b/hoverctl/cmd/targets.go
@@ -41,10 +41,8 @@ Delete target"
 
 	Run: func(cmd *cobra.Command, args []string) {
 		if targetName != "" {
-			if !force {
-				if !askForConfirmation("Are you sure you want to delete the target " + targetName + "?") {
-					return
-				}
+			if !askForConfirmation("Are you sure you want to delete the target " + targetName + "?") {
+				return
 			}
 			config.DeleteTarget(wrapper.TargetHoverfly{
 				Name: targetName,
@@ -89,10 +87,5 @@ func init() {
 	RootCmd.AddCommand(targetsCmd)
 
 	targetsCmd.AddCommand(targetsDeleteCmd)
-	targetsDeleteCmd.Flags().BoolVar(&force, "force", false,
-		"Delete the target without prompting for confirmation")
-
-	targetsDeleteCmd.Flag("force").Shorthand = "f"
-
 	targetsCmd.AddCommand(targetsCreateCmd)
 }

--- a/hoverctl/cmd/targets.go
+++ b/hoverctl/cmd/targets.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/SpectoLabs/hoverfly/hoverctl/wrapper"
+	"github.com/spf13/cobra"
+)
+
+var targetsCmd = &cobra.Command{
+	Use:   "targets",
+	Short: "Get the current targets registered with hoverctl",
+	Long: `
+Get the current targets registered with hoverctl"
+`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(config.Targets) == 0 {
+			handleIfError(errors.New("No targets registered"))
+		}
+
+		data := [][]string{
+			[]string{"Target name", "Admin port"},
+		}
+
+		for key, target := range config.Targets {
+			data = append(data, []string{key, strconv.Itoa(target.AdminPort)})
+		}
+
+		drawTable(data, true)
+	},
+}
+
+var targetsDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete target",
+	Long: `
+Delete target"
+`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		if targetName != "" {
+			if !force {
+				if !askForConfirmation("Are you sure you want to delete the target " + targetName + "?") {
+					return
+				}
+			}
+			config.DeleteTarget(wrapper.TargetHoverfly{
+				Name: targetName,
+			})
+
+			handleIfError(config.WriteToFile(hoverflyDirectory))
+		} else {
+			handleIfError(errors.New("Cannot delete a target without a name"))
+		}
+
+		targetsCmd.Run(cmd, args)
+	},
+}
+
+var targetsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create target",
+	Long: `
+Create target"
+`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		if targetName != "" {
+			adminPort, err := strconv.Atoi(config.HoverflyAdminPort)
+			handleIfError(err)
+			target := wrapper.TargetHoverfly{
+				Name:      targetName,
+				AdminPort: adminPort,
+			}
+			config.NewTarget(target)
+
+			handleIfError(config.WriteToFile(hoverflyDirectory))
+		} else {
+			handleIfError(errors.New("Cannot create a target without a name"))
+		}
+
+		targetsCmd.Run(cmd, args)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(targetsCmd)
+
+	targetsCmd.AddCommand(targetsDeleteCmd)
+	targetsDeleteCmd.Flags().BoolVar(&force, "force", false,
+		"Delete the target without prompting for confirmation")
+
+	targetsDeleteCmd.Flag("force").Shorthand = "f"
+
+	targetsCmd.AddCommand(targetsCreateCmd)
+}

--- a/hoverctl/cmd/version.go
+++ b/hoverctl/cmd/version.go
@@ -28,7 +28,7 @@ Shows the hoverctl version.
 			[]string{"hoverfly", string(hoverflyVersion)},
 		}
 
-		drawTable(data)
+		drawTable(data, false)
 	},
 }
 

--- a/hoverctl/wrapper/config.go
+++ b/hoverctl/wrapper/config.go
@@ -66,6 +66,10 @@ func GetConfig() *Config {
 }
 
 func (this *Config) GetTarget(targetName string) *TargetHoverfly {
+	if targetName == "" {
+		targetName = "default"
+	}
+
 	for key, target := range this.Targets {
 		if key == targetName {
 			return &target

--- a/hoverctl/wrapper/config.go
+++ b/hoverctl/wrapper/config.go
@@ -83,6 +83,18 @@ func (this *Config) NewTarget(target TargetHoverfly) {
 	this.Targets[target.Name] = target
 }
 
+func (this *Config) DeleteTarget(targetToDelete TargetHoverfly) {
+	targets := map[string]TargetHoverfly{}
+
+	for key, target := range this.Targets {
+		if key != targetToDelete.Name {
+			targets[key] = target
+		}
+	}
+
+	this.Targets = targets
+}
+
 func (this *Config) SetHost(host string) *Config {
 	if len(host) > 0 {
 		this.HoverflyHost = host

--- a/hoverctl/wrapper/config.go
+++ b/hoverctl/wrapper/config.go
@@ -12,6 +12,7 @@ import (
 type TargetHoverfly struct {
 	Name      string
 	AdminPort int `yaml:"admin.port"`
+	Pid       int `yaml:"pid"`
 }
 
 type Flags []string
@@ -43,6 +44,7 @@ func GetConfig() *Config {
 		targetHoverfly := TargetHoverfly{
 			Name:      key,
 			AdminPort: target.(map[interface{}]interface{})["admin.port"].(int),
+			Pid:       target.(map[interface{}]interface{})["pid"].(int),
 		}
 
 		targets[key] = targetHoverfly

--- a/hoverctl/wrapper/config_test.go
+++ b/hoverctl/wrapper/config_test.go
@@ -587,3 +587,18 @@ func Test_Config_NewTarget_AddsTarget(t *testing.T) {
 
 	Expect(unit.Targets["default"].AdminPort).To(Equal(1234))
 }
+
+func Test_Config_DeleteTarget_DeletesTarget(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := defaultConfig
+
+	unit.NewTarget(TargetHoverfly{
+		Name:      "default",
+		AdminPort: 1234,
+	})
+
+	Expect(unit.Targets).To(HaveLen(1))
+	unit.DeleteTarget(*unit.GetTarget("default"))
+	Expect(unit.Targets).To(HaveLen(0))
+}

--- a/hoverctl/wrapper/config_test.go
+++ b/hoverctl/wrapper/config_test.go
@@ -551,6 +551,20 @@ func Test_Config_GetTarget_ReturnsTargetIfAlreadyExists(t *testing.T) {
 	Expect(unit.GetTarget("default").AdminPort).To(Equal(1234))
 }
 
+func Test_Config_GetTarget_GetsDefaultIfTargetNameIsEmpty(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := &Config{
+		Targets: map[string]TargetHoverfly{
+			"default": TargetHoverfly{
+				AdminPort: 1234,
+			},
+		},
+	}
+
+	Expect(unit.GetTarget("").AdminPort).To(Equal(1234))
+}
+
 func Test_Config_GetTarget_ReturnsNilIfTargetDoesntExist(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/hoverctl/wrapper/config_test.go
+++ b/hoverctl/wrapper/config_test.go
@@ -22,6 +22,7 @@ var (
 		HoverflyDisableTls:    false,
 		HoverflyUpstreamProxy: "",
 		HoverflyCacheDisable:  false,
+		Targets:               map[string]TargetHoverfly{},
 	}
 )
 
@@ -534,4 +535,41 @@ func Test_Config_BuildFlags_CacheDisableDoesNotBuildCorrectFlagWhenFalse(t *test
 	}
 
 	Expect(unit.BuildFlags()).To(HaveLen(0))
+}
+
+func Test_Config_GetTarget_ReturnsTargetIfAlreadyExists(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := &Config{
+		Targets: map[string]TargetHoverfly{
+			"default": TargetHoverfly{
+				AdminPort: 1234,
+			},
+		},
+	}
+
+	Expect(unit.GetTarget("default").AdminPort).To(Equal(1234))
+}
+
+func Test_Config_GetTarget_ReturnsNilIfTargetDoesntExist(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := defaultConfig
+
+	Expect(unit.GetTarget("default")).To(BeNil())
+}
+
+func Test_Config_NewTarget_AddsTarget(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := defaultConfig
+
+	unit.NewTarget(TargetHoverfly{
+		Name:      "default",
+		AdminPort: 1234,
+	})
+
+	Expect(unit.Targets).To(HaveLen(1))
+
+	Expect(unit.Targets["default"].AdminPort).To(Equal(1234))
 }


### PR DESCRIPTION
This includes a new `targets` command for basic CRUD tasks regarding targets. Useful for testing.

Targets do nothing in this PR except get written to your config file.