### PR TITLE
Fixed bug regarding header keys in being in a different case that the simulation

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -94,12 +94,12 @@
 		{
 			"ImportPath": "github.com/SpectoLabs/goproxy",
 			"Comment": "v1.0-96-g6016d23",
-			"Rev": "b97fa8e29d6fa3c2c6f3625c0d92359b353794c4"
+			"Rev": "7f8d8488402730a2bff62981f386f85c73703a05"
 		},
 		{
 			"ImportPath": "github.com/SpectoLabs/goproxy/ext/auth",
 			"Comment": "v1.0-97-gd66a182",
-			"Rev": "b97fa8e29d6fa3c2c6f3625c0d92359b353794c4"
+			"Rev": "7f8d8488402730a2bff62981f386f85c73703a05"
 		},
 		{
 			"ImportPath": "github.com/antonholmquist/jason",

--- a/core/modes/modes.go
+++ b/core/modes/modes.go
@@ -71,25 +71,12 @@ func ReconstructResponse(request *http.Request, pair models.RequestResponsePair)
 	response := &http.Response{}
 	response.Request = request
 
-	// adding headers
-	response.Header = make(http.Header)
-
-	// applying payload
-	if len(pair.Response.Headers) > 0 {
-		for k, values := range pair.Response.Headers {
-			// headers is a map, appending each value
-			for _, v := range values {
-				response.Header.Add(k, v)
-			}
-
-		}
-	}
-
 	// adding body, length, status code
 	buf := bytes.NewBufferString(pair.Response.Body)
 	response.ContentLength = int64(buf.Len())
 	response.Body = ioutil.NopCloser(buf)
 	response.StatusCode = pair.Response.Status
+	response.Header = pair.Response.Headers
 
 	return response
 }

--- a/core/modes/modes_test.go
+++ b/core/modes/modes_test.go
@@ -133,6 +133,25 @@ func Test_ReconstructResponse_AddsHeadersToResponse(t *testing.T) {
 	Expect(response.Header.Get("Header")).To(Equal(headers["Header"][0]))
 }
 
+func Test_ReconstructResponse_AddsHeadersWithCorrectCapitalization(t *testing.T) {
+	RegisterTestingT(t)
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	pair := models.RequestResponsePair{}
+
+	headers := make(map[string][]string)
+	headers["HeaderOne"] = []string{"one"}
+	headers["HEADERTWO"] = []string{"two"}
+
+	pair.Response.Headers = headers
+
+	response := modes.ReconstructResponse(req, pair)
+
+	Expect(response.Header["HeaderOne"]).To(Equal([]string{"one"}))
+	Expect(response.Header["HEADERTWO"]).To(Equal([]string{"two"}))
+}
+
 func Test_ReconstructResponse_AddsMultipleHeaderValuesToResponse(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/vendor/github.com/SpectoLabs/goproxy/proxy.go
+++ b/vendor/github.com/SpectoLabs/goproxy/proxy.go
@@ -37,9 +37,7 @@ func copyHeaders(dst, src http.Header) {
 		dst.Del(k)
 	}
 	for k, vs := range src {
-		for _, v := range vs {
-			dst.Add(k, v)
-		}
+		dst[k] = vs
 	}
 }
 


### PR DESCRIPTION
This PR should resolve https://github.com/SpectoLabs/hoverfly/issues/573.

I was only able to test this at a unit level and not at the functional test level as I would have liked. The reason for this is because when testing it functionally, the response sent from Hoverfly will get processed by Golang which will then apply `CanonicalMIMEHeaderKey()` to each of the header keys to enforce its own standardization attempt.

The only way I think this can be tested is either pre-flight at the unit test)or by producing/introducing a new HTTP client that does not use `CanonicalMIMEHeaderKey()` so that we can check the case in the functional tests.