### PR TITLE
Combining all logs to use the same log config

### DIFF
--- a/core/admin.go
+++ b/core/admin.go
@@ -28,13 +28,7 @@ func (this *AdminApi) StartAdminInterface(hoverfly *Hoverfly) {
 	mux := this.getBoneRouter(hoverfly)
 	n := negroni.Classic()
 
-	logLevel := log.ErrorLevel
-
-	if hoverfly.Cfg.Verbose {
-		logLevel = log.DebugLevel
-	}
-
-	n.Use(negronilogrus.NewCustomMiddleware(logLevel, &log.JSONFormatter{}, "admin"))
+	n.Use(negronilogrus.NewMiddlewareFromLogger(log.StandardLogger(), "admin"))
 	n.UseHandler(mux)
 
 	// admin interface starting message

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -58,6 +58,7 @@ func NewHoverfly() *Hoverfly {
 		Authentication: authBackend,
 		Counter:        metrics.NewModeCounter([]string{modes.Simulate, modes.Synthesize, modes.Modify, modes.Capture}),
 		StoreLogsHook:  NewStoreLogsHook(),
+		Cfg:            InitSettings(),
 	}
 
 	hoverfly.version = "v0.11.3"
@@ -72,6 +73,8 @@ func NewHoverfly() *Hoverfly {
 	modeMap[modes.Synthesize] = &modes.SynthesizeMode{Hoverfly: hoverfly}
 
 	hoverfly.modeMap = modeMap
+
+	hoverfly.HTTP = GetDefaultHoverflyHTTPClient(hoverfly.Cfg.TLSVerification, hoverfly.Cfg.UpstreamProxy)
 
 	return hoverfly
 }

--- a/functional-tests/core/ft_api_v2_logs_test.go
+++ b/functional-tests/core/ft_api_v2_logs_test.go
@@ -10,6 +10,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func MakeLogsArray(logsJson []*jason.Object) []string {
+	var logs []string
+	for _, log := range logsJson {
+		logMessage, _ := log.GetString("msg")
+		logs = append(logs, logMessage)
+	}
+
+	return logs
+}
+
 var _ = Describe("/api/v2/logs", func() {
 
 	var (
@@ -45,10 +55,12 @@ var _ = Describe("/api/v2/logs", func() {
 
 			Expect(len(logsArray)).To(BeNumerically(">=", 4))
 
-			Expect(logsArray[0].GetString("msg")).Should(Equal("Proxy prepared..."))
-			Expect(logsArray[1].GetString("msg")).Should(Equal("current proxy configuration"))
-			Expect(logsArray[2].GetString("msg")).Should(Equal("serving proxy"))
-			Expect(logsArray[3].GetString("msg")).Should(Equal("Admin interface is starting..."))
+			logs := MakeLogsArray(logsArray)
+
+			Expect(logs).Should(ContainElement("Proxy prepared..."))
+			Expect(logs).Should(ContainElement("current proxy configuration"))
+			Expect(logs).Should(ContainElement("serving proxy"))
+			Expect(logs).Should(ContainElement("Admin interface is starting..."))
 		})
 
 		It("should limit the logs it returns", func() {

--- a/functional-tests/core/ft_api_v2_logs_test.go
+++ b/functional-tests/core/ft_api_v2_logs_test.go
@@ -43,10 +43,12 @@ var _ = Describe("/api/v2/logs", func() {
 			logsArray, err := jsonObject.GetObjectArray("logs")
 			Expect(err).To(BeNil())
 
-			Expect(len(logsArray)).To(BeNumerically(">=", 5))
+			Expect(len(logsArray)).To(BeNumerically(">=", 4))
 
 			Expect(logsArray[0].GetString("msg")).Should(Equal("Proxy prepared..."))
-			Expect(logsArray[4].GetString("msg")).Should(Equal("payloads imported"))
+			Expect(logsArray[1].GetString("msg")).Should(Equal("current proxy configuration"))
+			Expect(logsArray[2].GetString("msg")).Should(Equal("serving proxy"))
+			Expect(logsArray[3].GetString("msg")).Should(Equal("Admin interface is starting..."))
 		})
 
 		It("should limit the logs it returns", func() {
@@ -64,7 +66,7 @@ var _ = Describe("/api/v2/logs", func() {
 
 			Expect(len(logsArray)).To(Equal(1))
 
-			Expect(logsArray[0].GetString("msg")).Should(Equal("payloads imported"))
+			Expect(logsArray[0].GetString("msg")).Should(Equal("started handling request"))
 		})
 	})
 
@@ -98,7 +100,7 @@ var _ = Describe("/api/v2/logs", func() {
 
 			Expect(len(logsArray)).To(Equal(1))
 
-			Expect(logsArray[0].GetString("msg")).Should(Equal("payloads imported"))
+			Expect(logsArray[0].GetString("msg")).Should(Equal("started handling request"))
 		})
 	})
 })


### PR DESCRIPTION
This pull request tries to make sure that all logs from Hoverfly come from the same logger. The reason for this is that the `/api/v2/logs` endpoint is missing logs.

When starting the Hoverfly binary, several logs are printed before the logger is configured with the StoreLogsHook which enables the `/api/v2/logs` endpoint to work. This has been resolved in `core/cmd/hoverfly/main.go` by starting a new instance of Hoverfly before the first log messages.

The Admin API has always used its own, new logrus logger. This has been switched to use the current Hoverfly logger.

I am aware that `core/cmd/hoverfly/main.go` is overdue a tidy, I will address this in another PR in the future.



