### PR TITLE
Introduced local target, fixed bug around default target

### DIFF
--- a/functional-tests/hoverctl/config_test.go
+++ b/functional-tests/hoverctl/config_test.go
@@ -9,7 +9,7 @@ import (
 var _ = Describe("When I use hoverctl", func() {
 
 	BeforeEach(func() {
-		functional_tests.Run(hoverctlBinary, "targets", "create", "default")
+		functional_tests.Run(hoverctlBinary, "targets", "update", "local")
 	})
 
 	AfterEach(func() {

--- a/functional-tests/hoverctl/hoverfly_delete_test.go
+++ b/functional-tests/hoverctl/hoverfly_delete_test.go
@@ -23,7 +23,7 @@ var _ = Describe("When I use hoverctl", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start()
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/hoverfly_destination_test.go
+++ b/functional-tests/hoverctl/hoverfly_destination_test.go
@@ -18,7 +18,7 @@ var _ = Describe("When I use hoverctl", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start()
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/hoverfly_flush_test.go
+++ b/functional-tests/hoverctl/hoverfly_flush_test.go
@@ -20,7 +20,7 @@ var _ = Describe("hoverctl flush cache", func() {
 		hoverfly.ImportSimulation(functional_tests.JsonPayload)
 		hoverfly.Proxy(sling.New().Get("http://destination-server.com"))
 
-		functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
+		functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", hoverfly.GetAdminPort())
 	})
 
 	AfterEach(func() {

--- a/functional-tests/hoverctl/hoverfly_middleware_test.go
+++ b/functional-tests/hoverctl/hoverfly_middleware_test.go
@@ -25,7 +25,7 @@ var _ = Describe("When I use hoverctl", func() {
 			hoverfly.Start()
 			hoverfly.SetMiddleware("ruby", "#!/usr/bin/env ruby\n# encoding: utf-8\nwhile payload = STDIN.gets\nnext unless payload\n\nSTDOUT.puts payload\nend")
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/hoverfly_modes_test.go
+++ b/functional-tests/hoverctl/hoverfly_modes_test.go
@@ -18,7 +18,7 @@ var _ = Describe("When I use hoverfly-cli", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start()
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {
@@ -153,7 +153,7 @@ var _ = Describe("When I use hoverfly-cli", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start("-webserver")
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/import_export_test.go
+++ b/functional-tests/hoverctl/import_export_test.go
@@ -80,7 +80,7 @@ var _ = Describe("When I use hoverctl", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start()
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/login_test.go
+++ b/functional-tests/hoverctl/login_test.go
@@ -23,7 +23,7 @@ var _ = Describe("hoverctl login", func() {
 			hoverfly = functional_tests.NewHoverfly()
 			hoverfly.Start("-auth", "-username", username, "-password", password)
 
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", hoverfly.GetAdminPort())
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", hoverfly.GetAdminPort())
 		})
 
 		AfterEach(func() {

--- a/functional-tests/hoverctl/logs_test.go
+++ b/functional-tests/hoverctl/logs_test.go
@@ -23,7 +23,7 @@ var _ = Describe("When I use hoverctl", func() {
 	)
 
 	BeforeEach(func() {
-		functional_tests.Run(hoverctlBinary, "targets", "create", "localm", "--admin-port", adminPort, "--proxy-port", proxyPort)
+		functional_tests.Run(hoverctlBinary, "targets", "create", "local", "--admin-port", adminPort, "--proxy-port", proxyPort)
 	})
 
 	AfterEach(func() {

--- a/functional-tests/hoverctl/logs_test.go
+++ b/functional-tests/hoverctl/logs_test.go
@@ -23,7 +23,7 @@ var _ = Describe("When I use hoverctl", func() {
 	)
 
 	BeforeEach(func() {
-		functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", adminPort, "--proxy-port", proxyPort)
+		functional_tests.Run(hoverctlBinary, "targets", "create", "localm", "--admin-port", adminPort, "--proxy-port", proxyPort)
 	})
 
 	AfterEach(func() {

--- a/functional-tests/hoverctl/set_default_flag_test.go
+++ b/functional-tests/hoverctl/set_default_flag_test.go
@@ -19,7 +19,7 @@ var _ = Describe("hoverctl --set-default", func() {
 				"--target", "set-default-test2",
 				"--set-default")
 
-			Expect(output).To(ContainSubstring("default: default"))
+			Expect(output).To(ContainSubstring("default: local"))
 
 			output = functional_tests.Run(hoverctlBinary, "config", "-v")
 			Expect(output).To(ContainSubstring("default: set-default-test2"))
@@ -31,10 +31,10 @@ var _ = Describe("hoverctl --set-default", func() {
 			output := functional_tests.Run(hoverctlBinary, "config", "-v",
 				"--set-default")
 
-			Expect(output).To(ContainSubstring("default: default"))
+			Expect(output).To(ContainSubstring("default: local"))
 
 			output = functional_tests.Run(hoverctlBinary, "config", "-v")
-			Expect(output).To(ContainSubstring("default: default"))
+			Expect(output).To(ContainSubstring("default: local"))
 		})
 	})
 
@@ -45,7 +45,7 @@ var _ = Describe("hoverctl --set-default", func() {
 				"--set-default")
 
 			output := functional_tests.Run(hoverctlBinary, "config", "-v")
-			Expect(output).To(ContainSubstring("default: default"))
+			Expect(output).To(ContainSubstring("default: local"))
 		})
 	})
 })

--- a/functional-tests/hoverctl/start_test.go
+++ b/functional-tests/hoverctl/start_test.go
@@ -32,19 +32,19 @@ var _ = Describe("hoverctl `start`", func() {
 			Expect(output).To(ContainSubstring("8500"))
 		})
 
-		It("should create a default target", func() {
+		It("should create a local target", func() {
 			functional_tests.Run(hoverctlBinary, "start")
 
 			output := functional_tests.Run(hoverctlBinary, "targets")
 
 			targets := functional_tests.TableToSliceMapStringString(output)
-			Expect(targets).To(HaveKey("default"))
-			Expect(targets["default"]).To(HaveKeyWithValue("TARGET NAME", "default"))
-			Expect(targets["default"]).To(HaveKeyWithValue("ADMIN PORT", "8888"))
-			Expect(targets["default"]).To(HaveKeyWithValue("PROXY PORT", "8500"))
+			Expect(targets).To(HaveKey("local"))
+			Expect(targets["local"]).To(HaveKeyWithValue("TARGET NAME", "local"))
+			Expect(targets["local"]).To(HaveKeyWithValue("ADMIN PORT", "8888"))
+			Expect(targets["local"]).To(HaveKeyWithValue("PROXY PORT", "8500"))
 
-			Expect(targets["default"]).To(HaveKey("PID"))
-			Expect(strconv.Atoi(targets["default"]["PID"])).To(BeNumerically(">", 1))
+			Expect(targets["local"]).To(HaveKey("PID"))
+			Expect(strconv.Atoi(targets["local"]["PID"])).To(BeNumerically(">", 1))
 		})
 	})
 

--- a/functional-tests/hoverctl/stop_test.go
+++ b/functional-tests/hoverctl/stop_test.go
@@ -16,7 +16,7 @@ var _ = Describe("hoverctl `stop`", func() {
 
 	Context("without a running instance of Hoverfly", func() {
 		BeforeEach(func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default")
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local")
 		})
 
 		It("should return an error", func() {
@@ -28,7 +28,7 @@ var _ = Describe("hoverctl `stop`", func() {
 
 	Context("with an incorrect pid", func() {
 		BeforeEach(func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--pid", "432111")
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--pid", "432111")
 		})
 
 		It("should return an error", func() {
@@ -41,7 +41,7 @@ var _ = Describe("hoverctl `stop`", func() {
 	Context("with a running instance of Hoverfly", func() {
 		BeforeEach(func() {
 			hoverfly.Start()
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--pid", strconv.Itoa(hoverfly.GetPid()))
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--pid", strconv.Itoa(hoverfly.GetPid()))
 		})
 
 		AfterEach(func() {
@@ -60,7 +60,7 @@ var _ = Describe("hoverctl `stop`", func() {
 			output = functional_tests.Run(hoverctlBinary, "targets")
 
 			targets := functional_tests.TableToSliceMapStringString(output)
-			Expect(targets["default"]["PID"]).To(Equal("0"))
+			Expect(targets["local"]["PID"]).To(Equal("0"))
 		})
 	})
 

--- a/functional-tests/hoverctl/targets_test.go
+++ b/functional-tests/hoverctl/targets_test.go
@@ -207,14 +207,14 @@ var _ = Describe("When using the `targets` command", func() {
 			}))
 		})
 
-		It("should error when the default points to a non-existing  targets", func() {
+		It("the default should automatically get updated to local if the default does not exist", func() {
 			functional_tests.Run(hoverctlBinary, "targets", "create", "newdefault")
 			functional_tests.Run(hoverctlBinary, "targets", "default", "newdefault")
 			functional_tests.Run(hoverctlBinary, "targets", "delete", "newdefault", "--force")
 
 			output := functional_tests.Run(hoverctlBinary, "targets", "default")
 
-			Expect(output).To(ContainSubstring("No targets registered"))
+			Expect(output).To(ContainSubstring("Default target `newdefault` not found, changing default target to `local`"))
 		})
 
 		It("should error when given an invalid target name", func() {

--- a/functional-tests/hoverctl/targets_test.go
+++ b/functional-tests/hoverctl/targets_test.go
@@ -9,30 +9,22 @@ import (
 var _ = Describe("When using the `targets` command", func() {
 
 	Context("viewing targets", func() {
-		Context("with no targets", func() {
-
-			It("should fail nicely", func() {
-				output := functional_tests.Run(hoverctlBinary, "targets")
-
-				Expect(output).To(ContainSubstring("No targets registered"))
-			})
-		})
 
 		Context("with targets", func() {
 
 			BeforeEach(func() {
-				functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", "1234", "--proxy-port", "8765", "--host", "localhost")
+				functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", "1234", "--proxy-port", "8765", "--host", "localhost")
 			})
 
-			It("print default target", func() {
+			It("print default local target", func() {
 				output := functional_tests.Run(hoverctlBinary, "targets")
 				targets := functional_tests.TableToSliceMapStringString(output)
 
 				Expect(targets).To(HaveLen(1))
 
-				Expect(targets).To(HaveKey("default"))
-				Expect(targets["default"]).To(Equal(map[string]string{
-					"TARGET NAME": "default",
+				Expect(targets).To(HaveKey("local"))
+				Expect(targets["local"]).To(Equal(map[string]string{
+					"TARGET NAME": "local",
 					"PID":         "0",
 					"HOST":        "localhost",
 					"ADMIN PORT":  "1234",
@@ -49,9 +41,9 @@ var _ = Describe("When using the `targets` command", func() {
 
 				Expect(targets).To(HaveLen(3))
 
-				Expect(targets).To(HaveKey("default"))
-				Expect(targets["default"]).To(Equal(map[string]string{
-					"TARGET NAME": "default",
+				Expect(targets).To(HaveKey("local"))
+				Expect(targets["local"]).To(Equal(map[string]string{
+					"TARGET NAME": "local",
 					"PID":         "0",
 					"HOST":        "localhost",
 					"ADMIN PORT":  "1234",
@@ -94,8 +86,6 @@ var _ = Describe("When using the `targets` command", func() {
 			)
 			targets := functional_tests.TableToSliceMapStringString(output)
 
-			Expect(targets).To(HaveLen(1))
-
 			Expect(targets).To(HaveKey("new-target"))
 			Expect(targets["new-target"]).To(Equal(map[string]string{
 				"TARGET NAME": "new-target",
@@ -134,7 +124,6 @@ var _ = Describe("When using the `targets` command", func() {
 			)
 			targets := functional_tests.TableToSliceMapStringString(output)
 
-			Expect(targets).To(HaveLen(1))
 			Expect(targets).To(HaveKey("new-target"))
 			Expect(targets["new-target"]).To(Equal(map[string]string{
 				"TARGET NAME": "new-target",
@@ -163,11 +152,11 @@ var _ = Describe("When using the `targets` command", func() {
 	Context("deleting targets", func() {
 
 		BeforeEach(func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", "1234")
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", "1234")
 		})
 
 		It("should delete targets and print nice empty message", func() {
-			output := functional_tests.Run(hoverctlBinary, "targets", "delete", "default", "--force")
+			output := functional_tests.Run(hoverctlBinary, "targets", "delete", "local", "--force")
 
 			Expect(output).To(ContainSubstring("No targets registered"))
 		})
@@ -182,7 +171,7 @@ var _ = Describe("When using the `targets` command", func() {
 	Context("targets default", func() {
 
 		BeforeEach(func() {
-			functional_tests.Run(hoverctlBinary, "targets", "create", "default", "--admin-port", "1234")
+			functional_tests.Run(hoverctlBinary, "targets", "update", "local", "--admin-port", "1234")
 		})
 
 		It("should print the default target", func() {
@@ -191,9 +180,9 @@ var _ = Describe("When using the `targets` command", func() {
 
 			Expect(targets).To(HaveLen(1))
 
-			Expect(targets).To(HaveKey("default"))
-			Expect(targets["default"]).To(Equal(map[string]string{
-				"TARGET NAME": "default",
+			Expect(targets).To(HaveKey("local"))
+			Expect(targets["local"]).To(Equal(map[string]string{
+				"TARGET NAME": "local",
 				"PID":         "0",
 				"HOST":        "localhost",
 				"ADMIN PORT":  "1234",
@@ -219,7 +208,9 @@ var _ = Describe("When using the `targets` command", func() {
 		})
 
 		It("should error when the default points to a non-existing  targets", func() {
-			functional_tests.Run(hoverctlBinary, "targets", "delete", "default", "--force")
+			functional_tests.Run(hoverctlBinary, "targets", "create", "newdefault")
+			functional_tests.Run(hoverctlBinary, "targets", "default", "newdefault")
+			functional_tests.Run(hoverctlBinary, "targets", "delete", "newdefault", "--force")
 
 			output := functional_tests.Run(hoverctlBinary, "targets", "default")
 
@@ -239,9 +230,9 @@ var _ = Describe("When using the `targets` command", func() {
 
 			Expect(targets).To(HaveLen(1))
 
-			Expect(targets).To(HaveKey("default"))
-			Expect(targets["default"]).To(Equal(map[string]string{
-				"TARGET NAME": "default",
+			Expect(targets).To(HaveKey("local"))
+			Expect(targets["local"]).To(Equal(map[string]string{
+				"TARGET NAME": "local",
 				"PID":         "0",
 				"HOST":        "localhost",
 				"ADMIN PORT":  "1234",

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -77,6 +77,12 @@ func initConfig() {
 
 	config = configuration.GetConfig()
 
+	if config.GetTarget(config.DefaultTarget) == nil {
+		fmt.Printf("Default target `%v` not found, changing default target to `local`", config.DefaultTarget)
+		config.DefaultTarget = "local"
+
+	}
+
 	target = config.GetTarget(targetNameFlag)
 	if targetNameFlag == "" && target == nil {
 		target = configuration.NewDefaultTarget()

--- a/hoverctl/configuration/config.go
+++ b/hoverctl/configuration/config.go
@@ -88,6 +88,5 @@ func SetConfigurationPaths() {
 }
 
 func SetConfigurationDefaults() {
-	viper.SetDefault("default", "default")
-	viper.SetDefault("targets", map[string]Target{})
+	viper.SetDefault("default", "local")
 }

--- a/hoverctl/configuration/config_test.go
+++ b/hoverctl/configuration/config_test.go
@@ -10,8 +10,15 @@ import (
 
 var (
 	defaultConfig = Config{
-		DefaultTarget: "default",
-		Targets:       map[string]Target{},
+		DefaultTarget: "local",
+		Targets: map[string]Target{
+			"local": Target{
+				Name:      "local",
+				Host:      "localhost",
+				AdminPort: 8888,
+				ProxyPort: 8500,
+			},
+		},
 	}
 )
 
@@ -96,29 +103,33 @@ func Test_Config_GetTarget_ReturnsNilIfTargetDoesntExist(t *testing.T) {
 func Test_Config_NewTarget_AddsTarget(t *testing.T) {
 	RegisterTestingT(t)
 
-	unit := defaultConfig
+	unit := Config{
+		Targets: map[string]Target{},
+	}
 
 	unit.NewTarget(Target{
-		Name:      "default",
+		Name:      "newtarget",
 		AdminPort: 1234,
 	})
 
 	Expect(unit.Targets).To(HaveLen(1))
 
-	Expect(unit.Targets["default"].AdminPort).To(Equal(1234))
+	Expect(unit.Targets["newtarget"].AdminPort).To(Equal(1234))
 }
 
 func Test_Config_DeleteTarget_DeletesTarget(t *testing.T) {
 	RegisterTestingT(t)
 
-	unit := defaultConfig
-
-	unit.NewTarget(Target{
-		Name:      "default",
-		AdminPort: 1234,
-	})
+	unit := Config{
+		Targets: map[string]Target{
+			"deleteme": Target{
+				Name:      "deleteme",
+				AdminPort: 1234,
+			},
+		},
+	}
 
 	Expect(unit.Targets).To(HaveLen(1))
-	unit.DeleteTarget(*unit.GetTarget("default"))
+	unit.DeleteTarget(*unit.GetTarget("deleteme"))
 	Expect(unit.Targets).To(HaveLen(0))
 }

--- a/hoverctl/configuration/target.go
+++ b/hoverctl/configuration/target.go
@@ -32,7 +32,7 @@ type Target struct {
 
 func NewDefaultTarget() *Target {
 	return &Target{
-		Name:      "default",
+		Name:      "local",
 		Host:      "localhost",
 		AdminPort: 8888,
 		ProxyPort: 8500,
@@ -91,6 +91,11 @@ func getTargetsFromConfig(configTargets map[string]interface{}) map[string]Targe
 		}
 
 		targets[key] = targetHoverfly
+	}
+
+	if targets["local"] == (Target{}) {
+		localTarget := NewDefaultTarget()
+		targets["local"] = *localTarget
 	}
 
 	return targets

--- a/hoverctl/configuration/target_test.go
+++ b/hoverctl/configuration/target_test.go
@@ -10,7 +10,7 @@ func Test_NewTarget_ReturnsDefaultWithEmptyStrings(t *testing.T) {
 	RegisterTestingT(t)
 
 	Expect(NewTarget("", "", 0, 0)).To(Equal(&Target{
-		Name:      "default",
+		Name:      "local",
 		Host:      "localhost",
 		AdminPort: 8888,
 		ProxyPort: 8500,
@@ -32,7 +32,7 @@ func Test_NewTarget_OverridesHostfNotEmpty(t *testing.T) {
 	RegisterTestingT(t)
 
 	Expect(NewTarget("", "notlocalhost", 0, 0)).To(Equal(&Target{
-		Name:      "default",
+		Name:      "local",
 		Host:      "notlocalhost",
 		AdminPort: 8888,
 		ProxyPort: 8500,
@@ -43,7 +43,7 @@ func Test_NewTarget_OverridesAdminPortfNotEmpty(t *testing.T) {
 	RegisterTestingT(t)
 
 	Expect(NewTarget("", "", 1234, 0)).To(Equal(&Target{
-		Name:      "default",
+		Name:      "local",
 		Host:      "localhost",
 		AdminPort: 1234,
 		ProxyPort: 8500,
@@ -54,7 +54,7 @@ func Test_NewTarget_OverridesProxyPortfNotEmpty(t *testing.T) {
 	RegisterTestingT(t)
 
 	Expect(NewTarget("", "", 0, 8765)).To(Equal(&Target{
-		Name:      "default",
+		Name:      "local",
 		Host:      "localhost",
 		AdminPort: 8888,
 		ProxyPort: 8765,
@@ -65,14 +65,13 @@ func Test_getTargetsFromConfig_host(t *testing.T) {
 	RegisterTestingT(t)
 
 	targets := getTargetsFromConfig(map[string]interface{}{
-		"default": map[interface{}]interface{}{
+		"newtarget": map[interface{}]interface{}{
 			"host": "test.org",
 		},
 	})
 
-	Expect(targets).To(HaveLen(1))
-	Expect(targets).To(HaveKeyWithValue("default", Target{
-		Name: "default",
+	Expect(targets).To(HaveKeyWithValue("newtarget", Target{
+		Name: "newtarget",
 		Host: "test.org",
 	}))
 }
@@ -86,7 +85,6 @@ func Test_getTargetsFromConfig_adminport(t *testing.T) {
 		},
 	})
 
-	Expect(targets).To(HaveLen(1))
 	Expect(targets).To(HaveKeyWithValue("other", Target{
 		Name:      "other",
 		AdminPort: 1234,
@@ -102,7 +100,6 @@ func Test_getTargetsFromConfig_proxyport(t *testing.T) {
 		},
 	})
 
-	Expect(targets).To(HaveLen(1))
 	Expect(targets).To(HaveKeyWithValue("otherother", Target{
 		Name:      "otherother",
 		ProxyPort: 8765,
@@ -118,10 +115,41 @@ func Test_getTargetsFromConfig_authtoken(t *testing.T) {
 		},
 	})
 
-	Expect(targets).To(HaveLen(1))
 	Expect(targets).To(HaveKeyWithValue("anotherother", Target{
 		Name:      "anotherother",
 		AuthToken: "token123:456",
+	}))
+}
+
+func Test_getTargetsFromConfig_AddsLocal(t *testing.T) {
+	RegisterTestingT(t)
+
+	targets := getTargetsFromConfig(map[string]interface{}{})
+
+	Expect(targets).To(HaveKeyWithValue("local", Target{
+		Name:      "local",
+		Host:      "localhost",
+		AdminPort: 8888,
+		ProxyPort: 8500,
+	}))
+}
+
+func Test_getTargetsFromConfig_DoesNotOverwriteLocal(t *testing.T) {
+	RegisterTestingT(t)
+
+	targets := getTargetsFromConfig(map[string]interface{}{
+		"local": map[interface{}]interface{}{
+			"host":       "notlocalhost",
+			"admin.port": 1234,
+			"proxy.port": 4321,
+		},
+	})
+
+	Expect(targets).To(HaveKeyWithValue("local", Target{
+		Name:      "local",
+		Host:      "notlocalhost",
+		AdminPort: 1234,
+		ProxyPort: 4321,
 	}))
 }
 


### PR DESCRIPTION
If the set of targets read from the config.yaml does not contain a `local` target, it will create one. This target uses all the default target values.

The default target is now automatically get to use `local` as the default.

If the default target points to a non-existing target, it will reset it back to `local`, knowing that a `local` target should always exist. It will also print a warning when it does change the default target.