### PR TITLE
Tested and fixed bug where panic would happen

### DIFF
--- a/functional-tests/hoverctl/targets_test.go
+++ b/functional-tests/hoverctl/targets_test.go
@@ -171,6 +171,14 @@ var _ = Describe("When using the `targets` command", func() {
 			Expect(output).To(ContainSubstring("8500"))
 		})
 
+		It("should error when the default points to a non-existing  targets", func() {
+			functional_tests.Run(hoverctlBinary, "targets", "delete", "default", "--force")
+
+			output := functional_tests.Run(hoverctlBinary, "targets", "default")
+
+			Expect(output).To(ContainSubstring("No targets registered"))
+		})
+
 		It("should error when given an invalid target name", func() {
 			output := functional_tests.Run(hoverctlBinary, "targets", "default", "alternative")
 

--- a/hoverctl/cmd/targets.go
+++ b/hoverctl/cmd/targets.go
@@ -117,7 +117,7 @@ of the current default target."
 `,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(config.Targets) == 0 {
+		if config.GetTarget("") == nil {
 			handleIfError(errors.New("No targets registered"))
 		}
 


### PR DESCRIPTION
This was when trying to view the default target but the default target wasn't in the list of targets.