### PR TITLE
Ordering is now ignored in the jsonMatch matcher

### DIFF
--- a/core/matching/json_match.go
+++ b/core/matching/json_match.go
@@ -1,21 +1,22 @@
 package matching
 
 import (
+	"encoding/json"
 	"reflect"
-
-	"github.com/SpectoLabs/hoverfly/core/util"
 )
 
 func JsonMatch(matchingString string, toMatch string) bool {
-	minifiedMatchingString, err := util.MinifyJson(matchingString)
+	var matchingObject map[string]interface{}
+	err := json.Unmarshal([]byte(matchingString), &matchingObject)
 	if err != nil {
 		return false
 	}
 
-	minifiedToMatch, err := util.MinifyJson(toMatch)
+	var toMatchObject map[string]interface{}
+	err = json.Unmarshal([]byte(toMatch), &toMatchObject)
 	if err != nil {
 		return false
 	}
 
-	return reflect.DeepEqual(minifiedMatchingString, minifiedToMatch)
+	return reflect.DeepEqual(matchingObject, toMatchObject)
 }

--- a/core/matching/json_match_test.go
+++ b/core/matching/json_match_test.go
@@ -13,6 +13,12 @@ func Test_JsonMatch_MatchesTrueWithJSON(t *testing.T) {
 	Expect(matching.JsonMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"json":true,"minified":true}}`)).To(BeTrue())
 }
 
+func Test_JsonMatch_MatchesTrueWithJSON_InADifferentOrder(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matching.JsonMatch(`{"test":{"minified":true, "json":true}}`, `{"test":{"json":true,"minified":true}}`)).To(BeTrue())
+}
+
 func Test_JsonMatch_MatchesTrueWithUnminifiedJSON(t *testing.T) {
 	RegisterTestingT(t)
 


### PR DESCRIPTION
https://github.com/SpectoLabs/hoverfly/issues/558