### PR TITLE
Fixed bug where two empty strings would result in a false match in the JsonMatcher

### DIFF
--- a/core/matching/json_match.go
+++ b/core/matching/json_match.go
@@ -6,7 +6,7 @@ import (
 )
 
 func JsonMatch(matchingString string, toMatch string) bool {
-	if matchingString == "" && toMatch == "" {
+	if matchingString == toMatch {
 		return true
 	}
 	var matchingObject map[string]interface{}

--- a/core/matching/json_match.go
+++ b/core/matching/json_match.go
@@ -6,6 +6,9 @@ import (
 )
 
 func JsonMatch(matchingString string, toMatch string) bool {
+	if matchingString == "" && toMatch == "" {
+		return true
+	}
 	var matchingObject map[string]interface{}
 	err := json.Unmarshal([]byte(matchingString), &matchingObject)
 	if err != nil {

--- a/core/matching/json_match_test.go
+++ b/core/matching/json_match_test.go
@@ -51,3 +51,31 @@ func Test_JsonMatch_MatchesFalseWithInvalidJSON(t *testing.T) {
 		}
 	}`)).To(BeFalse())
 }
+
+func Test_JsonMatch_MatchesTrueWithTwoEmptyString(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matching.JsonMatch(``, ``)).To(BeTrue())
+}
+
+func Test_JsonMatch_MatchesFalseAgainstEmptyString(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matching.JsonMatch(`{
+		"test": {
+			"json": true,
+			"minified": 
+		}
+	}`, ``)).To(BeFalse())
+}
+
+func Test_JsonMatch_MatchesFalseWithEmptyString(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matching.JsonMatch(``, `{
+		"test": {
+			"json": true,
+			"minified": 
+		}
+	}`)).To(BeFalse())
+}


### PR DESCRIPTION
Originally, you could match a `jsonMatch: ""` against an empty request body. This was broken in v0.11.5.

This bug was introduced when updating the JsonMatcher to ignore the order of object fields.