### PR TITLE
Rebuilt UI and ensured it was compressed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,13 @@ build:
 	cd hoverctl && \
 	go build -ldflags "-X main.hoverctlVersion=$(GIT_TAG_NAME)" -o ../target/hoverctl
 
+build-ui:
+	cd core/static/admin && \
+	npm run compile && \
+	npm run deploy
+	cd core && \
+	statik -src=./static/admin/dist
+
 fmt:
 	go fmt $$(go list ./... | grep -v -E 'vendor')
 

--- a/core/static/admin/src/views/StateView/Stats.js
+++ b/core/static/admin/src/views/StateView/Stats.js
@@ -88,7 +88,7 @@ export class StatsComponent extends React.Component<void, Props, void> {
 
   componentWillMount () {
     if ('WebSocket' in window) {
-      if (window.location.protocol === "https:") {
+      if (window.location.protocol === 'https:') {
         this.state.ws = new WebSocket('wss:/' + window.location.host + '/api/statsws')
       } else {
         this.state.ws = new WebSocket('ws:/' + window.location.host + '/api/statsws')


### PR DESCRIPTION
There was an issue with the previous release where the Hoverfly binary was larger than usual. The reason for this was due to packaging the UI without it being compressed. This has been fixed and a new make target has been added to ensure all prerequisite steps are completed.