### PR TITLE
Added Bearer auth to `Proxy-Authorization` header

### DIFF
--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -70,12 +70,13 @@ var (
 	destination = flag.String("destination", ".", "destination URI to catch")
 	webserver   = flag.Bool("webserver", false, "start Hoverfly in webserver mode (simulate mode)")
 
-	addNew          = flag.Bool("add", false, "add new user '-add -username hfadmin -password hfpass'")
-	addUser         = flag.String("username", "", "username for new user")
-	addPassword     = flag.String("password", "", "password for new user")
-	addPasswordHash = flag.String("password-hash", "", "password hash for new user instead of password")
-	isAdmin         = flag.Bool("admin", true, "supply '-admin false' to make this non admin user (defaults to 'true') ")
-	authEnabled     = flag.Bool("auth", false, "enable authentication, currently it is disabled by default")
+	addNew           = flag.Bool("add", false, "add new user '-add -username hfadmin -password hfpass'")
+	addUser          = flag.String("username", "", "username for new user")
+	addPassword      = flag.String("password", "", "password for new user")
+	addPasswordHash  = flag.String("password-hash", "", "password hash for new user instead of password")
+	isAdmin          = flag.Bool("admin", true, "supply '-admin false' to make this non admin user (defaults to 'true') ")
+	authEnabled      = flag.Bool("auth", false, "enable authentication, currently it is disabled by default")
+	disableBasicAuth = flag.Bool("disable-basic-auth", false, "disable Basic authentication, requiring all authentication to use API tokens")
 
 	generateCA = flag.Bool("generate-ca-cert", false, "generate CA certificate and private key for MITM")
 	certName   = flag.String("cert-name", "hoverfly.proxy", "cert name")
@@ -215,6 +216,7 @@ func main() {
 	}
 
 	cfg.HttpsOnly = *httpsOnly
+	cfg.DisableBasicAuth = *disableBasicAuth
 
 	// development settings
 	cfg.Development = *dev

--- a/core/proxy.go
+++ b/core/proxy.go
@@ -21,6 +21,8 @@ import (
 func NewProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 	// creating proxy
 	proxy := goproxy.NewProxyHttpServer()
+	proxy.OnRequest(goproxy.UrlMatches(regexp.MustCompile(hoverfly.Cfg.Destination))).
+		HandleConnect(goproxy.AlwaysMitm)
 
 	if hoverfly.Cfg.HttpsOnly {
 		log.Info("Disabling HTTP")
@@ -42,9 +44,6 @@ func NewProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 			return authentication.IsJwtTokenValid(headerToken, hoverfly.Authentication, hoverfly.Cfg.SecretKey, hoverfly.Cfg.JWTExpirationDelta)
 		})
 	}
-
-	proxy.OnRequest(goproxy.UrlMatches(regexp.MustCompile(hoverfly.Cfg.Destination))).
-		HandleConnect(goproxy.AlwaysMitm)
 
 	// enable curl -p for all hosts on port 80
 	proxy.OnRequest(goproxy.UrlMatches(regexp.MustCompile(hoverfly.Cfg.Destination))).

