### PR TITLE
Added flags for HTTPS only mode

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -94,12 +94,12 @@
 		{
 			"ImportPath": "github.com/SpectoLabs/goproxy",
 			"Comment": "v1.0-96-g6016d23",
-			"Rev": "d66a182adfd8a2d79e0bc36b9ca60fc7dd154e99"
+			"Rev": "b97fa8e29d6fa3c2c6f3625c0d92359b353794c4"
 		},
 		{
 			"ImportPath": "github.com/SpectoLabs/goproxy/ext/auth",
 			"Comment": "v1.0-97-gd66a182",
-			"Rev": "d66a182adfd8a2d79e0bc36b9ca60fc7dd154e99"
+			"Rev": "b97fa8e29d6fa3c2c6f3625c0d92359b353794c4"
 		},
 		{
 			"ImportPath": "github.com/antonholmquist/jason",

--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -86,6 +86,7 @@ var (
 	tlsVerification = flag.Bool("tls-verification", true, "turn on/off tls verification for outgoing requests (will not try to verify certificates) - defaults to true")
 
 	upstreamProxy = flag.String("upstream-proxy", "", "specify an upstream proxy for hoverfly to route traffic through")
+	httpsOnly     = flag.Bool("https-only", false, "allow only secure secure requests to be proxied by hoverfly")
 
 	databasePath = flag.String("db-path", "", "database location - supply it to provide specific database location (will be created there if it doesn't exist)")
 	database     = flag.String("db", inmemoryBackend, "Persistance storage to use - 'boltdb' or 'memory' which will not write anything to disk")
@@ -212,6 +213,8 @@ func main() {
 	if *upstreamProxy != "" {
 		cfg.SetUpstreamProxy(*upstreamProxy)
 	}
+
+	cfg.HttpsOnly = *httpsOnly
 
 	// development settings
 	cfg.Development = *dev

--- a/core/proxy.go
+++ b/core/proxy.go
@@ -21,6 +21,11 @@ func NewProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 	// creating proxy
 	proxy := goproxy.NewProxyHttpServer()
 
+	if hoverfly.Cfg.HttpsOnly {
+		log.Info("Disabling HTTP")
+		proxy.DisableNonTls(true)
+	}
+
 	if hoverfly.Cfg.AuthEnabled {
 		auth.ProxyBasic(proxy, "hoverfly", func(user, password string) bool {
 

--- a/core/settings.go
+++ b/core/settings.go
@@ -33,6 +33,8 @@ type Configuration struct {
 	JWTExpirationDelta int
 	AuthEnabled        bool
 
+	HttpsOnly bool
+
 	ProxyControlWG sync.WaitGroup
 
 	mu sync.Mutex

--- a/functional-tests/core/ft_https_only_test.go
+++ b/functional-tests/core/ft_https_only_test.go
@@ -1,0 +1,70 @@
+package hoverfly_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/SpectoLabs/hoverfly/functional-tests"
+	"github.com/dghubble/sling"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("When I run Hoverfly", func() {
+
+	var (
+		hoverfly *functional_tests.Hoverfly
+	)
+
+	BeforeEach(func() {
+		hoverfly = functional_tests.NewHoverfly()
+	})
+
+	AfterEach(func() {
+		hoverfly.Stop()
+	})
+
+	Context("and specify https-only on startup", func() {
+
+		BeforeEach(func() {
+			hoverfly.Start("-https-only")
+			hoverfly.SetMode("capture")
+		})
+
+		It("should error with http requests", func() {
+
+			fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.Header().Set("Date", "date")
+				w.Write([]byte("Hello world"))
+			}))
+
+			defer fakeServer.Close()
+
+			resp := hoverfly.Proxy(sling.New().Get(fakeServer.URL))
+			Expect(resp.StatusCode).To(Equal(502))
+
+			responseBody, _ := ioutil.ReadAll(resp.Body)
+			Expect(string(responseBody)).To(ContainSubstring("This proxy requires TLS (HTTPS)"))
+		})
+
+		It("should not error with https requests", func() {
+
+			fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.Header().Set("Date", "date")
+				w.Write([]byte("Hello world"))
+			}))
+
+			fakeServer.StartTLS()
+			defer fakeServer.Close()
+
+			resp := hoverfly.Proxy(sling.New().Get(fakeServer.URL))
+			Expect(resp.StatusCode).To(Equal(200))
+
+			responseBody, _ := ioutil.ReadAll(resp.Body)
+			Expect(string(responseBody)).To(ContainSubstring("Hello world"))
+		})
+	})
+})

--- a/functional-tests/hoverctl/start_test.go
+++ b/functional-tests/hoverctl/start_test.go
@@ -154,6 +154,15 @@ var _ = Describe("hoverctl `start`", func() {
 			Expect(ioutil.ReadAll(response.Body)).To(ContainSubstring(`"upstream-proxy":"http://hoverfly.io:8080"`))
 		})
 
+		It("should start an instance of hoverfly with HTTPS only", func() {
+			output := functional_tests.Run(hoverctlBinary, "start", "--https-only")
+
+			Expect(output).To(ContainSubstring("Hoverfly is now running"))
+
+			output = functional_tests.Run(hoverctlBinary, "logs")
+			Expect(output).To(ContainSubstring("Disabling HTTP"))
+		})
+
 		It("should start hoverfly with authentication", func() {
 			output := functional_tests.Run(hoverctlBinary, "start", "--auth", "--username", "benji", "--password", "securepassword")
 

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -62,6 +62,7 @@ hoverctl configuration file.
 		target.DisableTls, _ = cmd.Flags().GetBool("disable-tls")
 
 		target.UpstreamProxyUrl, _ = cmd.Flags().GetString("upstream-proxy")
+		target.HttpsOnly, _ = cmd.Flags().GetBool("https-only")
 
 		if enableAuth, _ := cmd.Flags().GetBool("auth"); enableAuth {
 			username, _ := cmd.Flags().GetString("username")
@@ -112,6 +113,7 @@ func init() {
 	startCmd.Flags().String("key", "", "A path to a key file. Overrides the default Hoverfly TLS key")
 	startCmd.Flags().Bool("disable-tls", false, "Disables TLS verification")
 	startCmd.Flags().String("upstream-proxy", "", "A host for which Hoverfly will proxy its requests to")
+	startCmd.Flags().Bool("https-only", false, "Disables insecure HTTP traffic in Hoverfly")
 
 	startCmd.Flags().Bool("auth", false, "Enable authenticiation on Hoverfly")
 	startCmd.Flags().String("username", "", "Username to authenticate Hoverfly")

--- a/hoverctl/wrapper/target.go
+++ b/hoverctl/wrapper/target.go
@@ -23,6 +23,7 @@ type Target struct {
 	DisableTls      bool   `yaml:",omitempty"`
 
 	UpstreamProxyUrl string `yaml:",omitempty"`
+	HttpsOnly        bool   `yaml:",omitempty"`
 
 	AuthEnabled bool
 	Username    string
@@ -132,6 +133,10 @@ func (this Target) BuildFlags() Flags {
 
 	if this.UpstreamProxyUrl != "" {
 		flags = append(flags, "-upstream-proxy="+this.UpstreamProxyUrl)
+	}
+
+	if this.HttpsOnly {
+		flags = append(flags, "-https-only")
 	}
 
 	if this.AuthEnabled {

--- a/hoverctl/wrapper/target_test.go
+++ b/hoverctl/wrapper/target_test.go
@@ -224,6 +224,17 @@ func Test_Target_BuildFlags_UpstreamProxySetsUpstreamProxyFlag(t *testing.T) {
 	Expect(unit.BuildFlags()[0]).To(Equal("-upstream-proxy=hoverfly.io:8080"))
 }
 
+func Test_Target_BuildFlags_HttpsOnlySetsTheFlag(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := Target{
+		HttpsOnly: true,
+	}
+
+	Expect(unit.BuildFlags()).To(HaveLen(1))
+	Expect(unit.BuildFlags()[0]).To(Equal("-https-only"))
+}
+
 func Test_Target_BuildFlags_IfAuthEnabledThenIncludesUsernameAndPassword(t *testing.T) {
 	RegisterTestingT(t)
 


### PR DESCRIPTION
You can start Hoverfly `-https-only` and it will now only accept HTTPS traffic.

Also updated hoverctl to include the `--https-only` flag to `hoverctl start`.