### PR TITLE
Moving middleware to its own package

### DIFF
--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/cache"
 	hvc "github.com/SpectoLabs/hoverfly/core/certs"
 	"github.com/SpectoLabs/hoverfly/core/matching"
+	mw "github.com/SpectoLabs/hoverfly/core/middleware"
 	"github.com/SpectoLabs/hoverfly/core/modes"
 )
 
@@ -238,7 +239,7 @@ func main() {
 	cfg.Development = *dev
 
 	// overriding default middleware setting
-	newMiddleware, err := hv.ConvertToNewMiddleware(*middleware)
+	newMiddleware, err := mw.ConvertToNewMiddleware(*middleware)
 	if err != nil {
 		log.Error(err.Error())
 	}

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	"github.com/SpectoLabs/hoverfly/core/metrics"
+	"github.com/SpectoLabs/hoverfly/core/middleware"
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/modes"
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -112,7 +113,7 @@ func (hf Hoverfly) GetMiddleware() (string, string, string) {
 }
 
 func (hf *Hoverfly) SetMiddleware(binary, script, remote string) error {
-	newMiddleware := Middleware{}
+	newMiddleware := middleware.Middleware{}
 
 	if binary == "" && script == "" && remote == "" {
 		hf.Cfg.Middleware = newMiddleware

--- a/core/hoverfly_service_test.go
+++ b/core/hoverfly_service_test.go
@@ -1,6 +1,9 @@
 package hoverfly
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -49,6 +52,19 @@ var (
 		Delay:      201,
 	}
 )
+
+func processHandlerOkay(w http.ResponseWriter, r *http.Request) {
+	body, _ := ioutil.ReadAll(r.Body)
+
+	var newPairView v2.RequestResponsePairViewV1
+
+	json.Unmarshal(body, &newPairView)
+
+	newPairView.Response.Body = "You got straight up messed with"
+
+	pairViewBytes, _ := json.Marshal(newPairView)
+	w.Write(pairViewBytes)
+}
 
 func TestHoverflyGetSimulationReturnsBlankSimulation_ifThereIsNoData(t *testing.T) {
 	RegisterTestingT(t)

--- a/core/hoverfly_test.go
+++ b/core/hoverfly_test.go
@@ -16,6 +16,74 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const pythonMiddlewareBasic = "import sys\nprint(sys.stdin.readlines()[0])"
+
+const pythonModifyResponse = "#!/usr/bin/env python\n" +
+	"import sys\n" +
+	"import json\n" +
+
+	"def main():\n" +
+	"	data = sys.stdin.readlines()\n" +
+	"	payload = data[0]\n" +
+
+	"	payload_dict = json.loads(payload)\n" +
+
+	"	payload_dict['response']['status'] = 201\n" +
+	"	payload_dict['response']['body'] = \"body was replaced by middleware\"\n" +
+
+	"	print(json.dumps(payload_dict))\n" +
+
+	"if __name__ == \"__main__\":\n" +
+	"	main()\n"
+
+const rubyModifyResponse = "#!/usr/bin/env ruby\n" +
+	"# encoding: utf-8\n\n" +
+
+	"require 'rubygems'\n" +
+	"require 'json'\n\n" +
+
+	"while payload = STDIN.gets\n" +
+	"  next unless payload\n\n" +
+
+	"  jsonPayload = JSON.parse(payload)\n\n" +
+
+	"  jsonPayload[\"response\"][\"body\"] = \"body was replaced by middleware\\n\"\n\n" +
+
+	"  STDOUT.puts jsonPayload.to_json\n\n" +
+
+	"end"
+
+const pythonReflectBody = "#!/usr/bin/env python\n" +
+	"import sys\n" +
+	"import json\n" +
+
+	"def main():\n" +
+	"	data = sys.stdin.readlines()\n" +
+	"	payload = data[0]\n" +
+
+	"	payload_dict = json.loads(payload)\n" +
+
+	"	payload_dict['response']['status'] = 201\n" +
+	"	payload_dict['response']['body'] = payload_dict['request']['body']\n" +
+
+	"	print(json.dumps(payload_dict))\n" +
+
+	"if __name__ == \"__main__\":\n" +
+	"	main()\n"
+
+const pythonMiddlewareBad = "this shouldn't work"
+
+const rubyEcho = "#!/usr/bin/env ruby\n" +
+	"# encoding: utf-8\n" +
+	"while payload = STDIN.gets\n" +
+	"  next unless payload\n" +
+	"\n" +
+	"  STDOUT.puts payload\n" +
+	"\n" +
+	"  STDERR.puts \"Payload data: #{payload}\"\n" +
+	"\n" +
+	"end"
+
 func Test_NewHoverflyWithConfiguration_DoesNotCreateCacheIfCfgIsDisabled(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/middleware/middleware.go
+++ b/core/middleware/middleware.go
@@ -1,4 +1,4 @@
-package hoverfly
+package middleware
 
 import (
 	"bytes"

--- a/core/middleware/middleware.go
+++ b/core/middleware/middleware.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	"github.com/SpectoLabs/hoverfly/core/models"
 )
 
@@ -193,7 +192,7 @@ func (this Middleware) executeMiddlewareLocally(pair models.RequestResponsePair)
 	}
 
 	if len(stdout.Bytes()) > 0 {
-		var newPairView v2.RequestResponsePairViewV1
+		var newPairView RequestResponsePairView
 
 		err = json.Unmarshal(stdout.Bytes(), &newPairView)
 
@@ -256,7 +255,7 @@ func (this Middleware) executeMiddlewareRemotely(pair models.RequestResponsePair
 		return pair, err
 	}
 
-	var newPairView v2.RequestResponsePairViewV1
+	var newPairView RequestResponsePairView
 
 	err = json.Unmarshal(returnedPairViewBytes, &newPairView)
 	if err != nil {

--- a/core/middleware/middleware_test.go
+++ b/core/middleware/middleware_test.go
@@ -1,4 +1,4 @@
-package hoverfly
+package middleware
 
 import (
 	"encoding/json"
@@ -82,6 +82,19 @@ const rubyEcho = "#!/usr/bin/env ruby\n" +
 	"  STDERR.puts \"Payload data: #{payload}\"\n" +
 	"\n" +
 	"end"
+
+func processHandlerOkay(w http.ResponseWriter, r *http.Request) {
+	body, _ := ioutil.ReadAll(r.Body)
+
+	var newPairView v2.RequestResponsePairViewV1
+
+	json.Unmarshal(body, &newPairView)
+
+	newPairView.Response.Body = "You got straight up messed with"
+
+	pairViewBytes, _ := json.Marshal(newPairView)
+	w.Write(pairViewBytes)
+}
 
 func processHandlerOkayButNoResponse(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
@@ -218,19 +231,6 @@ func TestReflectBody(t *testing.T) {
 	Expect(newPair.Response.Body).To(Equal(req.Body))
 	Expect(newPair.Request.Method).To(Equal(req.Method))
 	Expect(newPair.Request.Destination).To(Equal(req.Destination))
-}
-
-func processHandlerOkay(w http.ResponseWriter, r *http.Request) {
-	body, _ := ioutil.ReadAll(r.Body)
-
-	var newPairView v2.RequestResponsePairViewV1
-
-	json.Unmarshal(body, &newPairView)
-
-	newPairView.Response.Body = "You got straight up messed with"
-
-	pairViewBytes, _ := json.Marshal(newPairView)
-	w.Write(pairViewBytes)
 }
 
 func TestExecuteMiddlewareRemotely(t *testing.T) {

--- a/core/middleware/views.go
+++ b/core/middleware/views.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"github.com/SpectoLabs/hoverfly/core/interfaces"
+	"github.com/SpectoLabs/hoverfly/core/util"
+)
+
+// This is a JSON serializable representation of the internal
+// Hoverfly structs for HTTP requests and responses.
+// These structs are only used when serializing requests
+// and responses to middleware.
+type RequestResponsePairView struct {
+	Response ResponseDetailsView `json:"response"`
+	Request  RequestDetailsView  `json:"request"`
+}
+
+func (this RequestResponsePairView) GetResponse() interfaces.Response { return this.Response }
+
+func (this RequestResponsePairView) GetRequest() interfaces.Request { return this.Request }
+
+type RequestDetailsView struct {
+	RequestType *string             `json:"requestType"`
+	Path        *string             `json:"path"`
+	Method      *string             `json:"method"`
+	Destination *string             `json:"destination"`
+	Scheme      *string             `json:"scheme"`
+	Query       *string             `json:"query"`
+	Body        *string             `json:"body"`
+	Headers     map[string][]string `json:"headers"`
+}
+
+func (this RequestDetailsView) GetPath() *string { return this.Path }
+
+func (this RequestDetailsView) GetMethod() *string { return this.Method }
+
+func (this RequestDetailsView) GetDestination() *string { return this.Destination }
+
+func (this RequestDetailsView) GetScheme() *string { return this.Scheme }
+
+func (this RequestDetailsView) GetQuery() *string {
+	if this.Query == nil {
+		return this.Query
+	}
+	queryString := util.SortQueryString(*this.Query)
+	return &queryString
+}
+
+func (this RequestDetailsView) GetBody() *string { return this.Body }
+
+func (this RequestDetailsView) GetHeaders() map[string][]string { return this.Headers }
+
+type ResponseDetailsView struct {
+	Status      int                 `json:"status"`
+	Body        string              `json:"body"`
+	EncodedBody bool                `json:"encodedBody"`
+	Headers     map[string][]string `json:"headers"`
+}
+
+func (this ResponseDetailsView) GetStatus() int { return this.Status }
+
+func (this ResponseDetailsView) GetBody() string { return this.Body }
+
+func (this ResponseDetailsView) GetEncodedBody() bool { return this.EncodedBody }
+
+func (this ResponseDetailsView) GetHeaders() map[string][]string { return this.Headers }

--- a/core/settings.go
+++ b/core/settings.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/SpectoLabs/hoverfly/core/middleware"
 )
 
 // Configuration - initial structure of configuration
@@ -16,7 +17,7 @@ type Configuration struct {
 	ProxyPort    string
 	Mode         string
 	Destination  string
-	Middleware   Middleware
+	Middleware   middleware.Middleware
 	DatabasePath string
 	Webserver    bool
 
@@ -161,7 +162,7 @@ func InitSettings() *Configuration {
 	}
 
 	// middleware configuration
-	newMiddleware, _ := ConvertToNewMiddleware(os.Getenv(HoverflyMiddlewareEV))
+	newMiddleware, _ := middleware.ConvertToNewMiddleware(os.Getenv(HoverflyMiddlewareEV))
 
 	appConfig.Middleware = *newMiddleware
 


### PR DESCRIPTION
I have moved middleware to its own package. I have also copied the structs middleware uses for serializing requests and responses. Originally, it was using the same structs that were being used for importing old v1 simulation files.

The reason for addition of structs is if we need to make changes to what data is being sent to middleware, we don't want to change the schema for old v1 simulation files.

This work was inevitable as it is required for deprecating the old v1 simulation schema.