### PR TITLE
Added X-HOVERFLY-AUTHORIZATION header and -disable-standard-proxy-auth flag

### DIFF
--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -75,7 +75,7 @@ var (
 	isAdmin         = flag.Bool("admin", true, "supply '-admin false' to make this non admin user (defaults to 'true') ")
 	authEnabled     = flag.Bool("auth", false, "enable authentication, currently it is disabled by default")
 
-	proxyAuthorizationHeader = flag.String("proxy-auth", "default", "Switch the Proxy-Authorization header from proxy-auth `Proxy-Authorization` to header-auth `X-HOVERFLY-AUTHORIZATION`")
+	proxyAuthorizationHeader = flag.String("proxy-auth", "proxy-auth", "Switch the Proxy-Authorization header from proxy-auth `Proxy-Authorization` to header-auth `X-HOVERFLY-AUTHORIZATION`. Switching to header-auth will auto enable -https-only")
 
 	generateCA = flag.Bool("generate-ca-cert", false, "generate CA certificate and private key for MITM")
 	certName   = flag.String("cert-name", "hoverfly.proxy", "cert name")

--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -68,13 +68,14 @@ var (
 	destination = flag.String("destination", ".", "destination URI to catch")
 	webserver   = flag.Bool("webserver", false, "start Hoverfly in webserver mode (simulate mode)")
 
-	addNew           = flag.Bool("add", false, "add new user '-add -username hfadmin -password hfpass'")
-	addUser          = flag.String("username", "", "username for new user")
-	addPassword      = flag.String("password", "", "password for new user")
-	addPasswordHash  = flag.String("password-hash", "", "password hash for new user instead of password")
-	isAdmin          = flag.Bool("admin", true, "supply '-admin false' to make this non admin user (defaults to 'true') ")
-	authEnabled      = flag.Bool("auth", false, "enable authentication, currently it is disabled by default")
-	disableProxyAuth = flag.Bool("disable-standard-proxy-auth", false, "disables the standard Proxy-Authorization header, only allowing `X-HOVERFLY-AUTHORIZATION`")
+	addNew          = flag.Bool("add", false, "add new user '-add -username hfadmin -password hfpass'")
+	addUser         = flag.String("username", "", "username for new user")
+	addPassword     = flag.String("password", "", "password for new user")
+	addPasswordHash = flag.String("password-hash", "", "password hash for new user instead of password")
+	isAdmin         = flag.Bool("admin", true, "supply '-admin false' to make this non admin user (defaults to 'true') ")
+	authEnabled     = flag.Bool("auth", false, "enable authentication, currently it is disabled by default")
+
+	proxyAuthorizationHeader = flag.String("proxy-auth", "default", "Switch the Proxy-Authorization header from proxy-auth `Proxy-Authorization` to header-auth `X-HOVERFLY-AUTHORIZATION`")
 
 	generateCA = flag.Bool("generate-ca-cert", false, "generate CA certificate and private key for MITM")
 	certName   = flag.String("cert-name", "hoverfly.proxy", "cert name")
@@ -282,7 +283,12 @@ func main() {
 		requestCache = nil
 	}
 
-	cfg.DisableProxyAuthoriation = *disableProxyAuth
+	if *proxyAuthorizationHeader == "header-auth" {
+		log.Warnf("Proxy authentication will use `X-HOVERFLY-AUTHORIZATION` instead of `Proxy-Authorization`")
+		cfg.ProxyAuthorizationHeader = "X-HOVERFLY-AUTHORIZATION"
+		log.Warnf("Setting Hoverfly to only proxy HTTPS requests")
+		cfg.HttpsOnly = true
+	}
 
 	authBackend := backends.NewCacheBasedAuthBackend(tokenCache, userCache)
 

--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -74,7 +74,7 @@ var (
 	addPasswordHash  = flag.String("password-hash", "", "password hash for new user instead of password")
 	isAdmin          = flag.Bool("admin", true, "supply '-admin false' to make this non admin user (defaults to 'true') ")
 	authEnabled      = flag.Bool("auth", false, "enable authentication, currently it is disabled by default")
-	disableBasicAuth = flag.Bool("disable-basic-auth", false, "disable Basic authentication, requiring all authentication to use API tokens")
+	disableProxyAuth = flag.Bool("disable-standard-proxy-auth", false, "disables the standard Proxy-Authorization header, only allowing `X-HOVERFLY-AUTHORIZATION`")
 
 	generateCA = flag.Bool("generate-ca-cert", false, "generate CA certificate and private key for MITM")
 	certName   = flag.String("cert-name", "hoverfly.proxy", "cert name")
@@ -214,7 +214,6 @@ func main() {
 	}
 
 	cfg.HttpsOnly = *httpsOnly
-	cfg.DisableBasicAuth = *disableBasicAuth
 
 	// development settings
 	cfg.Development = *dev
@@ -282,6 +281,8 @@ func main() {
 	if cfg.DisableCache {
 		requestCache = nil
 	}
+
+	cfg.DisableProxyAuthoriation = *disableProxyAuth
 
 	authBackend := backends.NewCacheBasedAuthBackend(tokenCache, userCache)
 

--- a/core/settings.go
+++ b/core/settings.go
@@ -32,7 +32,8 @@ type Configuration struct {
 	SecretKey          []byte
 	JWTExpirationDelta int
 	AuthEnabled        bool
-	DisableBasicAuth   bool
+
+	DisableProxyAuthoriation bool
 
 	HttpsOnly bool
 

--- a/core/settings.go
+++ b/core/settings.go
@@ -33,7 +33,7 @@ type Configuration struct {
 	JWTExpirationDelta int
 	AuthEnabled        bool
 
-	DisableProxyAuthoriation bool
+	ProxyAuthorizationHeader string
 
 	HttpsOnly bool
 
@@ -170,6 +170,8 @@ func InitSettings() *Configuration {
 	} else {
 		appConfig.TLSVerification = true
 	}
+
+	appConfig.ProxyAuthorizationHeader = "Proxy-Authorization"
 
 	return &appConfig
 }

--- a/functional-tests/core/ft_proxy_auth_test.go
+++ b/functional-tests/core/ft_proxy_auth_test.go
@@ -5,6 +5,8 @@ import (
 
 	"encoding/base64"
 
+	"io/ioutil"
+
 	"github.com/SpectoLabs/hoverfly/functional-tests"
 	"github.com/dghubble/sling"
 	. "github.com/onsi/ginkgo"
@@ -279,6 +281,9 @@ var _ = Describe("When I run Hoverfly", func() {
 
 				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
 				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+
+				responseBody, _ := ioutil.ReadAll(resp.Body)
+				Expect(string(responseBody)).To(Equal("407 `Proxy-Authorization` header is disabled, use `X-HOVERFLY-AUTHORIZATION` instead"))
 			})
 
 			It("should return a 407 when using Basic with an incorrect base64 encoded credentials", func() {
@@ -286,6 +291,9 @@ var _ = Describe("When I run Hoverfly", func() {
 
 				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
 				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+
+				responseBody, _ := ioutil.ReadAll(resp.Body)
+				Expect(string(responseBody)).To(Equal("407 `Proxy-Authorization` header is disabled, use `X-HOVERFLY-AUTHORIZATION` instead"))
 			})
 
 			It("should return a 407 (no match in simulate mode) when using Bearer", func() {
@@ -293,11 +301,17 @@ var _ = Describe("When I run Hoverfly", func() {
 
 				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Bearer "+token))
 				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+
+				responseBody, _ := ioutil.ReadAll(resp.Body)
+				Expect(string(responseBody)).To(Equal("407 `Proxy-Authorization` header is disabled, use `X-HOVERFLY-AUTHORIZATION` instead"))
 			})
 
 			It("should return a 407 when using Bearer with an incorrect token", func() {
 				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Bearer ewGvdww.wRgFhE34.token"))
 				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+
+				responseBody, _ := ioutil.ReadAll(resp.Body)
+				Expect(string(responseBody)).To(Equal("407 `Proxy-Authorization` header is disabled, use `X-HOVERFLY-AUTHORIZATION` instead"))
 			})
 		})
 	})

--- a/functional-tests/core/ft_proxy_auth_test.go
+++ b/functional-tests/core/ft_proxy_auth_test.go
@@ -52,7 +52,36 @@ var _ = Describe("When I run Hoverfly", func() {
 			})
 		})
 
-		Context("Using the `Proxy-Authorization header`", func() {
+		Context("Using the `X-HOVERFLY-AUTHORIZATION` header", func() {
+
+			It("should return a 502 (no match in simulate mode) when using Basic", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Basic with an incorrect base64 encoded credentials", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":incorect"))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 502 (no match in simulate mode) when using Bearer", func() {
+				token := hoverfly.GetAPIToken(username, password)
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Bearer "+token))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Bearer with an incorrect token", func() {
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Bearer ewGvdww.wRgFhE34.token"))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+		})
+
+		Context("Using the `Proxy-Authorization` header", func() {
 
 			It("should return a 502 (no match in simulate mode) when using Basic", func() {
 				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
@@ -110,7 +139,36 @@ var _ = Describe("When I run Hoverfly", func() {
 			})
 		})
 
-		Context("Using the `Proxy-Authorization header`", func() {
+		Context("Using the `X-HOVERFLY-AUTHORIZATION` header", func() {
+
+			It("should return a 502 (no match in simulate mode) when using Basic", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Basic with an incorrect base64 encoded credentials", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":incorect"))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 502 (no match in simulate mode) when using Bearer", func() {
+				token := hoverfly.GetAPIToken(username, password)
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Bearer "+token))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Bearer with an incorrect token", func() {
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Bearer ewGvdww.wRgFhE34.token"))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+		})
+
+		Context("Using the `Proxy-Authorization` header", func() {
 
 			It("should return a 502 (no match in simulate mode) when using Basic", func() {
 				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
@@ -175,33 +233,72 @@ var _ = Describe("When I run Hoverfly", func() {
 		})
 	})
 
-	Context("with auth turned on disabled auth basic", func() {
+	Context("with auth turned on and disabled standard proxy authorization", func() {
 
 		BeforeEach(func() {
-			hoverfly.Start("-auth", "-username", username, "-password", password, "-disable-basic-auth")
+			hoverfly.Start("-auth", "-username", username, "-password", password, "-disable-standard-proxy-auth")
 		})
 
 		AfterEach(func() {
 			hoverfly.Stop()
 		})
 
-		It("should return a 502 (no match in simulate mode) when trying to proxy with HTTP client proxy authentication config values", func() {
-			resp := hoverfly.ProxyWithAuth(sling.New().Get("https://hoverfly.io"), username, password)
-			Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+		Context("Using the `X-HOVERFLY-AUTHORIZATION` header", func() {
+
+			It("should return a 502 (no match in simulate mode) when using Basic", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Basic with an incorrect base64 encoded credentials", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":incorect"))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 502 (no match in simulate mode) when using Bearer", func() {
+				token := hoverfly.GetAPIToken(username, password)
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Bearer "+token))
+				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			})
+
+			It("should return a 407 when using Bearer with an incorrect token", func() {
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("X-HOVERFLY-AUTHORIZATION", "Bearer ewGvdww.wRgFhE34.token"))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
 		})
 
-		It("should return a 407 (no match in simulate mode) when using Basic Proxy-Authorization", func() {
-			base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+		Context("Using the `Proxy-Authorization` header", func() {
 
-			resp := hoverfly.Proxy(sling.New().Get("https://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
-			Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
-		})
+			It("should return a 407 (no match in simulate mode) when using Basic", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 
-		It("should return a 502 (no match in simulate mode) when using Bearer Proxy-Authorization", func() {
-			token := hoverfly.GetAPIToken(username, password)
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
 
-			resp := hoverfly.Proxy(sling.New().Get("https://hoverfly.io").Add("Proxy-Authorization", "Bearer "+token))
-			Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+			It("should return a 407 when using Basic with an incorrect base64 encoded credentials", func() {
+				base64Encoded := base64.StdEncoding.EncodeToString([]byte(username + ":incorect"))
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Basic "+base64Encoded))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 407 (no match in simulate mode) when using Bearer", func() {
+				token := hoverfly.GetAPIToken(username, password)
+
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Bearer "+token))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
+
+			It("should return a 407 when using Bearer with an incorrect token", func() {
+				resp := hoverfly.Proxy(sling.New().Get("http://hoverfly.io").Add("Proxy-Authorization", "Bearer ewGvdww.wRgFhE34.token"))
+				Expect(resp.StatusCode).To(Equal(http.StatusProxyAuthRequired))
+			})
 		})
 	})
 })


### PR DESCRIPTION
The disable-basic-auth flag has been removed due to it no longer being a requirement for Hoverfly Cloud.

Instead, we have introduced the new `X-HOVERFLY-AUTHORIZATION` header. The reason for this is it using a custom header ensures it is sent via the HTTPS tunnel when proxying requests to Hoverfly. Along with this change, we have introduced the `-disable-standard-proxy-auth` flag to Hoverfly to allow you to disable the standard `Proxy-Authorization` header, which can be sometimes sent outside of the HTTPS tunnel.