### PR TITLE
When upgrading to v2 simulations from v1

### DIFF
--- a/core/handlers/v2/simulation_views.go
+++ b/core/handlers/v2/simulation_views.go
@@ -105,42 +105,82 @@ func (this SimulationViewV1) Upgrade() SimulationViewV2 {
 		var schemeMatchers, methodMatchers, destinationMatchers, pathMatchers, queryMatchers, bodyMatchers *RequestFieldMatchersView
 		var headers map[string][]string
 
-		if pairV1.Request.RequestType != nil && *pairV1.Request.RequestType != "recording" {
+		isNotRecording := pairV1.Request.RequestType != nil && *pairV1.Request.RequestType != "recording"
+
+		if isNotRecording {
 			headers = pairV1.Request.Headers
 		}
 		if pairV1.Request.Scheme != nil {
-			schemeMatchers = &RequestFieldMatchersView{
-				ExactMatch: pairV1.Request.Scheme,
+
+			if isNotRecording {
+				schemeMatchers = &RequestFieldMatchersView{
+					GlobMatch: pairV1.Request.Scheme,
+				}
+			} else {
+				schemeMatchers = &RequestFieldMatchersView{
+					ExactMatch: pairV1.Request.Scheme,
+				}
 			}
 		}
 
 		if pairV1.Request.Method != nil {
-			methodMatchers = &RequestFieldMatchersView{
-				ExactMatch: pairV1.Request.Method,
+
+			if isNotRecording {
+				methodMatchers = &RequestFieldMatchersView{
+					GlobMatch: pairV1.Request.Method,
+				}
+			} else {
+				methodMatchers = &RequestFieldMatchersView{
+					ExactMatch: pairV1.Request.Method,
+				}
 			}
 		}
 
 		if pairV1.Request.Destination != nil {
-			destinationMatchers = &RequestFieldMatchersView{
-				ExactMatch: pairV1.Request.Destination,
+			if isNotRecording {
+				destinationMatchers = &RequestFieldMatchersView{
+					GlobMatch: pairV1.Request.Destination,
+				}
+			} else {
+				destinationMatchers = &RequestFieldMatchersView{
+					ExactMatch: pairV1.Request.Destination,
+				}
 			}
 		}
 
 		if pairV1.Request.Path != nil {
-			pathMatchers = &RequestFieldMatchersView{
-				ExactMatch: pairV1.Request.Path,
+			if isNotRecording {
+				pathMatchers = &RequestFieldMatchersView{
+					GlobMatch: pairV1.Request.Path,
+				}
+			} else {
+				pathMatchers = &RequestFieldMatchersView{
+					ExactMatch: pairV1.Request.Path,
+				}
 			}
 		}
 
 		if pairV1.Request.Query != nil {
-			queryMatchers = &RequestFieldMatchersView{
-				ExactMatch: pairV1.Request.Query,
+			if isNotRecording {
+				queryMatchers = &RequestFieldMatchersView{
+					GlobMatch: pairV1.Request.Query,
+				}
+			} else {
+				queryMatchers = &RequestFieldMatchersView{
+					ExactMatch: pairV1.Request.Query,
+				}
 			}
 		}
 
 		if pairV1.Request.Body != nil {
-			bodyMatchers = &RequestFieldMatchersView{
-				ExactMatch: pairV1.Request.Body,
+			if isNotRecording {
+				bodyMatchers = &RequestFieldMatchersView{
+					GlobMatch: pairV1.Request.Body,
+				}
+			} else {
+				bodyMatchers = &RequestFieldMatchersView{
+					ExactMatch: pairV1.Request.Body,
+				}
 			}
 		}
 

--- a/core/handlers/v2/simulation_views_test.go
+++ b/core/handlers/v2/simulation_views_test.go
@@ -286,6 +286,65 @@ func Test_SimulationViewV1_Upgrade_ReturnsAV2Simulation(t *testing.T) {
 	Expect(simulationViewV2.TimeExported).To(Equal("today"))
 }
 
+func Test_SimulationViewV1_Upgrade_ReturnsGlobMatchesIfTemplate(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := v2.SimulationViewV1{
+		v2.DataViewV1{
+			RequestResponsePairViewV1: []v2.RequestResponsePairViewV1{
+				v2.RequestResponsePairViewV1{
+					Request: v2.RequestDetailsViewV1{
+						RequestType: util.StringToPointer("template"),
+						Scheme:      util.StringToPointer("http"),
+						Body:        util.StringToPointer("body"),
+						Destination: util.StringToPointer("destination"),
+						Method:      util.StringToPointer("GET"),
+						Path:        util.StringToPointer("/path"),
+						Query:       util.StringToPointer("query=query"),
+					},
+					Response: v2.ResponseDetailsView{
+						Status:      200,
+						Body:        "body",
+						EncodedBody: false,
+						Headers: map[string][]string{
+							"Test": []string{"headers"},
+						},
+					},
+				},
+			},
+		},
+		v2.MetaView{
+			SchemaVersion:   "v1",
+			HoverflyVersion: "test",
+			TimeExported:    "today",
+		},
+	}
+
+	simulationViewV2 := unit.Upgrade()
+
+	Expect(simulationViewV2.RequestResponsePairs).To(HaveLen(1))
+
+	Expect(*simulationViewV2.RequestResponsePairs[0].Request.Scheme).To(Equal(v2.RequestFieldMatchersView{
+		GlobMatch: util.StringToPointer("http"),
+	}))
+	Expect(*simulationViewV2.RequestResponsePairs[0].Request.Body).To(Equal(v2.RequestFieldMatchersView{
+		GlobMatch: util.StringToPointer("body"),
+	}))
+	Expect(*simulationViewV2.RequestResponsePairs[0].Request.Destination).To(Equal(v2.RequestFieldMatchersView{
+		GlobMatch: util.StringToPointer("destination"),
+	}))
+	Expect(*simulationViewV2.RequestResponsePairs[0].Request.Method).To(Equal(v2.RequestFieldMatchersView{
+		GlobMatch: util.StringToPointer("GET"),
+	}))
+	Expect(*simulationViewV2.RequestResponsePairs[0].Request.Path).To(Equal(v2.RequestFieldMatchersView{
+		GlobMatch: util.StringToPointer("/path"),
+	}))
+	Expect(*simulationViewV2.RequestResponsePairs[0].Request.Query).To(Equal(v2.RequestFieldMatchersView{
+		GlobMatch: util.StringToPointer("query=query"),
+	}))
+	Expect(simulationViewV2.RequestResponsePairs[0].Request.Headers).To(BeEmpty())
+}
+
 func Test_SimulationViewV1_Upgrade_CanReturnAnIncompleteRequest(t *testing.T) {
 	RegisterTestingT(t)
 


### PR DESCRIPTION
...templates will use glob matching instead of exact matching