### PR TITLE
Added a 10 minute timeout to authentication login when three failed attempts are made

### DIFF
--- a/core/authentication/auth_service_test.go
+++ b/core/authentication/auth_service_test.go
@@ -1,0 +1,65 @@
+package authentication_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/SpectoLabs/hoverfly/core/authentication"
+	. "github.com/onsi/gomega"
+)
+
+var timeLayout = "2006-01-02T15:04:05.000Z"
+
+func Test_HasReachFailedAttemptsLimit_ReturnsFalseIfAttemptsIsBelowOrEqualToLimit(t *testing.T) {
+	RegisterTestingT(t)
+
+	authentication.Attempts.Count = 0
+	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeFalse())
+
+	authentication.Attempts.Count = 1
+	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeFalse())
+
+	authentication.Attempts.Count = 2
+	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeFalse())
+
+	authentication.Attempts.Count = 3
+	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeFalse())
+}
+
+func Test_HasReachFailedAttemptsLimit_ReturnsTrueIfAttemptsIsAboveLimit(t *testing.T) {
+	RegisterTestingT(t)
+
+	authentication.Attempts.Count = 4
+	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeFalse())
+}
+
+func Test_HasReachFailedAttemptsLimit_IncreasesCountIfAttemptsIsAboveLimit_AndLastFailedIsWithinTheTimeoutPeriod(t *testing.T) {
+	RegisterTestingT(t)
+
+	authentication.Attempts.Count = 4
+	authentication.Attempts.LastFailed = time.Now()
+
+	authentication.HasReachedFailedAttemptsLimit(3, "10s")
+
+	Expect(authentication.Attempts.Count).To(Equal(5))
+}
+
+func Test_HasReachFailedAttemptsLimit_ReturnsFalseIfAttemptsIsAboveLimit_ButLastFailedTimeIsAfterTimeoutPeriod(t *testing.T) {
+	RegisterTestingT(t)
+
+	authentication.Attempts.Count = 4
+
+	authentication.Attempts.LastFailed, _ = time.Parse(timeLayout, "2017-04-01T10:45:26.371Z")
+	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeFalse())
+}
+
+func Test_HasReachFailedAttemptsLimit_ResetsCountIfAttemptsIsAboveLimit_ButLastFailedTimeIsAfterTimeoutPeriod(t *testing.T) {
+	RegisterTestingT(t)
+
+	authentication.Attempts.Count = 4
+
+	authentication.Attempts.LastFailed, _ = time.Parse(timeLayout, "2017-04-01T10:45:26.371Z")
+	authentication.HasReachedFailedAttemptsLimit(3, "10s")
+
+	Expect(authentication.Attempts.Count).To(Equal(0))
+}

--- a/core/authentication/auth_service_test.go
+++ b/core/authentication/auth_service_test.go
@@ -26,11 +26,12 @@ func Test_HasReachFailedAttemptsLimit_ReturnsFalseIfAttemptsIsBelowOrEqualToLimi
 	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeFalse())
 }
 
-func Test_HasReachFailedAttemptsLimit_ReturnsTrueIfAttemptsIsAboveLimit(t *testing.T) {
+func Test_HasReachFailedAttemptsLimit_ReturnsTrueIfAttemptsIsAboveLimit_AndLastFailedIsWithinTheTimeoutPeriod(t *testing.T) {
 	RegisterTestingT(t)
 
 	authentication.Attempts.Count = 4
-	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeFalse())
+	authentication.Attempts.LastFailed = time.Now()
+	Expect(authentication.HasReachedFailedAttemptsLimit(3, "10s")).To(BeTrue())
 }
 
 func Test_HasReachFailedAttemptsLimit_IncreasesCountIfAttemptsIsAboveLimit_AndLastFailedIsWithinTheTimeoutPeriod(t *testing.T) {

--- a/functional-tests/core/ft_api_auth_test.go
+++ b/functional-tests/core/ft_api_auth_test.go
@@ -90,4 +90,34 @@ var _ = Describe("When I run Hoverfly with auth", func() {
 			})
 		})
 	})
