### PR TITLE
Added --set-default and hoverctl targets default

### DIFF
--- a/functional-tests/hoverctl/set_default_flag_test.go
+++ b/functional-tests/hoverctl/set_default_flag_test.go
@@ -9,8 +9,8 @@ import (
 var _ = Describe("hoverctl --set-default", func() {
 
 	BeforeEach(func() {
-		functional_tests.Run(hoverctlBinary, "targets", "new", "set-default-test1")
-		functional_tests.Run(hoverctlBinary, "targets", "new", "set-default-test2")
+		functional_tests.Run(hoverctlBinary, "targets", "create", "set-default-test1")
+		functional_tests.Run(hoverctlBinary, "targets", "create", "set-default-test2")
 	})
 
 	Context("on a successful command using the --target flag", func() {

--- a/functional-tests/hoverctl/set_default_flag_test.go
+++ b/functional-tests/hoverctl/set_default_flag_test.go
@@ -1,0 +1,51 @@
+package hoverctl_suite
+
+import (
+	"github.com/SpectoLabs/hoverfly/functional-tests"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("hoverctl --set-default", func() {
+
+	BeforeEach(func() {
+		functional_tests.Run(hoverctlBinary, "targets", "new", "set-default-test1")
+		functional_tests.Run(hoverctlBinary, "targets", "new", "set-default-test2")
+	})
+
+	Context("on a successful command using the --target flag", func() {
+		It("should change the default target to the current target", func() {
+			output := functional_tests.Run(hoverctlBinary, "config", "-v",
+				"--target", "set-default-test2",
+				"--set-default")
+
+			Expect(output).To(ContainSubstring("default: default"))
+
+			output = functional_tests.Run(hoverctlBinary, "config", "-v")
+			Expect(output).To(ContainSubstring("default: set-default-test2"))
+		})
+	})
+
+	Context("on a successful command without the --target flag", func() {
+		It("should not change the default target", func() {
+			output := functional_tests.Run(hoverctlBinary, "config", "-v",
+				"--set-default")
+
+			Expect(output).To(ContainSubstring("default: default"))
+
+			output = functional_tests.Run(hoverctlBinary, "config", "-v")
+			Expect(output).To(ContainSubstring("default: default"))
+		})
+	})
+
+	Context("on an unsuccessful command using the --target flag", func() {
+		It("should not change the default target", func() {
+			functional_tests.Run(hoverctlBinary, "mode", "-v",
+				"--target", "set-default-test2",
+				"--set-default")
+
+			output := functional_tests.Run(hoverctlBinary, "config", "-v")
+			Expect(output).To(ContainSubstring("default: default"))
+		})
+	})
+})

--- a/functional-tests/hoverctl/start_test.go
+++ b/functional-tests/hoverctl/start_test.go
@@ -214,6 +214,17 @@ var _ = Describe("hoverctl `start`", func() {
 		})
 	})
 
+	Context("with a target with a remote url", func() {
+		BeforeEach(func() {
+			functional_tests.Run(hoverctlBinary, "targets", "new", "remote", "--host", "hoverfly.io")
+		})
+		It("should error", func() {
+			output := functional_tests.Run(hoverctlBinary, "start", "--target", "remote")
+
+			Expect(output).To(ContainSubstring("Unable to start an instance of Hoverfly with the current target host"))
+		})
+	})
+
 	Context("with --new-target flag", func() {
 
 		It("should create a target using the flags to configure the target", func() {

--- a/functional-tests/hoverctl/start_test.go
+++ b/functional-tests/hoverctl/start_test.go
@@ -221,7 +221,20 @@ var _ = Describe("hoverctl `start`", func() {
 		It("should error", func() {
 			output := functional_tests.Run(hoverctlBinary, "start", "--target", "remote")
 
-			Expect(output).To(ContainSubstring("Unable to start an instance of Hoverfly with the current target host"))
+			Expect(output).To(ContainSubstring("Unable to start an instance of Hoverfly on a remote host (remote host: hoverfly.io)"))
+			Expect(output).To(ContainSubstring("Run `hoverctl start --new-target <name>`"))
+		})
+	})
+
+	Context("with a target with a running hoverfly", func() {
+		BeforeEach(func() {
+			functional_tests.Run(hoverctlBinary, "start", "--new-target", "running")
+		})
+		It("should error", func() {
+			output := functional_tests.Run(hoverctlBinary, "start", "--target", "running")
+
+			Expect(output).To(ContainSubstring("Target Hoverfly is already running"))
+			Expect(output).To(ContainSubstring("Run `hoverctl stop -t running` to stop it"))
 		})
 	})
 

--- a/functional-tests/hoverctl/start_test.go
+++ b/functional-tests/hoverctl/start_test.go
@@ -216,7 +216,7 @@ var _ = Describe("hoverctl `start`", func() {
 
 	Context("with a target with a remote url", func() {
 		BeforeEach(func() {
-			functional_tests.Run(hoverctlBinary, "targets", "new", "remote", "--host", "hoverfly.io")
+			functional_tests.Run(hoverctlBinary, "targets", "create", "remote", "--host", "hoverfly.io")
 		})
 		It("should error", func() {
 			output := functional_tests.Run(hoverctlBinary, "start", "--target", "remote")

--- a/functional-tests/hoverctl/stop_test.go
+++ b/functional-tests/hoverctl/stop_test.go
@@ -72,4 +72,28 @@ var _ = Describe("hoverctl `stop`", func() {
 			Expect(output).To(ContainSubstring("Run `hoverctl targets new test-target`"))
 		})
 	})
+
+	Context("with a target with a remote url", func() {
+		BeforeEach(func() {
+			functional_tests.Run(hoverctlBinary, "targets", "create", "remote", "--host", "hoverfly.io")
+		})
+		It("should error", func() {
+			output := functional_tests.Run(hoverctlBinary, "stop", "--target", "remote")
+
+			Expect(output).To(ContainSubstring("Unable to stop an instance of Hoverfly on a remote host (remote host: hoverfly.io)"))
+			Expect(output).To(ContainSubstring("Run `hoverctl start --new-target <name>`"))
+		})
+	})
+
+	Context("with a target with a running hoverfly", func() {
+		BeforeEach(func() {
+			functional_tests.Run(hoverctlBinary, "targets", "create", "not-running")
+		})
+		It("should error", func() {
+			output := functional_tests.Run(hoverctlBinary, "stop", "--target", "not-running")
+
+			Expect(output).To(ContainSubstring("Target Hoverfly is not running"))
+			Expect(output).To(ContainSubstring("Run `hoverctl start -t not-running` to start it"))
+		})
+	})
 })

--- a/functional-tests/hoverctl/targets_test.go
+++ b/functional-tests/hoverctl/targets_test.go
@@ -90,4 +90,60 @@ var _ = Describe("When using the `targets` command", func() {
 		})
 	})
 
+	Context("targets default", func() {
+
+		BeforeEach(func() {
+			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", "1234")
+		})
+
+		It("should print the default target", func() {
+			output := functional_tests.Run(hoverctlBinary, "targets", "default")
+
+			Expect(output).To(ContainSubstring("TARGET NAME"))
+			Expect(output).To(ContainSubstring("HOST"))
+			Expect(output).To(ContainSubstring("ADMIN PORT"))
+			Expect(output).To(ContainSubstring("PROXY PORT"))
+
+			Expect(output).To(ContainSubstring("default"))
+			Expect(output).To(ContainSubstring("localhost"))
+			Expect(output).To(ContainSubstring("1234"))
+			Expect(output).To(ContainSubstring("8500"))
+		})
+
+		It("should set the default target when given a target name", func() {
+			functional_tests.Run(hoverctlBinary, "targets", "create", "alternative", "--admin-port", "1233")
+			output := functional_tests.Run(hoverctlBinary, "targets", "default", "alternative")
+
+			Expect(output).To(ContainSubstring("TARGET NAME"))
+			Expect(output).To(ContainSubstring("HOST"))
+			Expect(output).To(ContainSubstring("ADMIN PORT"))
+			Expect(output).To(ContainSubstring("PROXY PORT"))
+
+			Expect(output).To(ContainSubstring("alternative"))
+			Expect(output).To(ContainSubstring("localhost"))
+			Expect(output).To(ContainSubstring("1233"))
+			Expect(output).To(ContainSubstring("8500"))
+		})
+
+		It("should error when given an invalid target name", func() {
+			output := functional_tests.Run(hoverctlBinary, "targets", "default", "alternative")
+
+			Expect(output).To(ContainSubstring("alternative is not a target\n\nRun `hoverctl targets new alternative`"))
+		})
+
+		It("should not set default when given an invalid target name ", func() {
+			functional_tests.Run(hoverctlBinary, "targets", "default", "alternative")
+			output := functional_tests.Run(hoverctlBinary, "targets", "default")
+
+			Expect(output).To(ContainSubstring("TARGET NAME"))
+			Expect(output).To(ContainSubstring("HOST"))
+			Expect(output).To(ContainSubstring("ADMIN PORT"))
+			Expect(output).To(ContainSubstring("PROXY PORT"))
+
+			Expect(output).To(ContainSubstring("default"))
+			Expect(output).To(ContainSubstring("localhost"))
+			Expect(output).To(ContainSubstring("1234"))
+			Expect(output).To(ContainSubstring("8500"))
+		})
+	})
 })

--- a/hoverctl/cmd/login.go
+++ b/hoverctl/cmd/login.go
@@ -15,7 +15,12 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Login to Hoverfly",
 	Long: `
-Login to Hoverfly"
+Will authenticate against the /api/token-auth API endpoint 
+target Hoverfly instance using the provided username and 
+password.
+
+The generated authentication token is then stored on the
+target in the hoverctl configuration file.
 	`,
 
 	Run: func(cmd *cobra.Command, args []string) {
@@ -59,7 +64,8 @@ Login to Hoverfly"
 func init() {
 	RootCmd.AddCommand(loginCmd)
 
-	loginCmd.Flags().StringVar(&username, "username", "", "Username to login to Hoverfly")
-	loginCmd.Flags().StringVar(&password, "password", "", "Password to login to Hoverfly")
-	loginCmd.Flags().String("new-target", "", "?")
+	loginCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
+
+	loginCmd.Flags().StringVar(&username, "username", "", "Username to authenticate against Hoverfly with")
+	loginCmd.Flags().StringVar(&password, "password", "", "Password to autenticate against Hoverfly with")
 }

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -17,7 +17,7 @@ import (
 var targetNameFlag, hostFlag string
 var adminPortFlag, proxyPortFlag int
 
-var force, verbose bool
+var force, verbose, setDefaultTargetFlag bool
 
 var hoverflyDirectory wrapper.HoverflyDirectory
 var config *wrapper.Config
@@ -38,6 +38,11 @@ func Execute(hoverctlVersion string) {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
+
+	if setDefaultTargetFlag && targetNameFlag != "" {
+		config.DefaultTarget = targetNameFlag
+	}
+	handleIfError(config.WriteToFile(hoverflyDirectory))
 }
 
 func init() {
@@ -49,6 +54,9 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&targetNameFlag, "target", "",
 		"A name for an instance of Hoverfly you are trying to communicate with. Overrides the default target (default)")
+	RootCmd.PersistentFlags().BoolVar(&setDefaultTargetFlag, "set-default", false,
+		"Sets the current target as the default target for hoverctl")
+
 	RootCmd.PersistentFlags().IntVar(&adminPortFlag, "admin-port", 0,
 		"A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	RootCmd.PersistentFlags().IntVar(&proxyPortFlag, "proxy-port", 0,

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -34,8 +34,8 @@ func Execute(hoverctlVersion string) {
 		os.Exit(-1)
 	}
 
-	if setDefaultTargetFlag && targetNameFlag != "" {
-		config.DefaultTarget = targetNameFlag
+	if setDefaultTargetFlag && target != nil {
+		config.DefaultTarget = target.Name
 	}
 	handleIfError(config.WriteToFile(hoverflyDirectory))
 }

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -1,16 +1,11 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strings"
-
-	"golang.org/x/crypto/ssh/terminal"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/SpectoLabs/hoverfly/hoverctl/wrapper"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -94,81 +89,4 @@ func initConfig() {
 	var err error
 	hoverflyDirectory, err = wrapper.NewHoverflyDirectory(*config)
 	handleIfError(err)
-}
-
-func handleIfError(err error) {
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-}
-
-func checkArgAndExit(args []string, message, command string) {
-	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, message)
-		fmt.Fprintln(os.Stderr, "\nTry hoverctl "+command+" --help for more information")
-		os.Exit(1)
-	}
-}
-
-func checkTargetAndExit(target *wrapper.Target) {
-	if target == nil {
-		handleIfError(fmt.Errorf("%[1]s is not a target\n\nRun `hoverctl targets new %[1]s`", targetNameFlag))
-	}
-}
-
-func askForConfirmation(message string) bool {
-	if force {
-		return true
-	}
-
-	for {
-		response := askForInput(message+" [y/n]", false)
-
-		if response == "y" || response == "yes" {
-			return true
-		} else if response == "n" || response == "no" {
-			return false
-		}
-	}
-}
-
-func askForInput(value string, sensitive bool) string {
-	if force {
-		return ""
-	}
-
-	reader := bufio.NewReader(os.Stdin)
-
-	for {
-		fmt.Printf(value + ": ")
-		if sensitive {
-			responseBytes, err := terminal.ReadPassword(0)
-			handleIfError(err)
-			fmt.Println("")
-
-			return strings.TrimSpace(string(responseBytes))
-		} else {
-			response, err := reader.ReadString('\n')
-			handleIfError(err)
-
-			return strings.TrimSpace(response)
-		}
-	}
-
-	return ""
-}
-
-func drawTable(data [][]string, header bool) {
-	table := tablewriter.NewWriter(os.Stdout)
-	if header {
-		table.SetHeader(data[0])
-		data = data[1:]
-	}
-
-	for _, v := range data {
-		table.Append(v)
-	}
-	fmt.Print("\n")
-	table.Render()
 }

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -24,6 +24,18 @@ port and proxy port.
 	Run: func(cmd *cobra.Command, args []string) {
 		checkTargetAndExit(target)
 
+		if !wrapper.IsLocal(target.Host) {
+			handleIfError(fmt.Errorf("Unable to start an instance of Hoverfly with the current target host"))
+		}
+
+		if target.Pid != 0 {
+			if _, err := wrapper.GetMode(*target); err == nil {
+				handleIfError(fmt.Errorf("Hoverfly is already running"))
+			}
+
+			target.Pid = 0
+		}
+
 		newTargetFlag, _ := cmd.Flags().GetString("new-target")
 
 		if newTargetFlag != "" {

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -25,12 +25,12 @@ hoverctl configuration file.
 		checkTargetAndExit(target)
 
 		if !wrapper.IsLocal(target.Host) {
-			handleIfError(fmt.Errorf("Unable to start an instance of Hoverfly with the current target host"))
+			handleIfError(fmt.Errorf("Unable to start an instance of Hoverfly on a remote host (%s host: %s)\n\nRun `hoverctl start --new-target <name>`", target.Name, target.Host))
 		}
 
 		if target.Pid != 0 {
 			if _, err := wrapper.GetMode(*target); err == nil {
-				handleIfError(fmt.Errorf("Target Hoverfly is already running\n\nRun `hoverctl start --new-target <name>`"))
+				handleIfError(fmt.Errorf("Target Hoverfly is already running (pid: %v) \n\nRun `hoverctl stop -t %s` to stop it", target.Pid, target.Name))
 			}
 
 			target.Pid = 0

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -13,13 +13,13 @@ var startCmd = &cobra.Command{
 	Short: "Start Hoverfly",
 	Long: `
 Starts an instance of Hoverfly using the current hoverctl
-configuration.
+target configuration.
 
-The Hoverfly process ID will be written to a "pid" file in the 
-".hoverfly" directory.
+To start an instance of Hoverfly as a webserver, add the 
+argument "webserver" to the start command.
 
-The "pid" file name is composed of the Hoverfly admin
-port and proxy port.
+The Hoverfly process ID is stored against the target in the
+hoverctl configuration file.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		checkTargetAndExit(target)
@@ -30,7 +30,7 @@ port and proxy port.
 
 		if target.Pid != 0 {
 			if _, err := wrapper.GetMode(*target); err == nil {
-				handleIfError(fmt.Errorf("Hoverfly is already running"))
+				handleIfError(fmt.Errorf("Target Hoverfly is already running\n\nRun `hoverctl start --new-target <name>`"))
 			}
 
 			target.Pid = 0
@@ -101,10 +101,10 @@ port and proxy port.
 
 func init() {
 	RootCmd.AddCommand(startCmd)
-	startCmd.Flags().String("new-target", "", "?")
+	startCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
 
 	startCmd.Flags().String("cache", "", "A path to a persisted Hoverfly cache. If the cache doesn't exist, Hoverfly will create it")
-	startCmd.Flags().Bool("disable-cache", false, "?")
+	startCmd.Flags().Bool("disable-cache", false, "Disables the request response cache on Hoverfly")
 	startCmd.Flags().String("certificate", "", "A path to a certificate file. Overrides the default Hoverfly certificate")
 	startCmd.Flags().String("key", "", "A path to a key file. Overrides the default Hoverfly TLS key")
 	startCmd.Flags().Bool("disable-tls", false, "Disables TLS verification")

--- a/hoverctl/cmd/stop.go
+++ b/hoverctl/cmd/stop.go
@@ -21,6 +21,14 @@ is stopped.
 	Run: func(cmd *cobra.Command, args []string) {
 		checkTargetAndExit(target)
 
+		if !wrapper.IsLocal(target.Host) {
+			handleIfError(fmt.Errorf("Unable to stop an instance of Hoverfly on a remote host (%s host: %s)\n\nRun `hoverctl start --new-target <name>` to start it", target.Name, target.Host))
+		}
+
+		if target.Pid == 0 {
+			handleIfError(fmt.Errorf("Target Hoverfly is not running\n\nRun `hoverctl start -t %s` to start it", target.Name))
+		}
+
 		err := wrapper.Stop(target, hoverflyDirectory)
 		handleIfError(err)
 

--- a/hoverctl/cmd/utils.go
+++ b/hoverctl/cmd/utils.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/SpectoLabs/hoverfly/hoverctl/wrapper"
+	"github.com/olekukonko/tablewriter"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func handleIfError(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func checkArgAndExit(args []string, message, command string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, message)
+		fmt.Fprintln(os.Stderr, "\nTry hoverctl "+command+" --help for more information")
+		os.Exit(1)
+	}
+}
+
+func checkTargetAndExit(target *wrapper.Target) {
+	if target == nil {
+		handleIfError(fmt.Errorf("%[1]s is not a target\n\nRun `hoverctl targets new %[1]s`", targetNameFlag))
+	}
+}
+
+func askForConfirmation(message string) bool {
+	if force {
+		return true
+	}
+
+	for {
+		response := askForInput(message+" [y/n]", false)
+
+		if response == "y" || response == "yes" {
+			return true
+		} else if response == "n" || response == "no" {
+			return false
+		}
+	}
+}
+
+func askForInput(value string, sensitive bool) string {
+	if force {
+		return ""
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Printf(value + ": ")
+		if sensitive {
+			responseBytes, err := terminal.ReadPassword(0)
+			handleIfError(err)
+			fmt.Println("")
+
+			return strings.TrimSpace(string(responseBytes))
+		} else {
+			response, err := reader.ReadString('\n')
+			handleIfError(err)
+
+			return strings.TrimSpace(response)
+		}
+	}
+
+	return ""
+}
+
+func drawTable(data [][]string, header bool) {
+	table := tablewriter.NewWriter(os.Stdout)
+	if header {
+		table.SetHeader(data[0])
+		data = data[1:]
+	}
+
+	for _, v := range data {
+		table.Append(v)
+	}
+	fmt.Print("\n")
+	table.Render()
+}

--- a/hoverctl/wrapper/config.go
+++ b/hoverctl/wrapper/config.go
@@ -12,7 +12,8 @@ import (
 type Flags []string
 
 type Config struct {
-	Targets map[string]Target `yaml:"targets"`
+	DefaultTarget string            `yaml:"default"`
+	Targets       map[string]Target `yaml:"targets"`
 }
 
 func GetConfig() *Config {
@@ -22,13 +23,14 @@ func GetConfig() *Config {
 	}
 
 	return &Config{
-		Targets: getTargetsFromConfig(viper.GetStringMap("targets")),
+		DefaultTarget: viper.GetString("default"),
+		Targets:       getTargetsFromConfig(viper.GetStringMap("targets")),
 	}
 }
 
 func (this *Config) GetTarget(targetName string) *Target {
 	if targetName == "" {
-		targetName = "default"
+		targetName = this.DefaultTarget
 	}
 
 	for key, target := range this.Targets {
@@ -86,5 +88,6 @@ func SetConfigurationPaths() {
 }
 
 func SetConfigurationDefaults() {
+	viper.SetDefault("default", "default")
 	viper.SetDefault("targets", map[string]Target{})
 }

--- a/hoverctl/wrapper/config_test.go
+++ b/hoverctl/wrapper/config_test.go
@@ -10,7 +10,8 @@ import (
 
 var (
 	defaultConfig = Config{
-		Targets: map[string]Target{},
+		DefaultTarget: "default",
+		Targets:       map[string]Target{},
 	}
 )
 
@@ -69,10 +70,11 @@ func Test_Config_GetTarget_ReturnsTargetIfAlreadyExists(t *testing.T) {
 	Expect(unit.GetTarget("default").AdminPort).To(Equal(1234))
 }
 
-func Test_Config_GetTarget_GetsDefaultIfTargetNameIsEmpty(t *testing.T) {
+func Test_Config_GetTarget_GetsCurrentTargetIfTargetNameIsEmpty(t *testing.T) {
 	RegisterTestingT(t)
 
 	unit := &Config{
+		DefaultTarget: "default",
 		Targets: map[string]Target{
 			"default": Target{
 				AdminPort: 1234,

--- a/hoverctl/wrapper/hoverfly.go
+++ b/hoverctl/wrapper/hoverfly.go
@@ -403,14 +403,6 @@ func Start(target *Target, hoverflyDirectory HoverflyDirectory) error {
 }
 
 func Stop(target *Target, hoverflyDirectory HoverflyDirectory) error {
-	if !IsLocal(target.Host) {
-		return errors.New("hoverctl can not stop an instance of Hoverfly on a remote host")
-	}
-
-	if target.Pid == 0 {
-		return errors.New("Hoverfly is not running")
-	}
-
 	hoverflyProcess := os.Process{Pid: target.Pid}
 	err := hoverflyProcess.Kill()
 	if err != nil {

--- a/hoverctl/wrapper/hoverfly.go
+++ b/hoverctl/wrapper/hoverfly.go
@@ -320,7 +320,7 @@ func buildURL(target Target, endpoint string) string {
 	return fmt.Sprintf("http://%v:%v%v", target.Host, target.AdminPort, endpoint)
 }
 
-func isLocal(url string) bool {
+func IsLocal(url string) bool {
 	return url == "localhost" || url == "127.0.0.1"
 }
 
@@ -353,19 +353,6 @@ func runBinary(target *Target, path string, hoverflyDirectory HoverflyDirectory)
 }
 
 func Start(target *Target, hoverflyDirectory HoverflyDirectory) error {
-
-	if !isLocal(target.Host) {
-		return errors.New("hoverctl can not start an instance of Hoverfly on a remote host")
-	}
-
-	if target.Pid != 0 {
-		_, err := GetMode(*target)
-		if err == nil {
-			return errors.New("Hoverfly is already running")
-		}
-		target.Pid = 0
-	}
-
 	err := checkPorts(target.AdminPort, target.ProxyPort)
 	if err != nil {
 		return err
@@ -416,7 +403,7 @@ func Start(target *Target, hoverflyDirectory HoverflyDirectory) error {
 }
 
 func Stop(target *Target, hoverflyDirectory HoverflyDirectory) error {
-	if !isLocal(target.Host) {
+	if !IsLocal(target.Host) {
 		return errors.New("hoverctl can not stop an instance of Hoverfly on a remote host")
 	}
 

--- a/hoverctl/wrapper/hoverfly_test.go
+++ b/hoverctl/wrapper/hoverfly_test.go
@@ -9,17 +9,17 @@ import (
 func Test_isLocal_WhenLocalhost(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(isLocal("localhost")).To(BeTrue())
+	Expect(IsLocal("localhost")).To(BeTrue())
 }
 
 func Test_isLocal_WhenLocalhostIP(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(isLocal("127.0.0.1")).To(BeTrue())
+	Expect(IsLocal("127.0.0.1")).To(BeTrue())
 }
 
 func Test_isLocal_WhenAnotherDNS(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(isLocal("specto.io")).To(BeFalse())
+	Expect(IsLocal("specto.io")).To(BeFalse())
 }


### PR DESCRIPTION
Also moved start and stop errors up into start and stop commands out of wrapper.Start() and wrapper.Stop().

Also moved some util functions out of root.go and into utils.go