### PR TITLE
Updated hoverctl targets command

### DIFF
--- a/functional-tests/hoverctl/config_test.go
+++ b/functional-tests/hoverctl/config_test.go
@@ -17,13 +17,13 @@ var _ = Describe("When I use hoverctl", func() {
 		})
 
 		It("prints the contents of the config.yaml", func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create")
+			functional_tests.Run(hoverctlBinary, "targets", "create", "config-test")
 
 			output := functional_tests.Run(hoverctlBinary, "config")
 
 			Expect(output).To(ContainSubstring(`targets:`))
-			Expect(output).To(ContainSubstring(`default:`))
-			Expect(output).To(ContainSubstring("name: default"))
+			Expect(output).To(ContainSubstring(`config-test:`))
+			Expect(output).To(ContainSubstring("name: config-test"))
 			Expect(output).To(ContainSubstring("host: localhost"))
 			Expect(output).To(ContainSubstring("admin.port: 8888"))
 			Expect(output).To(ContainSubstring("proxy.port: 8500"))

--- a/functional-tests/hoverctl/hoverfly_delete_test.go
+++ b/functional-tests/hoverctl/hoverfly_delete_test.go
@@ -23,7 +23,7 @@ var _ = Describe("When I use hoverctl", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start()
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/hoverfly_destination_test.go
+++ b/functional-tests/hoverctl/hoverfly_destination_test.go
@@ -18,7 +18,7 @@ var _ = Describe("When I use hoverctl", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start()
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/hoverfly_flush_test.go
+++ b/functional-tests/hoverctl/hoverfly_flush_test.go
@@ -20,7 +20,7 @@ var _ = Describe("hoverctl flush cache", func() {
 		hoverfly.ImportSimulation(functional_tests.JsonPayload)
 		hoverfly.Proxy(sling.New().Get("http://destination-server.com"))
 
-		functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", hoverfly.GetAdminPort())
+		functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
 	})
 
 	AfterEach(func() {
@@ -46,7 +46,7 @@ var _ = Describe("hoverctl flush cache", func() {
 	})
 
 	It("should error nicely when there is no hoverfly", func() {
-		functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", "12345")
+		functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", "12345")
 		output := functional_tests.Run(hoverctlBinary, "flush", "--force")
 
 		Expect(output).To(ContainSubstring("Could not connect to Hoverfly"))

--- a/functional-tests/hoverctl/hoverfly_middleware_test.go
+++ b/functional-tests/hoverctl/hoverfly_middleware_test.go
@@ -25,7 +25,7 @@ var _ = Describe("When I use hoverctl", func() {
 			hoverfly.Start()
 			hoverfly.SetMiddleware("ruby", "#!/usr/bin/env ruby\n# encoding: utf-8\nwhile payload = STDIN.gets\nnext unless payload\n\nSTDOUT.puts payload\nend")
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/hoverfly_modes_test.go
+++ b/functional-tests/hoverctl/hoverfly_modes_test.go
@@ -18,7 +18,7 @@ var _ = Describe("When I use hoverfly-cli", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start()
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {
@@ -153,7 +153,7 @@ var _ = Describe("When I use hoverfly-cli", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start("-webserver")
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/import_export_test.go
+++ b/functional-tests/hoverctl/import_export_test.go
@@ -80,7 +80,7 @@ var _ = Describe("When I use hoverctl", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start()
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/login_test.go
+++ b/functional-tests/hoverctl/login_test.go
@@ -23,7 +23,7 @@ var _ = Describe("hoverctl login", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start("-auth", "-username", username, "-password", password)
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {
@@ -99,7 +99,7 @@ var _ = Describe("hoverctl login", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start("-auth", "-username", username, "-password", password)
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "no-auth", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "create", "no-auth", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/logs_test.go
+++ b/functional-tests/hoverctl/logs_test.go
@@ -23,7 +23,7 @@ var _ = Describe("When I use hoverctl", func() {
 	)
 
 	BeforeEach(func() {
-		functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "default", "--admin-port", adminPort, "--proxy-port", proxyPort)
+		functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", adminPort, "--proxy-port", proxyPort)
 	})
 
 	AfterEach(func() {
@@ -42,7 +42,7 @@ var _ = Describe("When I use hoverctl", func() {
 
 		It("should return an error if the logs don't exist", func() {
 			functional_tests.Run(hoverctlBinary, "start", "--admin-port="+adminPort, "--proxy-port="+proxyPort)
-			functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "incorrect", "--admin-port", "12345", "--proxy-port", "65432")
+			functional_tests.Run(hoverctlBinary, "targets", "create", "incorrect", "--admin-port", "12345", "--proxy-port", "65432")
 
 			output := functional_tests.Run(hoverctlBinary, "logs", "-t", "incorrect")
 

--- a/functional-tests/hoverctl/start_test.go
+++ b/functional-tests/hoverctl/start_test.go
@@ -173,8 +173,7 @@ var _ = Describe("hoverctl `start`", func() {
 
 	Context("with a target", func() {
 		It("should start an instance of Hoverfly with the target configuration", func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create",
-				"--target", "test-target",
+			functional_tests.Run(hoverctlBinary, "targets", "create", "test-target",
 				"--admin-port", "1234",
 				"--proxy-port", "8765",
 			)
@@ -191,8 +190,7 @@ var _ = Describe("hoverctl `start`", func() {
 		})
 
 		It("should update the target with a pid", func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create",
-				"--target", "test-target",
+			functional_tests.Run(hoverctlBinary, "targets", "create", "test-target",
 				"--admin-port", "4567",
 				"--proxy-port", "4342",
 			)

--- a/functional-tests/hoverctl/stop_test.go
+++ b/functional-tests/hoverctl/stop_test.go
@@ -16,7 +16,7 @@ var _ = Describe("hoverctl `stop`", func() {
 
 	Context("without a running instance of Hoverfly", func() {
 		BeforeEach(func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "default")
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default")
 		})
 
 		It("should return an error", func() {
@@ -28,7 +28,7 @@ var _ = Describe("hoverctl `stop`", func() {
 
 	Context("with an incorrect pid", func() {
 		BeforeEach(func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "default", "--pid", "432111")
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--pid", "432111")
 		})
 
 		It("should return an error", func() {
@@ -41,7 +41,7 @@ var _ = Describe("hoverctl `stop`", func() {
 	Context("with a running instance of Hoverfly", func() {
 		BeforeEach(func() {
 			hoverfly.Start()
-			functional_tests.Run(hoverctlBinary, "targets", "create", "-t", "default", "--pid", strconv.Itoa(hoverfly.GetPid()))
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--pid", strconv.Itoa(hoverfly.GetPid()))
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/targets_test.go
+++ b/functional-tests/hoverctl/targets_test.go
@@ -21,7 +21,7 @@ var _ = Describe("When using the `targets` command", func() {
 		Context("with targets", func() {
 
 			BeforeEach(func() {
-				functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", "1234", "--proxy-port", "8765", "--host", "localhost")
+				functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", "1234", "--proxy-port", "8765", "--host", "localhost")
 			})
 
 			It("print targets", func() {
@@ -44,7 +44,7 @@ var _ = Describe("When using the `targets` command", func() {
 
 		It("should create the target and print it", func() {
 
-			output := functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "new-target",
+			output := functional_tests.Run(hoverctlBinary, "targets", "create", "new-target",
 				"--pid", "12345",
 				"--host", "localhost",
 				"--admin-port", "1234",
@@ -64,29 +64,21 @@ var _ = Describe("When using the `targets` command", func() {
 			Expect(output).To(ContainSubstring("8765"))
 		})
 
-		It("should create a default if no target name is provided", func() {
+		It("should not create a target if no target name is provided", func() {
 			output := functional_tests.Run(hoverctlBinary, "targets", "create")
 
-			Expect(output).To(ContainSubstring("TARGET NAME"))
-			Expect(output).To(ContainSubstring("PID"))
-			Expect(output).To(ContainSubstring("HOST"))
-			Expect(output).To(ContainSubstring("ADMIN PORT"))
-
-			Expect(output).To(ContainSubstring("default"))
-			Expect(output).To(ContainSubstring("0"))
-			Expect(output).To(ContainSubstring("localhost"))
-			Expect(output).To(ContainSubstring("8888"))
+			Expect(output).To(ContainSubstring("Cannot create a target without a name"))
 		})
 	})
 
 	Context("deleting targets", func() {
 
 		BeforeEach(func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create", "--target", "default", "--admin-port", "1234")
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", "1234")
 		})
 
 		It("should delete targets and print nice empty message", func() {
-			output := functional_tests.Run(hoverctlBinary, "targets", "delete", "--target", "default", "--force")
+			output := functional_tests.Run(hoverctlBinary, "targets", "delete", "default", "--force")
 
 			Expect(output).To(ContainSubstring("No targets registered"))
 		})

--- a/hoverctl/cmd/targets.go
+++ b/hoverctl/cmd/targets.go
@@ -42,33 +42,32 @@ Delete target"
 `,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		if targetNameFlag != "" {
-			if !askForConfirmation("Are you sure you want to delete the target " + targetNameFlag + "?") {
-				return
-			}
-			config.DeleteTarget(wrapper.Target{
-				Name: targetNameFlag,
-			})
+		checkArgAndExit(args, "Cannot delete a target without a name", "targets delete")
 
-			handleIfError(config.WriteToFile(hoverflyDirectory))
-		} else {
-			handleIfError(errors.New("Cannot delete a target without a name"))
+		if !askForConfirmation("Are you sure you want to delete the target " + args[0] + "?") {
+			return
 		}
+		config.DeleteTarget(wrapper.Target{
+			Name: args[0],
+		})
+
+		handleIfError(config.WriteToFile(hoverflyDirectory))
 
 		targetsCmd.Run(cmd, args)
 	},
 }
 
-var targetsCreateCmd = &cobra.Command{
+var targetsNewCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create target",
+	Short: "Create a new target",
 	Long: `
 Create target"
 `,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		checkArgAndExit(args, "Cannot create a target without a name", "targets new")
 
-		newTarget := wrapper.NewTarget(targetNameFlag, hostFlag, adminPortFlag, proxyPortFlag)
+		newTarget := wrapper.NewTarget(args[0], hostFlag, adminPortFlag, proxyPortFlag)
 		newTarget.Pid = pidFlag
 
 		config.NewTarget(*newTarget)
@@ -83,7 +82,7 @@ func init() {
 	RootCmd.AddCommand(targetsCmd)
 
 	targetsCmd.AddCommand(targetsDeleteCmd)
-	targetsCmd.AddCommand(targetsCreateCmd)
+	targetsCmd.AddCommand(targetsNewCmd)
 
-	targetsCreateCmd.Flags().IntVar(&pidFlag, "pid", 0, "Process id for a running instance of Hoverfly")
+	targetsNewCmd.Flags().IntVar(&pidFlag, "pid", 0, "Process id for a running instance of Hoverfly")
 }


### PR DESCRIPTION
`hoverctl targets create` is now `hoverctl targets new`

Both `hoverctl targets new` and `hoverctl targets delete` will now take an argument instead of a flag for targetName.

```
hoverctl targets new new-target --admin-port 1234
```