+
+	Context("Using a password  provided via command line", func() {
+
+		BeforeEach(func() {
+			hoverfly.Start("-auth", "-username", username, "-password", password)
+		})
+
+		AfterEach(func() {
+			hoverfly.Stop()
+		})
+		It("should return a 429 after three incorrect attempts", func() {
+			request := sling.New().Post("http://localhost:" + hoverfly.GetAdminPort() + "/api/token-auth").BodyJSON(backends.User{
+				Username: username,
+				Password: "wfewrrw",
+			})
+
+			response := functional_tests.DoRequest(request)
+			Expect(response.StatusCode).To(Equal(401))
+
+			response = functional_tests.DoRequest(request)
+			Expect(response.StatusCode).To(Equal(401))
+
+			response = functional_tests.DoRequest(request)
+			Expect(response.StatusCode).To(Equal(401))
+
+			response = functional_tests.DoRequest(request)
+			Expect(response.StatusCode).To(Equal(429))
+		})
+
+	})
 })

--- a/functional-tests/hoverctl/login_test.go
+++ b/functional-tests/hoverctl/login_test.go
@@ -39,7 +39,21 @@ var _ = Describe("hoverctl login", func() {
 		It("should not log you with incorrect credentials", func() {
 			output := functional_tests.Run(hoverctlBinary, "login", "--username", "incorrect", "--password", "incorrect")
 
-			Expect(output).To(ContainSubstring("Failed to login to Hoverfly"))
+			Expect(output).To(ContainSubstring("Incorrect username or password"))
+		})
+
+		It("should error after too many failed attempts", func() {
+			output := functional_tests.Run(hoverctlBinary, "login", "--username", "incorrect", "--password", "incorrect")
+			Expect(output).To(ContainSubstring("Incorrect username or password"))
+
+			output = functional_tests.Run(hoverctlBinary, "login", "--username", "incorrect", "--password", "incorrect")
+			Expect(output).To(ContainSubstring("Incorrect username or password"))
+
+			output = functional_tests.Run(hoverctlBinary, "login", "--username", "incorrect", "--password", "incorrect")
+			Expect(output).To(ContainSubstring("Incorrect username or password"))
+
+			output = functional_tests.Run(hoverctlBinary, "login", "--username", "incorrect", "--password", "incorrect")
+			Expect(output).To(ContainSubstring("Too many failed login attempts, please wait 10 minutes"))
 		})
 
 		It("should error nicely if username is missing", func() {
@@ -59,7 +73,7 @@ var _ = Describe("hoverctl login", func() {
 		It("should error nicely if it cannot connect", func() {
 			output := functional_tests.Run(hoverctlBinary, "login", "--username", username, "--password", password)
 
-			Expect(output).To(ContainSubstring("Failed to login to Hoverfly"))
+			Expect(output).To(ContainSubstring("There was an error when logging in"))
 		})
 	})
 

--- a/hoverctl/cmd/login.go
+++ b/hoverctl/cmd/login.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/SpectoLabs/hoverfly/hoverctl/wrapper"
 	"github.com/spf13/cobra"
@@ -55,11 +54,7 @@ target in the hoverctl configuration file.
 
 		token, err := wrapper.Login(*target, username, password)
 		if err != nil {
-			if verbose {
-				fmt.Fprintln(os.Stderr, err.Error())
-			}
-
-			handleIfError(errors.New("Failed to login to Hoverfly"))
+			handleIfError(err)
 		}
 
 		target.AuthToken = token


### PR DESCRIPTION
If a subsequent failed attempt is made, the timeout is reset for another 10 minutes. When a timeout occurs, the user will receive a `429 Too Many Requests`.

Timeout will also occur if someone tries to bruteforce the username and password via a proxy request instead of an API call, though this will return a 401 regardless how many attempts have been made.

Updated Hoverctl to include a nice error message when this error occurs using `hoverctl login`

Hoverfly UI doesn't need to be updated, when the error occurs, an error message saying `Authentication Error: 429 Too Many Requests`