### PR TITLE
Added a journal function to Hoverfly

### DIFF
--- a/core/admin.go
+++ b/core/admin.go
@@ -105,6 +105,7 @@ func GetAllHandlers(hoverfly *Hoverfly) []handlers.AdminHandler {
 	list = append(list, &v2.SimulationHandler{Hoverfly: hoverfly})
 	list = append(list, &v2.CacheHandler{Hoverfly: hoverfly})
 	list = append(list, &v2.LogsHandler{Hoverfly: hoverfly.StoreLogsHook})
+	list = append(list, &v2.JournalHandler{Hoverfly: hoverfly.Journal})
 	list = append(list, &v2.ShutdownHandler{})
 
 	return list

--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/cache"
 	hvc "github.com/SpectoLabs/hoverfly/core/certs"
 	"github.com/SpectoLabs/hoverfly/core/handlers"
+	"github.com/SpectoLabs/hoverfly/core/journal"
 	"github.com/SpectoLabs/hoverfly/core/matching"
 	mw "github.com/SpectoLabs/hoverfly/core/middleware"
 	"github.com/SpectoLabs/hoverfly/core/modes"
@@ -96,6 +97,8 @@ var (
 	disableCache = flag.Bool("disable-cache", false, "Disable the cache that sits infront of matching")
 
 	logsFormat = flag.String("logs", "plaintext", "Specify format for logs, options are \"plaintext\" and \"json\" (default \"plaintext\")")
+
+	enableJournal = flag.Bool("journal", true, "Enable or disable request/response journal (default \"true\")")
 )
 
 var CA_CERT = []byte(`-----BEGIN CERTIFICATE-----
@@ -179,6 +182,10 @@ func main() {
 	if *version {
 		fmt.Println(hv.NewHoverfly().GetVersion())
 		os.Exit(0)
+	}
+
+	if !*enableJournal {
+		hoverfly.Journal = journal.NewDisabledJournal()
 	}
 
 	// getting settings

--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -99,6 +99,7 @@ var (
 	logsFormat = flag.String("logs", "plaintext", "Specify format for logs, options are \"plaintext\" and \"json\" (default \"plaintext\")")
 
 	enableJournal = flag.Bool("journal", true, "Enable or disable request/response journal (default \"true\")")
+	journalSize   = flag.Int("journal-size", 1000, "Set the size of request/response journal (default \"1000\")")
 )
 
 var CA_CERT = []byte(`-----BEGIN CERTIFICATE-----
@@ -187,6 +188,8 @@ func main() {
 	if !*enableJournal {
 		hoverfly.Journal = journal.NewDisabledJournal()
 	}
+
+	hoverfly.Journal.EntryLimit = *journalSize
 
 	// getting settings
 	cfg := hv.InitSettings()

--- a/core/handlers/v2/journal_handler.go
+++ b/core/handlers/v2/journal_handler.go
@@ -11,6 +11,7 @@ import (
 
 type HoverflyJournal interface {
 	GetEntries() []JournalEntryView
+	DeleteEntries()
 }
 
 type JournalHandler struct {
@@ -22,6 +23,10 @@ func (this *JournalHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandl
 		negroni.HandlerFunc(am.RequireTokenAuthentication),
 		negroni.HandlerFunc(this.Get),
 	))
+	mux.Delete("/api/v2/journal", negroni.New(
+		negroni.HandlerFunc(am.RequireTokenAuthentication),
+		negroni.HandlerFunc(this.Delete),
+	))
 	mux.Options("/api/v2/journal", negroni.New(
 		negroni.HandlerFunc(this.Options),
 	))
@@ -32,7 +37,12 @@ func (this *JournalHandler) Get(response http.ResponseWriter, request *http.Requ
 	handlers.WriteResponse(response, bytes)
 }
 
+func (this *JournalHandler) Delete(response http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
+	this.Hoverfly.DeleteEntries()
+	this.Get(response, request, next)
+}
+
 func (this *JournalHandler) Options(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	w.Header().Add("Allow", "OPTIONS, GET")
+	w.Header().Add("Allow", "OPTIONS, GET, DELETE")
 	handlers.WriteResponse(w, []byte(""))
 }

--- a/core/handlers/v2/journal_handler.go
+++ b/core/handlers/v2/journal_handler.go
@@ -1,0 +1,38 @@
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/SpectoLabs/hoverfly/core/handlers"
+	"github.com/codegangsta/negroni"
+	"github.com/go-zoo/bone"
+)
+
+type HoverflyJournal interface {
+	GetEntries() []JournalEntryView
+}
+
+type JournalHandler struct {
+	Hoverfly HoverflyJournal
+}
+
+func (this *JournalHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandler) {
+	mux.Get("/api/v2/journal", negroni.New(
+		negroni.HandlerFunc(am.RequireTokenAuthentication),
+		negroni.HandlerFunc(this.Get),
+	))
+	mux.Options("/api/v2/journal", negroni.New(
+		negroni.HandlerFunc(this.Options),
+	))
+}
+
+func (this *JournalHandler) Get(response http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
+	bytes, _ := json.Marshal(this.Hoverfly.GetEntries())
+	handlers.WriteResponse(response, bytes)
+}
+
+func (this *JournalHandler) Options(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	w.Header().Add("Allow", "OPTIONS, GET")
+	handlers.WriteResponse(w, []byte(""))
+}

--- a/core/handlers/v2/journal_handler.go
+++ b/core/handlers/v2/journal_handler.go
@@ -10,8 +10,8 @@ import (
 )
 
 type HoverflyJournal interface {
-	GetEntries() []JournalEntryView
-	DeleteEntries()
+	GetEntries() ([]JournalEntryView, error)
+	DeleteEntries() error
 }
 
 type JournalHandler struct {
@@ -33,12 +33,23 @@ func (this *JournalHandler) RegisterRoutes(mux *bone.Mux, am *handlers.AuthHandl
 }
 
 func (this *JournalHandler) Get(response http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
-	bytes, _ := json.Marshal(this.Hoverfly.GetEntries())
+	entries, err := this.Hoverfly.GetEntries()
+	if err != nil {
+		handlers.WriteErrorResponse(response, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	bytes, _ := json.Marshal(entries)
 	handlers.WriteResponse(response, bytes)
 }
 
 func (this *JournalHandler) Delete(response http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
-	this.Hoverfly.DeleteEntries()
+	err := this.Hoverfly.DeleteEntries()
+	if err != nil {
+		handlers.WriteErrorResponse(response, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	this.Get(response, request, next)
 }
 

--- a/core/handlers/v2/journal_handler_test.go
+++ b/core/handlers/v2/journal_handler_test.go
@@ -1,0 +1,74 @@
+package v2
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+type HoverflyJournalStub struct {
+	limit int
+}
+
+func (this *HoverflyJournalStub) GetEntries() []JournalEntryView {
+	return []JournalEntryView{
+		JournalEntryView{
+			Mode: "test",
+		},
+	}
+}
+
+func Test_JournalHandler_Get_ReturnsJournal(t *testing.T) {
+	RegisterTestingT(t)
+
+	stubHoverfly := &HoverflyJournalStub{}
+	unit := JournalHandler{Hoverfly: stubHoverfly}
+
+	request, err := http.NewRequest("GET", "/api/v2/journal", nil)
+	Expect(err).To(BeNil())
+
+	response := makeRequestOnHandler(unit.Get, request)
+
+	Expect(response.Code).To(Equal(http.StatusOK))
+
+	journalView, err := unmarshalJournalEntryView(response.Body)
+	Expect(err).To(BeNil())
+
+	Expect(journalView).To(HaveLen(1))
+	Expect(journalView[0].Mode).To(Equal("test"))
+}
+
+func Test_JournalHandler_Options_GetsOptions(t *testing.T) {
+	RegisterTestingT(t)
+
+	var stubHoverfly HoverflyJournalStub
+	unit := JournalHandler{Hoverfly: &stubHoverfly}
+
+	request, err := http.NewRequest("OPTIONS", "/api/v2/journal", nil)
+	Expect(err).To(BeNil())
+
+	response := makeRequestOnHandler(unit.Options, request)
+
+	Expect(response.Code).To(Equal(http.StatusOK))
+	Expect(response.Header().Get("Allow")).To(Equal("OPTIONS, GET"))
+}
+
+func unmarshalJournalEntryView(buffer *bytes.Buffer) ([]JournalEntryView, error) {
+	body, err := ioutil.ReadAll(buffer)
+	if err != nil {
+		return []JournalEntryView{}, err
+	}
+
+	var journalView []JournalEntryView
+
+	err = json.Unmarshal(body, &journalView)
+	if err != nil {
+		return []JournalEntryView{}, err
+	}
+
+	return journalView, nil
+}

--- a/core/handlers/v2/views.go
+++ b/core/handlers/v2/views.go
@@ -1,6 +1,8 @@
 package v2
 
 import (
+	"time"
+
 	"github.com/SpectoLabs/hoverfly/core/metrics"
 )
 
@@ -25,7 +27,7 @@ type ModeView struct {
 
 type ModeArgumentsView struct {
 	Headers          []string `json:"headersWhitelist,omitempty"`
-	MatchingStrategy *string `json:"matchingStrategy,omitempty"`
+	MatchingStrategy *string  `json:"matchingStrategy,omitempty"`
 }
 
 type VersionView struct {
@@ -54,8 +56,16 @@ type CacheView struct {
 }
 
 type CachedResponseView struct {
-	Key          string                     `json:"key"`
+	Key          string                            `json:"key"`
 	MatchingPair *RequestMatcherResponsePairViewV2 `json:"matchingPair,omitempty"`
-	HeaderMatch  bool                       `json:"headerMatch"`
-	ClosestMiss  *ClosestMissView `json:"closestMiss"`
+	HeaderMatch  bool                              `json:"headerMatch"`
+	ClosestMiss  *ClosestMissView                  `json:"closestMiss"`
+}
+
+type JournalEntryView struct {
+	Request     RequestDetailsViewV1 `json:"request"`
+	Response    ResponseDetailsView  `json:"response"`
+	Mode        string               `json:"mode"`
+	TimeStarted time.Time            `json:"timeStarted"`
+	Latency     time.Duration        `json:"latency"`
 }

--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -16,6 +16,7 @@ import (
 	"github.com/SpectoLabs/goproxy"
 	"github.com/SpectoLabs/hoverfly/core/authentication/backends"
 	"github.com/SpectoLabs/hoverfly/core/cache"
+	"github.com/SpectoLabs/hoverfly/core/journal"
 	"github.com/SpectoLabs/hoverfly/core/matching"
 	"github.com/SpectoLabs/hoverfly/core/metrics"
 	"github.com/SpectoLabs/hoverfly/core/models"
@@ -50,6 +51,7 @@ type Hoverfly struct {
 
 	Simulation    *models.Simulation
 	StoreLogsHook *StoreLogsHook
+	Journal       *journal.Journal
 }
 
 func NewHoverfly() *Hoverfly {
@@ -60,6 +62,7 @@ func NewHoverfly() *Hoverfly {
 		Authentication: authBackend,
 		Counter:        metrics.NewModeCounter([]string{modes.Simulate, modes.Synthesize, modes.Modify, modes.Capture}),
 		StoreLogsHook:  NewStoreLogsHook(),
+		Journal:        journal.NewJournal(),
 		Cfg:            InitSettings(),
 	}
 

--- a/core/journal/journal.go
+++ b/core/journal/journal.go
@@ -1,0 +1,66 @@
+package journal
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
+	"github.com/SpectoLabs/hoverfly/core/models"
+	"github.com/SpectoLabs/hoverfly/core/util"
+)
+
+type JournalEntry struct {
+	Request     *models.RequestDetails
+	Response    *models.ResponseDetails
+	Mode        string
+	TimeStarted time.Time
+	Latency     time.Duration
+}
+
+type Journal struct {
+	entries []JournalEntry
+}
+
+func NewJournal() *Journal {
+	return &Journal{
+		entries: []JournalEntry{},
+	}
+}
+
+func (this *Journal) NewEntry(request *http.Request, response *http.Response, mode string, started time.Time) {
+	payloadRequest, _ := models.NewRequestDetailsFromHttpRequest(request)
+
+	respBody, _ := util.GetResponseBody(response)
+
+	payloadResponse := &models.ResponseDetails{
+		Status:  response.StatusCode,
+		Body:    string(respBody),
+		Headers: response.Header,
+	}
+
+	this.entries = append(this.entries, JournalEntry{
+		Request:     &payloadRequest,
+		Response:    payloadResponse,
+		Mode:        mode,
+		TimeStarted: started,
+		Latency:     time.Since(started),
+	})
+}
+
+func (this Journal) GetEntries() []v2.JournalEntryView {
+	journalEntryViews := []v2.JournalEntryView{}
+	for _, journalEntry := range this.entries {
+		journalEntryViews = append(journalEntryViews, v2.JournalEntryView{
+			Request:     journalEntry.Request.ConvertToRequestDetailsView(),
+			Response:    journalEntry.Response.ConvertToResponseDetailsView(),
+			Mode:        journalEntry.Mode,
+			TimeStarted: journalEntry.TimeStarted,
+			Latency:     (journalEntry.Latency / time.Millisecond),
+		})
+	}
+	return journalEntryViews
+}
+
+func (this *Journal) DeleteEntries() {
+	this.entries = []JournalEntry{}
+}

--- a/core/journal/journal.go
+++ b/core/journal/journal.go
@@ -1,6 +1,7 @@
 package journal
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -27,7 +28,15 @@ func NewJournal() *Journal {
 	}
 }
 
-func (this *Journal) NewEntry(request *http.Request, response *http.Response, mode string, started time.Time) {
+func NewDisabledJournal() *Journal {
+	return &Journal{}
+}
+
+func (this *Journal) NewEntry(request *http.Request, response *http.Response, mode string, started time.Time) error {
+	if this.entries == nil {
+		return fmt.Errorf("No journal set")
+	}
+
 	payloadRequest, _ := models.NewRequestDetailsFromHttpRequest(request)
 
 	respBody, _ := util.GetResponseBody(response)
@@ -45,9 +54,15 @@ func (this *Journal) NewEntry(request *http.Request, response *http.Response, mo
 		TimeStarted: started,
 		Latency:     time.Since(started),
 	})
+
+	return nil
 }
 
-func (this Journal) GetEntries() []v2.JournalEntryView {
+func (this Journal) GetEntries() ([]v2.JournalEntryView, error) {
+	if this.entries == nil {
+		return []v2.JournalEntryView{}, fmt.Errorf("No journal set")
+	}
+
 	journalEntryViews := []v2.JournalEntryView{}
 	for _, journalEntry := range this.entries {
 		journalEntryViews = append(journalEntryViews, v2.JournalEntryView{
@@ -58,9 +73,15 @@ func (this Journal) GetEntries() []v2.JournalEntryView {
 			Latency:     (journalEntry.Latency / time.Millisecond),
 		})
 	}
-	return journalEntryViews
+	return journalEntryViews, nil
 }
 
-func (this *Journal) DeleteEntries() {
+func (this *Journal) DeleteEntries() error {
+	if this.entries == nil {
+		return fmt.Errorf("No journal set")
+	}
+
 	this.entries = []JournalEntry{}
+
+	return nil
 }

--- a/core/journal/journal.go
+++ b/core/journal/journal.go
@@ -19,12 +19,14 @@ type JournalEntry struct {
 }
 
 type Journal struct {
-	entries []JournalEntry
+	entries    []JournalEntry
+	EntryLimit int
 }
 
 func NewJournal() *Journal {
 	return &Journal{
-		entries: []JournalEntry{},
+		entries:    []JournalEntry{},
+		EntryLimit: 1000,
 	}
 }
 
@@ -45,6 +47,10 @@ func (this *Journal) NewEntry(request *http.Request, response *http.Response, mo
 		Status:  response.StatusCode,
 		Body:    string(respBody),
 		Headers: response.Header,
+	}
+
+	if len(this.entries) >= this.EntryLimit {
+		this.entries = append(this.entries[:0], this.entries[1:]...)
 	}
 
 	this.entries = append(this.entries, JournalEntry{

--- a/core/journal/journal_test.go
+++ b/core/journal/journal_test.go
@@ -1,0 +1,126 @@
+package journal_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/SpectoLabs/hoverfly/core/journal"
+	. "github.com/onsi/gomega"
+)
+
+func Test_NewJournal_ProducesAJournalWithAnEmptyArray(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := journal.NewJournal()
+
+	entries := unit.GetEntries()
+
+	Expect(entries).ToNot(BeNil())
+	Expect(entries).To(HaveLen(0))
+}
+
+func Test_Journal_NewEntry_AddsJournalEntryToEntries(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := journal.NewJournal()
+
+	request, _ := http.NewRequest("GET", "http://hoverfly.io", nil)
+
+	nowTime := time.Now()
+
+	unit.NewEntry(request, &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString("test body")),
+		Header: http.Header{
+			"test-header": []string{
+				"one", "two",
+			},
+		},
+	}, "test-mode", nowTime)
+
+	entries := unit.GetEntries()
+
+	Expect(entries).ToNot(BeNil())
+	Expect(entries).To(HaveLen(1))
+
+	Expect(*entries[0].Request.Method).To(Equal("GET"))
+	Expect(*entries[0].Request.Destination).To(Equal("hoverfly.io"))
+	Expect(*entries[0].Request.Body).To(Equal(""))
+
+	Expect(entries[0].Response.Status).To(Equal(200))
+	Expect(entries[0].Response.Body).To(Equal("test body"))
+	Expect(entries[0].Response.Headers["test-header"]).To(ContainElement("one"))
+	Expect(entries[0].Response.Headers["test-header"]).To(ContainElement("two"))
+
+	Expect(entries[0].Mode).To(Equal("test-mode"))
+	Expect(entries[0].TimeStarted).To(Equal(nowTime))
+	Expect(entries[0].Latency).To(BeNumerically("<", 1))
+}
+
+func Test_Journal_NewEntry_KeepsOrder(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := journal.NewJournal()
+
+	request, _ := http.NewRequest("GET", "http://hoverfly.io", nil)
+
+	nowTime := time.Now()
+
+	unit.NewEntry(request, &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString("test body")),
+		Header: http.Header{
+			"test-header": []string{
+				"one", "two",
+			},
+		},
+	}, "test-mode", nowTime)
+
+	request.Method = "DELETE"
+	unit.NewEntry(request, &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString("test body")),
+		Header: http.Header{
+			"test-header": []string{
+				"one", "two",
+			},
+		},
+	}, "test-mode", nowTime)
+
+	entries := unit.GetEntries()
+
+	Expect(entries).ToNot(BeNil())
+	Expect(entries).To(HaveLen(2))
+
+	Expect(*entries[0].Request.Method).To(Equal("GET"))
+	Expect(*entries[1].Request.Method).To(Equal("DELETE"))
+}
+
+func Test_Journal_DeleteEntries_DeletesAllEntries(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := journal.NewJournal()
+
+	request, _ := http.NewRequest("GET", "http://hoverfly.io", nil)
+
+	nowTime := time.Now()
+
+	unit.NewEntry(request, &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString("test body")),
+		Header: http.Header{
+			"test-header": []string{
+				"one", "two",
+			},
+		},
+	}, "test-mode", nowTime)
+
+	unit.DeleteEntries()
+
+	entries := unit.GetEntries()
+
+	Expect(entries).To(HaveLen(0))
+}

--- a/core/proxy.go
+++ b/core/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"fmt"
 
@@ -85,7 +86,9 @@ func NewProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 	// processing connections
 	proxy.OnRequest(goproxy.UrlMatches(regexp.MustCompile(hoverfly.Cfg.Destination))).DoFunc(
 		func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+			startTime := time.Now()
 			resp := hoverfly.processRequest(r)
+			hoverfly.Journal.NewEntry(r, resp, hoverfly.Cfg.Mode, startTime)
 			return r, resp
 		})
 

--- a/functional-tests/core/ft_api_v2_journal_test.go
+++ b/functional-tests/core/ft_api_v2_journal_test.go
@@ -1,0 +1,138 @@
+package hoverfly_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
+	"github.com/SpectoLabs/hoverfly/functional-tests"
+	"github.com/dghubble/sling"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("/api/v2/journal", func() {
+
+	var (
+		hoverfly *functional_tests.Hoverfly
+	)
+
+	BeforeEach(func() {
+		hoverfly = functional_tests.NewHoverfly()
+		hoverfly.Start()
+	})
+
+	AfterEach(func() {
+		hoverfly.Stop()
+	})
+
+	Context("GET", func() {
+
+		It("should display an empty journal", func() {
+			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+			res := functional_tests.DoRequest(req)
+
+			Expect(res.StatusCode).To(Equal(200))
+
+			responseJson, err := ioutil.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			var journal []v2.JournalEntryView
+
+			err = json.Unmarshal(responseJson, &journal)
+			Expect(err).To(BeNil())
+
+			Expect(journal).To(HaveLen(0))
+		})
+
+		It("should display one item in the journal", func() {
+			hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
+
+			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+			res := functional_tests.DoRequest(req)
+
+			Expect(res.StatusCode).To(Equal(200))
+
+			responseJson, err := ioutil.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			var journal []v2.JournalEntryView
+
+			err = json.Unmarshal(responseJson, &journal)
+			Expect(err).To(BeNil())
+
+			Expect(journal).To(HaveLen(1))
+
+			Expect(*journal[0].Request.Scheme).To(Equal("http"))
+			Expect(*journal[0].Request.Method).To(Equal("GET"))
+			Expect(*journal[0].Request.Destination).To(Equal("hoverfly.io"))
+			Expect(*journal[0].Request.Path).To(Equal("/"))
+			Expect(*journal[0].Request.Query).To(Equal(""))
+			Expect(journal[0].Request.Headers["Accept-Encoding"]).To(ContainElement("gzip"))
+			Expect(journal[0].Request.Headers["User-Agent"]).To(ContainElement("Go-http-client/1.1"))
+
+			Expect(journal[0].Response.Status).To(Equal(502))
+			Expect(journal[0].Response.Body).To(Equal("Hoverfly Error!\n\nThere was an error when matching\n\nGot error: Could not find a match for request, create or record a valid matcher first!"))
+			Expect(journal[0].Response.Headers["Content-Type"]).To(ContainElement("text/plain"))
+
+			Expect(journal[0].Latency).To(BeNumerically("<", 1))
+			Expect(journal[0].Mode).To(Equal("simulate"))
+		})
+
+		It("should display multiple items in the journal", func() {
+			hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
+			hoverfly.Proxy(sling.New().Get("http://github.com/SpectoLabs/hoverfly"))
+			hoverfly.Proxy(sling.New().Get("http://specto.io"))
+
+			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+			res := functional_tests.DoRequest(req)
+
+			Expect(res.StatusCode).To(Equal(200))
+
+			responseJson, err := ioutil.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			var journal []v2.JournalEntryView
+
+			err = json.Unmarshal(responseJson, &journal)
+			Expect(err).To(BeNil())
+
+			Expect(journal).To(HaveLen(3))
+
+			Expect(*journal[0].Request.Destination).To(Equal("hoverfly.io"))
+			Expect(*journal[0].Request.Path).To(Equal("/"))
+
+			Expect(*journal[1].Request.Destination).To(Equal("github.com"))
+			Expect(*journal[1].Request.Path).To(Equal("/SpectoLabs/hoverfly"))
+
+			Expect(*journal[2].Request.Destination).To(Equal("specto.io"))
+			Expect(*journal[2].Request.Path).To(Equal("/"))
+		})
+
+		It("should display the mode each request was in", func() {
+			hoverfly.SetMode("simulate")
+			hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+
+			hoverfly.SetMode("capture")
+			hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+
+			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+			res := functional_tests.DoRequest(req)
+
+			Expect(res.StatusCode).To(Equal(200))
+
+			responseJson, err := ioutil.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			var journal []v2.JournalEntryView
+
+			err = json.Unmarshal(responseJson, &journal)
+			Expect(err).To(BeNil())
+
+			Expect(journal).To(HaveLen(2))
+
+			Expect(journal[0].Mode).To(Equal("simulate"))
+			Expect(journal[1].Mode).To(Equal("capture"))
+		})
+	})
+})

--- a/functional-tests/core/ft_api_v2_journal_test.go
+++ b/functional-tests/core/ft_api_v2_journal_test.go
@@ -3,7 +3,9 @@ package hoverfly_test
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 
+	"github.com/SpectoLabs/hoverfly/core/handlers"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	"github.com/SpectoLabs/hoverfly/functional-tests"
 	"github.com/dghubble/sling"
@@ -17,147 +19,202 @@ var _ = Describe("/api/v2/journal", func() {
 		hoverfly *functional_tests.Hoverfly
 	)
 
-	BeforeEach(func() {
-		hoverfly = functional_tests.NewHoverfly()
-		hoverfly.Start()
+	Context("With journal enabled", func() {
+
+		BeforeEach(func() {
+			hoverfly = functional_tests.NewHoverfly()
+			hoverfly.Start()
+		})
+
+		AfterEach(func() {
+			hoverfly.Stop()
+		})
+
+		Context("GET", func() {
+
+			It("should display an empty journal", func() {
+				req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				res := functional_tests.DoRequest(req)
+
+				Expect(res.StatusCode).To(Equal(200))
+
+				responseJson, err := ioutil.ReadAll(res.Body)
+				Expect(err).To(BeNil())
+
+				var journal []v2.JournalEntryView
+
+				err = json.Unmarshal(responseJson, &journal)
+				Expect(err).To(BeNil())
+
+				Expect(journal).To(HaveLen(0))
+			})
+
+			It("should display one item in the journal", func() {
+				hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
+
+				req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				res := functional_tests.DoRequest(req)
+
+				Expect(res.StatusCode).To(Equal(200))
+
+				responseJson, err := ioutil.ReadAll(res.Body)
+				Expect(err).To(BeNil())
+
+				var journal []v2.JournalEntryView
+
+				err = json.Unmarshal(responseJson, &journal)
+				Expect(err).To(BeNil())
+
+				Expect(journal).To(HaveLen(1))
+
+				Expect(*journal[0].Request.Scheme).To(Equal("http"))
+				Expect(*journal[0].Request.Method).To(Equal("GET"))
+				Expect(*journal[0].Request.Destination).To(Equal("hoverfly.io"))
+				Expect(*journal[0].Request.Path).To(Equal("/"))
+				Expect(*journal[0].Request.Query).To(Equal(""))
+				Expect(journal[0].Request.Headers["Accept-Encoding"]).To(ContainElement("gzip"))
+				Expect(journal[0].Request.Headers["User-Agent"]).To(ContainElement("Go-http-client/1.1"))
+
+				Expect(journal[0].Response.Status).To(Equal(502))
+				Expect(journal[0].Response.Body).To(Equal("Hoverfly Error!\n\nThere was an error when matching\n\nGot error: Could not find a match for request, create or record a valid matcher first!"))
+				Expect(journal[0].Response.Headers["Content-Type"]).To(ContainElement("text/plain"))
+
+				Expect(journal[0].Latency).To(BeNumerically("<", 1))
+				Expect(journal[0].Mode).To(Equal("simulate"))
+			})
+
+			It("should display multiple items in the journal", func() {
+				hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
+				hoverfly.Proxy(sling.New().Get("http://github.com/SpectoLabs/hoverfly"))
+				hoverfly.Proxy(sling.New().Get("http://specto.io"))
+
+				req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				res := functional_tests.DoRequest(req)
+
+				Expect(res.StatusCode).To(Equal(200))
+
+				responseJson, err := ioutil.ReadAll(res.Body)
+				Expect(err).To(BeNil())
+
+				var journal []v2.JournalEntryView
+
+				err = json.Unmarshal(responseJson, &journal)
+				Expect(err).To(BeNil())
+
+				Expect(journal).To(HaveLen(3))
+
+				Expect(*journal[0].Request.Destination).To(Equal("hoverfly.io"))
+				Expect(*journal[0].Request.Path).To(Equal("/"))
+
+				Expect(*journal[1].Request.Destination).To(Equal("github.com"))
+				Expect(*journal[1].Request.Path).To(Equal("/SpectoLabs/hoverfly"))
+
+				Expect(*journal[2].Request.Destination).To(Equal("specto.io"))
+				Expect(*journal[2].Request.Path).To(Equal("/"))
+			})
+
+			It("should display the mode each request was in", func() {
+				hoverfly.SetMode("simulate")
+				hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+
+				hoverfly.SetMode("capture")
+				hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+
+				req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				res := functional_tests.DoRequest(req)
+
+				Expect(res.StatusCode).To(Equal(200))
+
+				responseJson, err := ioutil.ReadAll(res.Body)
+				Expect(err).To(BeNil())
+
+				var journal []v2.JournalEntryView
+
+				err = json.Unmarshal(responseJson, &journal)
+				Expect(err).To(BeNil())
+
+				Expect(journal).To(HaveLen(2))
+
+				Expect(journal[0].Mode).To(Equal("simulate"))
+				Expect(journal[1].Mode).To(Equal("capture"))
+			})
+		})
+
+		Context("DELETE", func() {
+			It("should delete journal entries", func() {
+				hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+				hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+
+				req := sling.New().Delete("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				functional_tests.DoRequest(req)
+
+				req = sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				res := functional_tests.DoRequest(req)
+
+				Expect(res.StatusCode).To(Equal(200))
+
+				responseJson, err := ioutil.ReadAll(res.Body)
+				Expect(err).To(BeNil())
+
+				var journal []v2.JournalEntryView
+
+				err = json.Unmarshal(responseJson, &journal)
+				Expect(err).To(BeNil())
+
+				Expect(journal).To(HaveLen(0))
+			})
+		})
 	})
 
-	AfterEach(func() {
-		hoverfly.Stop()
-	})
+	Context("With journal disabled", func() {
 
-	Context("GET", func() {
-
-		It("should display an empty journal", func() {
-			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
-			res := functional_tests.DoRequest(req)
-
-			Expect(res.StatusCode).To(Equal(200))
-
-			responseJson, err := ioutil.ReadAll(res.Body)
-			Expect(err).To(BeNil())
-
-			var journal []v2.JournalEntryView
-
-			err = json.Unmarshal(responseJson, &journal)
-			Expect(err).To(BeNil())
-
-			Expect(journal).To(HaveLen(0))
+		BeforeEach(func() {
+			hoverfly = functional_tests.NewHoverfly()
+			hoverfly.Start("-journal=false")
 		})
 
-		It("should display one item in the journal", func() {
-			hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
-
-			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
-			res := functional_tests.DoRequest(req)
-
-			Expect(res.StatusCode).To(Equal(200))
-
-			responseJson, err := ioutil.ReadAll(res.Body)
-			Expect(err).To(BeNil())
-
-			var journal []v2.JournalEntryView
-
-			err = json.Unmarshal(responseJson, &journal)
-			Expect(err).To(BeNil())
-
-			Expect(journal).To(HaveLen(1))
-
-			Expect(*journal[0].Request.Scheme).To(Equal("http"))
-			Expect(*journal[0].Request.Method).To(Equal("GET"))
-			Expect(*journal[0].Request.Destination).To(Equal("hoverfly.io"))
-			Expect(*journal[0].Request.Path).To(Equal("/"))
-			Expect(*journal[0].Request.Query).To(Equal(""))
-			Expect(journal[0].Request.Headers["Accept-Encoding"]).To(ContainElement("gzip"))
-			Expect(journal[0].Request.Headers["User-Agent"]).To(ContainElement("Go-http-client/1.1"))
-
-			Expect(journal[0].Response.Status).To(Equal(502))
-			Expect(journal[0].Response.Body).To(Equal("Hoverfly Error!\n\nThere was an error when matching\n\nGot error: Could not find a match for request, create or record a valid matcher first!"))
-			Expect(journal[0].Response.Headers["Content-Type"]).To(ContainElement("text/plain"))
-
-			Expect(journal[0].Latency).To(BeNumerically("<", 1))
-			Expect(journal[0].Mode).To(Equal("simulate"))
+		AfterEach(func() {
+			hoverfly.Stop()
 		})
 
-		It("should display multiple items in the journal", func() {
-			hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
-			hoverfly.Proxy(sling.New().Get("http://github.com/SpectoLabs/hoverfly"))
-			hoverfly.Proxy(sling.New().Get("http://specto.io"))
+		Context("GET", func() {
 
-			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
-			res := functional_tests.DoRequest(req)
+			It("should return an error", func() {
+				req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				res := functional_tests.DoRequest(req)
 
-			Expect(res.StatusCode).To(Equal(200))
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 
-			responseJson, err := ioutil.ReadAll(res.Body)
-			Expect(err).To(BeNil())
+				responseJson, err := ioutil.ReadAll(res.Body)
+				Expect(err).To(BeNil())
 
-			var journal []v2.JournalEntryView
+				var errorView handlers.ErrorView
 
-			err = json.Unmarshal(responseJson, &journal)
-			Expect(err).To(BeNil())
+				err = json.Unmarshal(responseJson, &errorView)
+				Expect(err).To(BeNil())
 
-			Expect(journal).To(HaveLen(3))
-
-			Expect(*journal[0].Request.Destination).To(Equal("hoverfly.io"))
-			Expect(*journal[0].Request.Path).To(Equal("/"))
-
-			Expect(*journal[1].Request.Destination).To(Equal("github.com"))
-			Expect(*journal[1].Request.Path).To(Equal("/SpectoLabs/hoverfly"))
-
-			Expect(*journal[2].Request.Destination).To(Equal("specto.io"))
-			Expect(*journal[2].Request.Path).To(Equal("/"))
+				Expect(errorView.Error).To(Equal("No journal set"))
+			})
 		})
 
-		It("should display the mode each request was in", func() {
-			hoverfly.SetMode("simulate")
-			hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+		Context("DELETE", func() {
 
-			hoverfly.SetMode("capture")
-			hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+			It("should return an error", func() {
+				req := sling.New().Delete("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				res := functional_tests.DoRequest(req)
 
-			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
-			res := functional_tests.DoRequest(req)
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 
-			Expect(res.StatusCode).To(Equal(200))
+				responseJson, err := ioutil.ReadAll(res.Body)
+				Expect(err).To(BeNil())
 
-			responseJson, err := ioutil.ReadAll(res.Body)
-			Expect(err).To(BeNil())
+				var errorView handlers.ErrorView
 
-			var journal []v2.JournalEntryView
+				err = json.Unmarshal(responseJson, &errorView)
+				Expect(err).To(BeNil())
 
-			err = json.Unmarshal(responseJson, &journal)
-			Expect(err).To(BeNil())
-
-			Expect(journal).To(HaveLen(2))
-
-			Expect(journal[0].Mode).To(Equal("simulate"))
-			Expect(journal[1].Mode).To(Equal("capture"))
-		})
-	})
-
-	Context("DELETE", func() {
-		It("should delete journal entries", func() {
-			hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
-			hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
-
-			req := sling.New().Delete("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
-			functional_tests.DoRequest(req)
-
-			req = sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
-			res := functional_tests.DoRequest(req)
-
-			Expect(res.StatusCode).To(Equal(200))
-
-			responseJson, err := ioutil.ReadAll(res.Body)
-			Expect(err).To(BeNil())
-
-			var journal []v2.JournalEntryView
-
-			err = json.Unmarshal(responseJson, &journal)
-			Expect(err).To(BeNil())
-
-			Expect(journal).To(HaveLen(0))
+				Expect(errorView.Error).To(Equal("No journal set"))
+			})
 		})
 	})
 })

--- a/functional-tests/core/ft_api_v2_journal_test.go
+++ b/functional-tests/core/ft_api_v2_journal_test.go
@@ -135,4 +135,29 @@ var _ = Describe("/api/v2/journal", func() {
 			Expect(journal[1].Mode).To(Equal("capture"))
 		})
 	})
+
+	Context("DELETE", func() {
+		It("should delete journal entries", func() {
+			hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+			hoverfly.Proxy(sling.New().Get("http://localhost:" + hoverfly.GetAdminPort()))
+
+			req := sling.New().Delete("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+			functional_tests.DoRequest(req)
+
+			req = sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+			res := functional_tests.DoRequest(req)
+
+			Expect(res.StatusCode).To(Equal(200))
+
+			responseJson, err := ioutil.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			var journal []v2.JournalEntryView
+
+			err = json.Unmarshal(responseJson, &journal)
+			Expect(err).To(BeNil())
+
+			Expect(journal).To(HaveLen(0))
+		})
+	})
 })

--- a/functional-tests/core/ft_api_v2_journal_test.go
+++ b/functional-tests/core/ft_api_v2_journal_test.go
@@ -217,4 +217,40 @@ var _ = Describe("/api/v2/journal", func() {
 			})
 		})
 	})
+
+	Context("with -journal-size=100", func() {
+
+		BeforeEach(func() {
+			hoverfly = functional_tests.NewHoverfly()
+			hoverfly.Start("-journal-size=100")
+		})
+
+		AfterEach(func() {
+			hoverfly.Stop()
+		})
+
+		Context("GET", func() {
+
+			It("should not exceed size", func() {
+				for i := 0; i < 111; i++ {
+					hoverfly.Proxy(sling.New().Get("http://hoverfly.io"))
+				}
+
+				req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/journal")
+				res := functional_tests.DoRequest(req)
+
+				Expect(res.StatusCode).To(Equal(200))
+
+				responseJson, err := ioutil.ReadAll(res.Body)
+				Expect(err).To(BeNil())
+
+				var journal []v2.JournalEntryView
+
+				err = json.Unmarshal(responseJson, &journal)
+				Expect(err).To(BeNil())
+
+				Expect(journal).To(HaveLen(100))
+			})
+		})
+	})
 })


### PR DESCRIPTION
This journal will store all requests received via the proxy port along with the corresponding response served. Each of these pairs comes with meta data including the mode Hoverfly was in, the datetime that the request was received and how long Hoverfly took to process.

There is a new API endpoint for viewing the journal which can be found at `GET /api/v2/journal`. The journal can be deleted by calling `DELETE /api/v2/journal`.

To prevent growing memory usage, the journal is limited to storing only 1000 transactions. This limit can be changed by using the new `-journal-size` flag on Hoverfly.

The journal can be completely disabled by providing the new `-journal=false` flag on Hoverfly.