--- a/core/proxy.go
+++ b/core/proxy.go
@@ -21,6 +21,7 @@ import (
 func NewProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 	// creating proxy
 	proxy := goproxy.NewProxyHttpServer()
+
 	proxy.OnRequest(goproxy.UrlMatches(regexp.MustCompile(hoverfly.Cfg.Destination))).
 		HandleConnect(goproxy.AlwaysMitm)
 
@@ -32,6 +33,10 @@ func NewProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 	if hoverfly.Cfg.AuthEnabled {
 		log.Info("Enabling proxy authentication")
 		proxyBasicAndBearer(proxy, "hoverfly", func(user, password string) bool {
+			if hoverfly.Cfg.DisableBasicAuth {
+				log.Warn("Attempted basic authentication against proxy, basic authentication is currently disabled")
+				return false
+			}
 
 			proxyUser := &backends.User{
 				Username: user,

--- a/core/proxy_test.go
+++ b/core/proxy_test.go
@@ -1,0 +1,73 @@
+package hoverfly
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_authFromHeader_ShouldRemoveProxyAuthorizationHeader(t *testing.T) {
+	RegisterTestingT(t)
+	req, _ := http.NewRequest(http.MethodGet, "localhost:8888", nil)
+	req.Header.Add("Proxy-Authorization", "something")
+
+	authFromHeader(req, nil, nil)
+	Expect(req.Header).ToNot(HaveKey("Proxy-Authorization"))
+}
+
+func Test_authFromHeader_ShouldReturnFalseIfBasicOrBearer(t *testing.T) {
+	RegisterTestingT(t)
+	req, _ := http.NewRequest(http.MethodGet, "localhost:8888", nil)
+	req.Header.Add("Proxy-Authorization", "Something YmVuamloOlBhc3N3b3JkMTIz")
+
+	Expect(authFromHeader(req, nil, nil)).To(BeFalse())
+}
+
+func Test_authFromHeader_Basic_ShouldBase64DecodeUsernameAndPassword(t *testing.T) {
+	RegisterTestingT(t)
+	req, _ := http.NewRequest(http.MethodGet, "localhost:8888", nil)
+	req.Header.Add("Proxy-Authorization", "Basic YmVuamloOlBhc3N3b3JkMTIz")
+
+	var basicUsername, basicPassword string
+
+	Expect(authFromHeader(req, func(username, password string) bool {
+		basicUsername = username
+		basicPassword = password
+		return true
+	}, nil)).To(BeTrue())
+
+	Expect(basicUsername).To(Equal("benjih"))
+	Expect(basicPassword).To(Equal("Password123"))
+}
+
+func Test_authFromHeader_Basic_ShouldReturnFalseIfNotBase64Encoded(t *testing.T) {
+	RegisterTestingT(t)
+	req, _ := http.NewRequest(http.MethodGet, "localhost:8888", nil)
+	req.Header.Add("Proxy-Authorization", "Basic benjih:Password123")
+
+	Expect(authFromHeader(req, nil, nil)).To(BeFalse())
+}
+
+func Test_authFromHeader_Basic_ShouldReturnFalseIfDecodedBasicCredentialsArentFormattedCorrectly(t *testing.T) {
+	RegisterTestingT(t)
+	req, _ := http.NewRequest(http.MethodGet, "localhost:8888", nil)
+	req.Header.Add("Proxy-Authorization", "Basic YmVuamlo")
+
+	Expect(authFromHeader(req, nil, nil)).To(BeFalse())
+}
+
+func Test_authFromHeader_Bearer_ShouldPassJwtTokenOntoFunction(t *testing.T) {
+	RegisterTestingT(t)
+	req, _ := http.NewRequest(http.MethodGet, "localhost:8888", nil)
+	req.Header.Add("Proxy-Authorization", "Bearer gregg.EEewGREQ.GDSG")
+
+	var bearerToken string
+
+	Expect(authFromHeader(req, nil, func(token string) bool {
+		bearerToken = token
+		return true
+	})).To(BeTrue())
+
+	Expect(bearerToken).To(Equal("gregg.EEewGREQ.GDSG"))
+}

--- a/core/settings.go
+++ b/core/settings.go
@@ -32,6 +32,7 @@ type Configuration struct {
 	SecretKey          []byte
 	JWTExpirationDelta int
 	AuthEnabled        bool
+	AuthHeader         bool
 
 	HttpsOnly bool
 

--- a/core/settings.go
+++ b/core/settings.go
@@ -32,7 +32,7 @@ type Configuration struct {
 	SecretKey          []byte
 	JWTExpirationDelta int
 	AuthEnabled        bool
-	AuthHeader         bool
+	DisableBasicAuth   bool
 
 	HttpsOnly bool
 

--- a/functional-tests/core/ft_proxy_auth_test.go
+++ b/functional-tests/core/ft_proxy_auth_test.go
@@ -3,6 +3,8 @@ package hoverfly_test
 import (
 	"net/http"
 
+	"encoding/base64"
+
 	"github.com/SpectoLabs/hoverfly/functional-tests"
 	"github.com/dghubble/sling"
 	. "github.com/onsi/ginkgo"
@@ -32,19 +34,51 @@ var _ = Describe("When I run Hoverfly", func() {
 			hoverfly.Stop()
 		})
 
-		It("should return a 407 when trying to proxy without auth credentials", func() {
-			resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
-			Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+		Context("Using HTTP Proxy authentication config values", func() {
+
+			It("should return a 407 when trying to proxy without auth credentials", func() {
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 407 when trying to proxy with incorrect auth credentials", func() {
+				resp := hoverfly.ProxyWithAuth(sling.New().Get("http://hoverfly.io"), "incorrect", "incorrect")
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 502 (no match in simulate mode) when trying to proxy with auth credentials", func() {
+				resp := hoverfly.ProxyWithAuth(sling.New().Get("http://hoverfly.io"), username, password)
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
 		})
 
-		It("should return a 407 (no match in simulate mode) when trying to proxy with incorrect auth credentials", func() {
-			resp := hoverfly.ProxyWithAuth(sling.New().Get("http://hoverfly.io"), "incorrect", "incorrect")
-			Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
-		})
+		Context("Using the `Proxy-Authorization header`", func() {
 
-		It("should return a 502 (no match in simulate mode) when trying to proxy with auth credentials", func() {
-			resp := hoverfly.ProxyWithAuth(sling.New().Get("http://hoverfly.io"), username, password)
-			Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			It("should return a 502 (no match in simulate mode) when using Basic", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Basic with an incorrect base64 encoded credentials", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":incorect"))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 502 (no match in simulate mode) when using Bearer", func() {
+				token := hoverfly.GetAPIToken(username, password)
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Bearer "+token))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Bearer with an incorrect token", func() {
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Bearer ewGvdww.wRgFhE34.token"))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
 		})
 	})
 
@@ -58,19 +92,51 @@ var _ = Describe("When I run Hoverfly", func() {
 			hoverfly.Stop()
 		})
 
-		It("should return a 407 when trying to proxy without auth credentials", func() {
-			resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
-			Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+		Context("Using HTTP Proxy authentication config values", func() {
+
+			It("should return a 407 when trying to proxy without auth credentials", func() {
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 407 when trying to proxy with incorrect auth credentials", func() {
+				resp := hoverfly.ProxyWithAuth(sling.New().Get("http://hoverfly.io"), "incorrect", "incorrect")
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 502 (no match in simulate mode) when trying to proxy with auth credentials", func() {
+				resp := hoverfly.ProxyWithAuth(sling.New().Get("http://hoverfly.io"), username, password)
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
 		})
 
-		It("should return a 407 (no match in simulate mode) when trying to proxy with incorrect auth credentials", func() {
-			resp := hoverfly.ProxyWithAuth(sling.New().Get("http://hoverfly.io"), "incorrect", "incorrect")
-			Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
-		})
+		Context("Using the `Proxy-Authorization header`", func() {
 
-		It("should return a 502 (no match in simulate mode) when trying to proxy with auth credentials", func() {
-			resp := hoverfly.ProxyWithAuth(sling.New().Get("http://hoverfly.io"), username, password)
-			Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			It("should return a 502 (no match in simulate mode) when using Basic", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Basic with an incorrect base64 encoded credentials", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":incorect"))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 502 (no match in simulate mode) when using Bearer", func() {
+				token := hoverfly.GetAPIToken(username, password)
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Bearer "+token))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Bearer with an incorrect token", func() {
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Bearer ewGvdww.wRgFhE34.token"))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
 		})
 	})
 })

--- a/functional-tests/core/ft_proxy_auth_test.go
+++ b/functional-tests/core/ft_proxy_auth_test.go
@@ -139,4 +139,39 @@ var _ = Describe("When I run Hoverfly", func() {
 			})
 		})
 	})
+
+	Context("with auth turned on and using https", func() {
+
+		BeforeEach(func() {
+			hoverfly.Start("-auth", "-username", username, "-password", password)
+		})
+
+		AfterEach(func() {
+			hoverfly.Stop()
+		})
+
+		// This test fails, if you try to manually execute it using the command below
+		// you will get an error, making me believe this isn't supported
+
+		// curl -proxy benji:password@localhost:8500 https://hoverfly.io
+
+		// It("should return a 502 (no match in simulate mode) when trying to proxy with auth credentials", func() {
+		// 	resp := hoverfly.ProxyWithAuth(sling.New().Get("https://hoverfly.io"), username, password)
+		// 	Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+		// })
+
+		It("should return a 502 (no match in simulate mode) when using Basic Proxy-Authorization", func() {
+			base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+			resp := hoverfly.Proxy(sling.New().Get("https://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
+			Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+		})
+
+		It("should return a 502 (no match in simulate mode) when using Bearer Proxy-Authorization", func() {
+			token := hoverfly.GetAPIToken(username, password)
+
+			resp := hoverfly.Proxy(sling.New().Get("https://hoverfly.io").Add("Proxy-Authorization", "Bearer "+token))
+			Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+		})
+	})
 })

--- a/functional-tests/functional_tests.go
+++ b/functional-tests/functional_tests.go
@@ -182,6 +182,23 @@ func (this Hoverfly) ProxyWithAuth(r *sling.Sling, user, password string) *http.
 	return response
 }
 
+func (this Hoverfly) GetAPIToken(username, password string) string {
+	response := DoRequest(
+		sling.New().Post(this.adminUrl + "/api/token-auth").BodyJSON(map[string]interface{}{
+			"username": username,
+			"password": password,
+		}),
+	)
+
+	body, err := ioutil.ReadAll(response.Body)
+	Expect(err).To(BeNil())
+
+	bodyMap := make(map[string]interface{})
+	err = json.Unmarshal(body, &bodyMap)
+	Expect(err).To(BeNil())
+
+	return bodyMap["token"].(string)
+}
 func (this Hoverfly) GetAdminPort() string {
 	return strconv.Itoa(this.adminPort)
 }


### PR DESCRIPTION
As part of this PR, there three changes

- Reimplemented proxy authentication, allowing both Basic and Bearer type authentication tokens on `Proxy-Authorization` header
- Added the flag `-disable-basic-auth` to hoverfly so it is possible to disable the use of Basic authentication
- Fixed a bug where authentication messed up HTTPS requests due to the ordering of HttpsRequestHandlers in goproxy