### PR TITLE
Added text/plain support for Logs API

### DIFF
--- a/core/handlers/v2/logs_handler.go
+++ b/core/handlers/v2/logs_handler.go
@@ -23,6 +23,8 @@ type LogsHandler struct {
 	Hoverfly HoverflyLogs
 }
 
+var DefaultLimit = 500
+
 func (this *LogsHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandler) {
 	mux.Get("/api/v2/logs", negroni.New(
 		negroni.HandlerFunc(am.RequireTokenAuthentication),
@@ -36,11 +38,10 @@ func (this *LogsHandler) Get(w http.ResponseWriter, req *http.Request, next http
 	var logs []*logrus.Entry
 
 	queryParams := req.URL.Query()
-	limitQuery, err := strconv.Atoi(queryParams.Get("limit"))
-	if err != nil {
-		limitQuery = 500
+	limitQuery, _ := strconv.Atoi(queryParams.Get("limit"))
+	if limitQuery == 0 {
+		limitQuery = DefaultLimit
 	}
-
 	logs = this.Hoverfly.GetLogs(limitQuery)
 
 	if strings.Contains(req.Header.Get("Content-Type"), "text/plain") {

--- a/core/handlers/v2/logs_handler_test.go
+++ b/core/handlers/v2/logs_handler_test.go
@@ -5,36 +5,18 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	. "github.com/onsi/gomega"
 )
 
 type HoverflyLogsStub struct{}
 
-func (this HoverflyLogsStub) GetLogsView() LogsView {
-	return LogsView{[]map[string]interface{}{
-		map[string]interface{}{
-			"msg": "test",
-		},
+func (this HoverflyLogsStub) GetLogs(limit int) []*logrus.Entry {
+	return []*logrus.Entry{&logrus.Entry{
+		Message: "a line of logs",
 	}}
-}
-
-func (this HoverflyLogsStub) GetFilteredLogsView(limit int) LogsView {
-	return LogsView{[]map[string]interface{}{
-		map[string]interface{}{
-			"msg": "limited",
-		},
-	}}
-}
-
-func (this HoverflyLogsStub) GetLogs() string {
-	return "a line of logs"
-}
-
-func (this HoverflyLogsStub) GetFilteredLogs(limit int) string {
-	return "filtered logs by " + strconv.Itoa(limit)
 }
 
 func Test_LogsHandler_Get_ReturnsLogsView(t *testing.T) {
@@ -53,7 +35,7 @@ func Test_LogsHandler_Get_ReturnsLogsView(t *testing.T) {
 	logsView, err := unmarshalLogsView(response.Body)
 	Expect(err).To(BeNil())
 
-	Expect(logsView.Logs[0]["msg"]).To(Equal("test"))
+	Expect(logsView.Logs[0]["msg"]).To(Equal("a line of logs"))
 }
 
 func Test_LogsHandler_Get_ReturnsLogsInPlaintext(t *testing.T) {
@@ -72,7 +54,7 @@ func Test_LogsHandler_Get_ReturnsLogsInPlaintext(t *testing.T) {
 
 	logs, _ := ioutil.ReadAll(response.Body)
 
-	Expect(string(logs)).To(Equal("a line of logs"))
+	Expect(string(logs)).To(ContainSubstring("time=\"0001-01-01T00:00:00Z\" level=panic msg=\"a line of logs\""))
 }
 
 func unmarshalLogsView(buffer *bytes.Buffer) (LogsView, error) {

--- a/core/store_logs_hook.go
+++ b/core/store_logs_hook.go
@@ -1,6 +1,8 @@
 package hoverfly
 
 import (
+	"bytes"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 )
@@ -65,4 +67,26 @@ func (hook StoreLogsHook) GetFilteredLogsView(limit int) v2.LogsView {
 	return v2.LogsView{
 		Logs: logs,
 	}
+}
+
+func (hook StoreLogsHook) GetLogs() string {
+	return hook.GetFilteredLogs(500)
+}
+
+func (hook StoreLogsHook) GetFilteredLogs(limit int) string {
+
+	if limit > len(hook.Entries) {
+		limit = len(hook.Entries)
+	}
+
+	var buffer bytes.Buffer
+	for _, entry := range hook.Entries[:limit] {
+		entry.Logger = logrus.New()
+		log, err := entry.String()
+		if err == nil {
+			buffer.WriteString(log)
+		}
+	}
+
+	return buffer.String()
 }

--- a/core/store_logs_hook.go
+++ b/core/store_logs_hook.go
@@ -1,10 +1,7 @@
 package hoverfly
 
 import (
-	"bytes"
-
 	"github.com/Sirupsen/logrus"
-	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 )
 
 type StoreLogsHook struct {
@@ -39,54 +36,10 @@ func (hook StoreLogsHook) GetLogsCount() int {
 	return len(hook.Entries)
 }
 
-func (hook StoreLogsHook) GetLogsView() v2.LogsView {
-	return hook.GetFilteredLogsView(500)
-}
-
-func (hook StoreLogsHook) GetFilteredLogsView(limit int) v2.LogsView {
-
-	if limit > len(hook.Entries) {
-		limit = len(hook.Entries)
+func (hook StoreLogsHook) GetLogs(limit int) []*logrus.Entry {
+	entriesLength := len(hook.Entries)
+	if limit > entriesLength {
+		limit = entriesLength
 	}
-
-	var logs []map[string]interface{}
-	for _, entry := range hook.Entries[:limit] {
-		data := make(map[string]interface{}, len(entry.Data)+3)
-
-		for k, v := range entry.Data {
-			data[k] = v
-		}
-
-		data["time"] = entry.Time.Format(logrus.DefaultTimestampFormat)
-		data["msg"] = entry.Message
-		data["level"] = entry.Level.String()
-
-		logs = append(logs, data)
-	}
-
-	return v2.LogsView{
-		Logs: logs,
-	}
-}
-
-func (hook StoreLogsHook) GetLogs() string {
-	return hook.GetFilteredLogs(500)
-}
-
-func (hook StoreLogsHook) GetFilteredLogs(limit int) string {
-
-	if limit > len(hook.Entries) {
-		limit = len(hook.Entries)
-	}
-
-	var buffer bytes.Buffer
-	for _, entry := range hook.Entries[:limit] {
-		entry.Logger = logrus.New()
-		log, err := entry.String()
-		if err == nil {
-			buffer.WriteString(log)
-		}
-	}
-
-	return buffer.String()
+	return hook.Entries[:limit]
 }

--- a/core/store_logs_hook_test.go
+++ b/core/store_logs_hook_test.go
@@ -48,160 +48,7 @@ func Test_StoreLogsHook_Fire_LogsArePrepended(t *testing.T) {
 	Expect(unit.Entries[1].Message).To(Equal("oldest"))
 }
 
-func Test_StoreLogsHook_GetLogsView_BuildsLogsViewFromEntriesArray(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	unit.Entries = append(unit.Entries, &logrus.Entry{
-		Message: "test entry",
-	})
-
-	logs := unit.GetLogsView()
-
-	Expect(logs.Logs).To(HaveLen(1))
-	Expect(logs.Logs[0]["msg"]).To(Equal("test entry"))
-}
-
-func Test_StoreLogsHook_GetLogsView_LogsContainFields(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	unit.Entries = append(unit.Entries, &logrus.Entry{
-		Message: "test entry",
-		Data: logrus.Fields{
-			"test": "field",
-		},
-	})
-
-	logs := unit.GetLogsView()
-
-	Expect(logs.Logs).To(HaveLen(1))
-	Expect(logs.Logs[0]["test"]).To(Equal("field"))
-}
-
-func Test_StoreLogsHook_GetLogsView_LimitsTo500Logs(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	for i := 0; i <= 501; i++ {
-		unit.Fire(&logrus.Entry{
-			Message: strconv.Itoa(i),
-		})
-	}
-
-	logs := unit.GetLogsView()
-
-	Expect(logs.Logs).To(HaveLen(500))
-	Expect(logs.Logs[0]["msg"]).To(Equal("501"))
-	Expect(logs.Logs[499]["msg"]).To(Equal("2"))
-}
-
-func Test_StoreLogsHook_GetFilteredLogsView_CanSetLimit(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	for i := 0; i <= 3; i++ {
-		unit.Fire(&logrus.Entry{
-			Message: strconv.Itoa(i),
-		})
-	}
-
-	logs := unit.GetFilteredLogsView(2)
-
-	Expect(logs.Logs).To(HaveLen(2))
-	Expect(logs.Logs[0]["msg"]).To(Equal("3"))
-	Expect(logs.Logs[1]["msg"]).To(Equal("2"))
-}
-
-func Test_StoreLogsHook_GetFilteredLogsView_DoesNotErrorWhenLimitIsLargerThanArray(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	for i := 0; i <= 2; i++ {
-		unit.Fire(&logrus.Entry{
-			Message: strconv.Itoa(i),
-		})
-	}
-
-	logs := unit.GetFilteredLogsView(1)
-
-	Expect(logs.Logs).To(HaveLen(1))
-	Expect(logs.Logs[0]["msg"]).To(Equal("2"))
-}
-
-func Test_StoreLogsHook_GetLogs_BuildsStringFromEntriesArray(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	unit.Entries = append(unit.Entries, &logrus.Entry{
-		Message: "test entry",
-	})
-
-	logs := unit.GetLogs()
-
-	Expect(logs).To(ContainSubstring(`time="0001-01-01T00:00:00Z" level=panic msg="test entry"`))
-}
-
-func Test_StoreLogsHook_GetLogs_LogsContainFields(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	unit.Entries = append(unit.Entries, &logrus.Entry{
-		Message: "test entry",
-		Data: logrus.Fields{
-			"test": "field",
-		},
-	})
-
-	logs := unit.GetLogs()
-
-	Expect(logs).To(ContainSubstring(`time="0001-01-01T00:00:00Z" level=panic msg="test entry" test=field `))
-}
-
-func Test_StoreLogsHook_GetLogs_LimitsTo500Logs(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	for i := 0; i <= 501; i++ {
-		unit.Fire(&logrus.Entry{
-			Message: "log-" + strconv.Itoa(i),
-		})
-	}
-
-	logs := unit.GetLogs()
-
-	Expect(logs).To(ContainSubstring("log-501"))
-	Expect(logs).To(ContainSubstring("log-1"))
-	Expect(logs).ToNot(ContainSubstring("logs-0"))
-}
-
-func Test_StoreLogsHook_GetFilteredLogs_CanSetLimit(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewStoreLogsHook()
-
-	for i := 0; i <= 3; i++ {
-		unit.Fire(&logrus.Entry{
-			Message: "log-" + strconv.Itoa(i),
-		})
-	}
-
-	logs := unit.GetFilteredLogs(2)
-
-	Expect(logs).To(ContainSubstring("log-3"))
-	Expect(logs).To(ContainSubstring("log-2"))
-	Expect(logs).ToNot(ContainSubstring("logs-1"))
-}
-
-func Test_StoreLogsHook_GetFilteredLogs_DoesNotErrorWhenLimitIsLargerThanArray(t *testing.T) {
+func Test_StoreLogsHook_NewGetLogs_LimitsLogs(t *testing.T) {
 	RegisterTestingT(t)
 
 	unit := NewStoreLogsHook()
@@ -212,7 +59,22 @@ func Test_StoreLogsHook_GetFilteredLogs_DoesNotErrorWhenLimitIsLargerThanArray(t
 		})
 	}
 
-	logs := unit.GetFilteredLogs(1)
+	logs := unit.GetLogs(2)
+	Expect(logs).To(HaveLen(2))
+	Expect(logs[0].Message).To(Equal("log-2"))
+	Expect(logs[1].Message).To(Equal("log-1"))
+}
 
-	Expect(logs).To(ContainSubstring("log-2"))
+func Test_StoreLogsHook_NewGetLogs_AcceptsALimitThatIsTooLarge(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewStoreLogsHook()
+
+	unit.Fire(&logrus.Entry{
+		Message: "log-0",
+	})
+
+	logs := unit.GetLogs(1000)
+	Expect(logs).To(HaveLen(1))
+	Expect(logs[0].Message).To(Equal("log-0"))
 }

--- a/core/store_logs_hook_test.go
+++ b/core/store_logs_hook_test.go
@@ -133,3 +133,86 @@ func Test_StoreLogsHook_GetFilteredLogsView_DoesNotErrorWhenLimitIsLargerThanArr
 	Expect(logs.Logs).To(HaveLen(1))
 	Expect(logs.Logs[0]["msg"]).To(Equal("2"))
 }
+
+func Test_StoreLogsHook_GetLogs_BuildsStringFromEntriesArray(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewStoreLogsHook()
+
+	unit.Entries = append(unit.Entries, &logrus.Entry{
+		Message: "test entry",
+	})
+
+	logs := unit.GetLogs()
+
+	Expect(logs).To(ContainSubstring(`time="0001-01-01T00:00:00Z" level=panic msg="test entry"`))
+}
+
+func Test_StoreLogsHook_GetLogs_LogsContainFields(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewStoreLogsHook()
+
+	unit.Entries = append(unit.Entries, &logrus.Entry{
+		Message: "test entry",
+		Data: logrus.Fields{
+			"test": "field",
+		},
+	})
+
+	logs := unit.GetLogs()
+
+	Expect(logs).To(ContainSubstring(`time="0001-01-01T00:00:00Z" level=panic msg="test entry" test=field `))
+}
+
+func Test_StoreLogsHook_GetLogs_LimitsTo500Logs(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewStoreLogsHook()
+
+	for i := 0; i <= 501; i++ {
+		unit.Fire(&logrus.Entry{
+			Message: "log-" + strconv.Itoa(i),
+		})
+	}
+
+	logs := unit.GetLogs()
+
+	Expect(logs).To(ContainSubstring("log-501"))
+	Expect(logs).To(ContainSubstring("log-1"))
+	Expect(logs).ToNot(ContainSubstring("logs-0"))
+}
+
+func Test_StoreLogsHook_GetFilteredLogs_CanSetLimit(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewStoreLogsHook()
+
+	for i := 0; i <= 3; i++ {
+		unit.Fire(&logrus.Entry{
+			Message: "log-" + strconv.Itoa(i),
+		})
+	}
+
+	logs := unit.GetFilteredLogs(2)
+
+	Expect(logs).To(ContainSubstring("log-3"))
+	Expect(logs).To(ContainSubstring("log-2"))
+	Expect(logs).ToNot(ContainSubstring("logs-1"))
+}
+
+func Test_StoreLogsHook_GetFilteredLogs_DoesNotErrorWhenLimitIsLargerThanArray(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewStoreLogsHook()
+
+	for i := 0; i <= 2; i++ {
+		unit.Fire(&logrus.Entry{
+			Message: "log-" + strconv.Itoa(i),
+		})
+	}
+
+	logs := unit.GetFilteredLogs(1)
+
+	Expect(logs).To(ContainSubstring("log-2"))
+}

--- a/functional-tests/core/ft_api_v2_logs_test.go
+++ b/functional-tests/core/ft_api_v2_logs_test.go
@@ -66,4 +66,38 @@ var _ = Describe("/api/v2/logs", func() {
 			Expect(logsArray[0].GetString("msg")).Should(Equal("payloads imported"))
 		})
 	})
+
+	Context("GET Content-Type text/plain", func() {
+
+		It("should get logs", func() {
+			req := sling.New().Get("http://localhost:"+hoverfly.GetAdminPort()+"/api/v2/logs").Add("Content-Type", "text/plain")
+			res := functional_tests.DoRequest(req)
+			Expect(res.StatusCode).To(Equal(200))
+			responseBody, err := ioutil.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			Expect(responseBody).To(ContainSubstring(`msg="Proxy prepared..."`))
+			Expect(responseBody).To(ContainSubstring(`Destination=.`))
+			Expect(responseBody).To(ContainSubstring(`Mode=simulate`))
+			Expect(responseBody).To(ContainSubstring(`ProxyPort=` + hoverfly.GetProxyPort()))
+		})
+
+		It("should limit the logs it returns", func() {
+			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/logs?limit=1")
+			res := functional_tests.DoRequest(req)
+			Expect(res.StatusCode).To(Equal(200))
+			responseJson, err := ioutil.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			jsonObject, err := jason.NewObjectFromBytes(responseJson)
+			Expect(err).To(BeNil())
+
+			logsArray, err := jsonObject.GetObjectArray("logs")
+			Expect(err).To(BeNil())
+
+			Expect(len(logsArray)).To(Equal(1))
+
+			Expect(logsArray[0].GetString("msg")).Should(Equal("payloads imported"))
+		})
+	})
 })

--- a/functional-tests/hoverctl/logs_test.go
+++ b/functional-tests/hoverctl/logs_test.go
@@ -63,7 +63,8 @@ var _ = Describe("When I use hoverctl", func() {
 				file, err := ioutil.ReadFile(filePath)
 				Expect(err).To(BeNil())
 
-				Expect(string(file)).To(ContainSubstring("listening on :" + adminPort))
+				Expect(string(file)).To(ContainSubstring("Admin interface is starting..."))
+				Expect(string(file)).To(ContainSubstring("serving proxy"))
 			})
 
 			It("and they get updated when you use hoverfly", func() {


### PR DESCRIPTION
Sending a Content-Type header with `text/plain` will result in plaintext logs