### PR TITLE
Miss caching

### DIFF
--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -251,25 +251,24 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 	cachedResponse, cacheErr := hf.CacheMatcher.GetCachedResponse(&requestDetails)
 	if cacheErr == nil && cachedResponse.MatchingPair == nil {
 		return nil, matching.MissedError(cachedResponse.ClosestMiss)
-	} else if cacheErr == nil && !cachedResponse.HeaderMatch {
+	} else if cacheErr == nil {
 		return &cachedResponse.MatchingPair.Response, nil
 	}
 
 	var pair *models.RequestMatcherResponsePair
-	var err error
-	var closestMiss *models.ClosestMiss
+	var err * models.MatchError
 
 	mode := (hf.modeMap[modes.Simulate]).(*modes.SimulateMode)
 
 	strongestMatch := strings.ToLower(mode.MatchingStrategy) == "strongest"
 
 	if strongestMatch {
-		pair, closestMiss, err = matching.StrongestMatchRequestMatcher(requestDetails, hf.Cfg.Webserver, hf.Simulation)
+		pair, err = matching.StrongestMatchRequestMatcher(requestDetails, hf.Cfg.Webserver, hf.Simulation)
 	} else {
 		pair, err = matching.FirstMatchRequestMatcher(requestDetails, hf.Cfg.Webserver, hf.Simulation)
 	}
 
-	hf.CacheMatcher.SaveRequestMatcherResponsePair(requestDetails, pair, closestMiss)
+	hf.CacheMatcher.SaveRequestMatcherResponsePair(requestDetails, pair, err)
 
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -280,7 +279,7 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 			"method":      requestDetails.Method,
 		}).Warn("Failed to find matching request from simulation")
 
-		return nil, matching.MissedError(closestMiss)
+		return nil, matching.MissedError(err.ClosestMiss)
 	}
 
 	return &pair.Response, nil

--- a/core/matching/header_matcher.go
+++ b/core/matching/header_matcher.go
@@ -6,9 +6,9 @@ import (
 	glob "github.com/ryanuber/go-glob"
 )
 
-func CountlessHeaderMatcher(matchingHeaders, toMatch map[string][]string) * FieldMatch {
+func CountlessHeaderMatcher(requestMatcherHeaders, toMatch map[string][]string) * FieldMatch {
 
-	for matcherHeaderKey, matcherHeaderValues := range matchingHeaders {
+	for matcherHeaderKey, matcherHeaderValues := range requestMatcherHeaders {
 
 		// Make everything lowercase, as headers are case insensitive
 		for requestHeaderKey, requestHeaderValues := range toMatch {
@@ -37,12 +37,12 @@ func CountlessHeaderMatcher(matchingHeaders, toMatch map[string][]string) * Fiel
 	return FieldMatchWithNoScore(true)
 }
 
-func CountingHeaderMatcher(matchingHeaders, toMatch map[string][]string) * FieldMatch {
+func CountingHeaderMatcher(requestMatcherHeaders, toMatch map[string][]string) * FieldMatch {
 
 	matched := true
 	var matchScore int
 
-	for matcherHeaderKey, matcherHeaderValues := range matchingHeaders {
+	for matcherHeaderKey, matcherHeaderValues := range requestMatcherHeaders {
 
 		// Make everything lowercase, as headers are case insensitive
 		for requestHeaderKey, requestHeaderValues := range toMatch {

--- a/core/matching/header_matcher_test.go
+++ b/core/matching/header_matcher_test.go
@@ -189,7 +189,7 @@ func Test_CountingHeaderMatcher_CountsMatches_WhenThereIsAMatch(t *testing.T) {
 			"header1": {"val1", "val2"},
 		},
 		map[string][]string{
-			"header1": {"val1", "val2"},
+			"header1":     {"val1", "val2"},
 			"extraHeader": {"extraHeader1", "extraHeader2"},
 		})
 
@@ -202,8 +202,8 @@ func Test_CountingHeaderMatcher_CountsMatches_WhenThereIsAMatch(t *testing.T) {
 			"header2": {"val3"},
 		},
 		map[string][]string{
-			"header1": {"val1", "val2"},
-			"header2": {"val3", "extra"},
+			"header1":     {"val1", "val2"},
+			"header2":     {"val3", "extra"},
 			"extraHeader": {"extraHeader1", "extraHeader2"},
 		})
 
@@ -220,8 +220,8 @@ func Test_CountingHeaderMatcher_CountsMatches_WhenThereIsNoMatch(t *testing.T) {
 			"header2": {"val3", "nomatch"},
 		},
 		map[string][]string{
-			"header1": {"val1", "val2"},
-			"header2": {"val3", "extra"},
+			"header1":     {"val1", "val2"},
+			"header2":     {"val3", "extra"},
 			"extraHeader": {"extraHeader1", "extraHeader2"},
 		})
 

--- a/core/matching/strongest_request_matcher_test.go
+++ b/core/matching/strongest_request_matcher_test.go
@@ -27,7 +27,7 @@ func Test_ClosestRequestMatcherRequestMatcher_EmptyRequestMatchersShouldMatchOnA
 			"sdv": {"ascd"},
 		},
 	}
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result).ToNot(BeNil())
 	Expect(result.Response.Body).To(Equal("request matched"))
@@ -50,7 +50,7 @@ func Test_ClosestRequestMatcherRequestMatcher_RequestMatchersShouldMatchOnBody(t
 	r := models.RequestDetails{
 		Body: "body",
 	}
-	result, _, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 	Expect(err).To(BeNil())
 
 	Expect(result.Response.Body).To(Equal("request matched"))
@@ -82,7 +82,7 @@ func Test_ClosestRequestMatcherRequestMatcher_ReturnResponseWhenAllHeadersMatch(
 		},
 	}
 
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result.Response.Body).To(Equal("request matched"))
 }
@@ -112,7 +112,7 @@ func Test_ClosestRequestMatcherRequestMatcher_ReturnNilWhenOneHeaderNotPresentIn
 		},
 	}
 
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result).To(BeNil())
 }
@@ -142,7 +142,7 @@ func Test_ClosestRequestMatcherRequestMatcher_ReturnNilWhenOneHeaderValueDiffere
 			"header2": {"different"},
 		},
 	}
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result).To(BeNil())
 }
@@ -173,7 +173,7 @@ func Test_ClosestRequestMatcherRequestMatcher_ReturnResponseWithMultiValuedHeade
 			"header2": {"val2"},
 		},
 	}
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result.Response.Body).To(Equal("request matched"))
 }
@@ -204,7 +204,7 @@ func Test_ClosestRequestMatcherRequestMatcher_ReturnNilWithDifferentMultiValuedH
 		},
 	}
 
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result).To(BeNil())
 }
@@ -253,7 +253,7 @@ func Test_ClosestRequestMatcherRequestMatcher_EndpointMatchWithHeaders(t *testin
 			"header2": {"val2"},
 		},
 	}
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result.Response.Body).To(Equal("request matched"))
 }
@@ -303,7 +303,7 @@ func Test_ClosestRequestMatcherRequestMatcher_EndpointMismatchWithHeadersReturns
 		},
 	}
 
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result).To(BeNil())
 }
@@ -340,7 +340,7 @@ func Test_ClosestRequestMatcherRequestMatcher_AbleToMatchAnEmptyPathInAReasonabl
 		Destination: "testhost.com",
 		Query:       "q=test",
 	}
-	result, _, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result.Response.Body).To(Equal("request matched"))
 
@@ -351,7 +351,7 @@ func Test_ClosestRequestMatcherRequestMatcher_AbleToMatchAnEmptyPathInAReasonabl
 		Query:       "q=test",
 	}
 
-	result, _, _ = matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, _ = matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(result).To(BeNil())
 }
@@ -376,7 +376,7 @@ func Test_ClosestRequestMatcherRequestMatcher_RequestMatchersCanUseGlobsAndBeMat
 		Path:        "/api/1",
 	}
 
-	response, _, err := matching.StrongestMatchRequestMatcher(request, false, simulation)
+	response, err := matching.StrongestMatchRequestMatcher(request, false, simulation)
 	Expect(err).To(BeNil())
 
 	Expect(response.Response.Body).To(Equal("request matched"))
@@ -403,7 +403,7 @@ func Test_ClosestRequestMatcherRequestMatcher_RequestMatchersCanUseGlobsOnScheme
 		Path:        "/api/1",
 	}
 
-	response, _, err := matching.StrongestMatchRequestMatcher(request, false, simulation)
+	response, err := matching.StrongestMatchRequestMatcher(request, false, simulation)
 	Expect(err).To(BeNil())
 
 	Expect(response.Response.Body).To(Equal("request matched"))
@@ -432,7 +432,7 @@ func Test_ClosestRequestMatcherRequestMatcher_RequestMatchersCanUseGlobsOnHeader
 		},
 	}
 
-	response, _, err := matching.StrongestMatchRequestMatcher(request, false, simulation)
+	response, err := matching.StrongestMatchRequestMatcher(request, false, simulation)
 	Expect(err).To(BeNil())
 
 	Expect(response.Response.Body).To(Equal("request matched"))
@@ -491,16 +491,16 @@ func Test_ShouldReturnClosestMissIfMatchIsNotFound(t *testing.T) {
 		Path: "nomatch",
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).ToNot(BeNil())
 	Expect(result).To(BeNil())
-	Expect(closestMiss).ToNot(BeNil())
-	Expect(*closestMiss.RequestMatcher.Body.ExactMatch).To(Equal(`body`))
-	Expect(*closestMiss.RequestMatcher.Body.GlobMatch).To(Equal(`bod*`))
-	Expect(*closestMiss.RequestMatcher.Path.ExactMatch).To(Equal(`path`))
-	Expect(closestMiss.Response.Body).To(Equal(`two`))
-	Expect(closestMiss.RequestDetails.Body).To(Equal(`body`))
+	Expect(err.ClosestMiss).ToNot(BeNil())
+	Expect(*err.ClosestMiss.RequestMatcher.Body.ExactMatch).To(Equal(`body`))
+	Expect(*err.ClosestMiss.RequestMatcher.Body.GlobMatch).To(Equal(`bod*`))
+	Expect(*err.ClosestMiss.RequestMatcher.Path.ExactMatch).To(Equal(`path`))
+	Expect(err.ClosestMiss.Response.Body).To(Equal(`two`))
+	Expect(err.ClosestMiss.RequestDetails.Body).To(Equal(`body`))
 }
 
 func Test_ShouldReturnClosestMissIfMatchIsNotFoundAgain(t *testing.T) {
@@ -559,15 +559,15 @@ func Test_ShouldReturnClosestMissIfMatchIsNotFoundAgain(t *testing.T) {
 		Method: "GET",
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).ToNot(BeNil())
 	Expect(result).To(BeNil())
-	Expect(closestMiss).ToNot(BeNil())
-	Expect(*closestMiss.RequestMatcher.Body.RegexMatch).To(Equal(`.*`))
-	Expect(*closestMiss.RequestMatcher.Path.ExactMatch).To(Equal(`miss`))
-	Expect(*closestMiss.RequestMatcher.Method.ExactMatch).To(Equal(`GET`))
-	Expect(closestMiss.Response.Body).To(Equal(`one`))
+	Expect(err.ClosestMiss).ToNot(BeNil())
+	Expect(*err.ClosestMiss.RequestMatcher.Body.RegexMatch).To(Equal(`.*`))
+	Expect(*err.ClosestMiss.RequestMatcher.Path.ExactMatch).To(Equal(`miss`))
+	Expect(*err.ClosestMiss.RequestMatcher.Method.ExactMatch).To(Equal(`GET`))
+	Expect(err.ClosestMiss.Response.Body).To(Equal(`one`))
 }
 
 func Test_ShouldNotReturnClosestMissWhenThereIsAMatch(t *testing.T) {
@@ -608,12 +608,196 @@ func Test_ShouldNotReturnClosestMissWhenThereIsAMatch(t *testing.T) {
 		Method: "GET",
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).To(BeNil())
 	Expect(result).ToNot(BeNil())
-	Expect(closestMiss).To(BeNil())
-	Expect(result).ToNot(BeNil())
+}
+
+func Test__ShouldStoreIfMatchedOnEverythingApartFromHeadersAtLeastOnce(t *testing.T) {
+	RegisterTestingT(t)
+
+	simulation := models.NewSimulation()
+
+	simulation.MatchingPairs = append(simulation.MatchingPairs, models.RequestMatcherResponsePair{
+		RequestMatcher: models.RequestMatcher{
+			Method: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("POST"),
+			},
+			Body: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("body"),
+			},
+			Scheme: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("http"),
+			},
+			Query: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("?foo=bar"),
+			},
+			Path: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("/foo"),
+			},
+			Destination: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("www.test.com"),
+			},
+			Headers: map[string][]string {
+				"foo" : {"bar"},
+			},
+		},
+		Response: testResponse,
+	})
+
+	simulation.MatchingPairs = append(simulation.MatchingPairs, models.RequestMatcherResponsePair{
+		RequestMatcher: models.RequestMatcher{
+			Method: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("GET"),
+			},
+		},
+		Response: testResponse,
+	})
+
+	r := models.RequestDetails{
+		Method:      "POST",
+		Destination: "www.test.com",
+		Query:       "?foo=bar",
+		Scheme: "http",
+		Body: "body",
+		Path: "/foo",
+		Headers: map[string][]string {
+			"miss" : {"me"},
+		},
+	}
+
+	_, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+
+	Expect(err).ToNot(BeNil())
+	Expect(err.MatchedOnAllButHeadersAtLeastOnce).To(BeTrue())
+}
+
+func Test__ShouldStoreIfMatchedOnEverythingApartFromHeadersZeroTimes(t *testing.T) {
+	RegisterTestingT(t)
+
+	simulation := models.NewSimulation()
+
+	simulation.MatchingPairs = append(simulation.MatchingPairs, models.RequestMatcherResponsePair{
+		RequestMatcher: models.RequestMatcher{
+			Method: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("POST"),
+			},
+			Body: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("body"),
+			},
+			Scheme: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("http"),
+			},
+			Query: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("?foo=bar"),
+			},
+			Path: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("/foo"),
+			},
+			Destination: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("www.test.com"),
+			},
+			Headers: map[string][]string {
+				"foo" : {"bar"},
+			},
+		},
+		Response: testResponse,
+	})
+
+	simulation.MatchingPairs = append(simulation.MatchingPairs, models.RequestMatcherResponsePair{
+		RequestMatcher: models.RequestMatcher{
+			Method: &models.RequestFieldMatchers{
+				ExactMatch: StringToPointer("GET"),
+			},
+		},
+		Response: testResponse,
+	})
+
+	r := models.RequestDetails{
+		Method:      "MISS",
+		Destination: "www.test.com",
+		Query:       "?foo=bar",
+		Scheme: "http",
+		Body: "body",
+		Path: "/foo",
+		Headers: map[string][]string {
+			"miss" : {"me"},
+		},
+	}
+
+	_, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+
+	Expect(err).ToNot(BeNil())
+	Expect(err.MatchedOnAllButHeadersAtLeastOnce).To(BeFalse())
+
+	r = models.RequestDetails{
+		Method:      "POST",
+		Destination: "miss",
+		Query:       "?foo=bar",
+		Scheme: "http",
+		Body: "body",
+		Path: "/foo",
+		Headers: map[string][]string {
+			"miss" : {"me"},
+		},
+	}
+
+	_, err = matching.StrongestMatchRequestMatcher(r, false, simulation)
+
+	Expect(err).ToNot(BeNil())
+	Expect(err.MatchedOnAllButHeadersAtLeastOnce).To(BeFalse())
+
+	r = models.RequestDetails{
+		Method:      "POST",
+		Destination: "www.test.com",
+		Query:       "miss",
+		Scheme: "http",
+		Body: "body",
+		Path: "/foo",
+		Headers: map[string][]string {
+			"miss" : {"me"},
+		},
+	}
+
+	_, err = matching.StrongestMatchRequestMatcher(r, false, simulation)
+
+	Expect(err).ToNot(BeNil())
+	Expect(err.MatchedOnAllButHeadersAtLeastOnce).To(BeFalse())
+
+	r = models.RequestDetails{
+		Method:      "POST",
+		Destination: "www.test.com",
+		Query:       "?foo=bar",
+		Scheme: "http",
+		Body: "miss",
+		Path: "/foo",
+		Headers: map[string][]string {
+			"miss" : {"me"},
+		},
+	}
+
+	_, err = matching.StrongestMatchRequestMatcher(r, false, simulation)
+
+	Expect(err).ToNot(BeNil())
+	Expect(err.MatchedOnAllButHeadersAtLeastOnce).To(BeFalse())
+
+	r = models.RequestDetails{
+		Method:      "POST",
+		Destination: "www.test.com",
+		Query:       "?foo=bar",
+		Scheme: "http",
+		Body: "body",
+		Path: "miss",
+		Headers: map[string][]string {
+			"miss" : {"me"},
+		},
+	}
+
+	_, err = matching.StrongestMatchRequestMatcher(r, false, simulation)
+
+	Expect(err).ToNot(BeNil())
+	Expect(err.MatchedOnAllButHeadersAtLeastOnce).To(BeFalse())
 }
 
 func Test_ShouldReturnStrongestMatchWhenThereAreMultipleMatches(t *testing.T) {
@@ -671,10 +855,9 @@ func Test_ShouldReturnStrongestMatchWhenThereAreMultipleMatches(t *testing.T) {
 		Method: "GET",
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).To(BeNil())
-	Expect(closestMiss).To(BeNil())
 	Expect(result).ToNot(BeNil())
 	Expect(result.Response.Body).To(Equal("two"))
 }
@@ -735,10 +918,9 @@ func Test_ShouldReturnStrongestMatchWhenThereAreMultipleMatchesAgain(t *testing.
 		Method: "GET",
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).To(BeNil())
-	Expect(closestMiss).To(BeNil())
 	Expect(result).ToNot(BeNil())
 	Expect(result.Response.Body).To(Equal("one"))
 }
@@ -781,9 +963,9 @@ func Test_ShouldSetClosestMissBackToNilIfThereIsAMatchLaterOn(t *testing.T) {
 		Method: "POST",
 	}
 
-	_, closestMiss, _ := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	_, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
-	Expect(closestMiss).To(BeNil())
+	Expect(err).To(BeNil())
 }
 
 func Test_ShouldIncludeHeadersInCalculationForStrongestMatch(t *testing.T) {
@@ -836,10 +1018,9 @@ func Test_ShouldIncludeHeadersInCalculationForStrongestMatch(t *testing.T) {
 		},
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).To(BeNil())
-	Expect(closestMiss).To(BeNil())
 	Expect(result).ToNot(BeNil())
 	Expect(result.Response.Body).To(Equal("one"))
 }
@@ -894,12 +1075,12 @@ func Test_ShouldIncludeHeadersInCalculationForClosestMiss(t *testing.T) {
 		},
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).ToNot(BeNil())
 	Expect(result).To(BeNil())
-	Expect(closestMiss).ToNot(BeNil())
-	Expect(closestMiss.Response.Body).To(Equal("one"))
+	Expect(err.ClosestMiss).ToNot(BeNil())
+	Expect(err.ClosestMiss.Response.Body).To(Equal("one"))
 }
 
 func Test_ShouldReturnFieldsMissedInClosestMiss(t *testing.T) {
@@ -946,13 +1127,13 @@ func Test_ShouldReturnFieldsMissedInClosestMiss(t *testing.T) {
 		},
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).ToNot(BeNil())
 	Expect(result).To(BeNil())
-	Expect(closestMiss).ToNot(BeNil())
+	Expect(err.ClosestMiss).ToNot(BeNil())
 	//TODO: Scheme matching?
-	Expect(closestMiss.MissedFields).To(ConsistOf(`body`, `path`, `query`))
+	Expect(err.ClosestMiss.MissedFields).To(ConsistOf(`body`, `path`, `query`))
 }
 
 func Test_ShouldReturnFieldsMissedInClosestMissAgain(t *testing.T) {
@@ -996,13 +1177,13 @@ func Test_ShouldReturnFieldsMissedInClosestMissAgain(t *testing.T) {
 		Query: "hit",
 	}
 
-	result, closestMiss, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
+	result, err := matching.StrongestMatchRequestMatcher(r, false, simulation)
 
 	Expect(err).ToNot(BeNil())
 	Expect(result).To(BeNil())
-	Expect(closestMiss).ToNot(BeNil())
+	Expect(err.ClosestMiss).ToNot(BeNil())
 	//TODO: Scheme matching?
-	Expect(closestMiss.MissedFields).To(ConsistOf(`method`, `destination`, `headers`))
+	Expect(err.ClosestMiss.MissedFields).To(ConsistOf(`method`, `destination`, `headers`))
 }
 
 func Test_ShouldReturnMessageForClosestMiss(t *testing.T) {

--- a/core/models/cached_response.go
+++ b/core/models/cached_response.go
@@ -9,7 +9,6 @@ type CachedResponse struct {
 	Request      RequestDetails
 	MatchingPair *RequestMatcherResponsePair
 	ClosestMiss  *ClosestMiss
-	HeaderMatch  bool
 }
 
 func (this CachedResponse) Encode() ([]byte, error) {

--- a/core/models/request_matcher.go
+++ b/core/models/request_matcher.go
@@ -120,6 +120,10 @@ type RequestMatcher struct {
 	Headers     map[string][]string
 }
 
+func (this RequestMatcher) IncludesHeaderMatching() bool {
+	return this.Headers != nil && len(this.Headers) > 0
+}
+
 func (this RequestMatcher) BuildRequestDetailsFromExactMatches() *RequestDetails {
 	if this.Body == nil || this.Body.ExactMatch == nil ||
 		this.Destination == nil || this.Destination.ExactMatch == nil ||
@@ -139,5 +143,29 @@ func (this RequestMatcher) BuildRequestDetailsFromExactMatches() *RequestDetails
 		Query:       *this.Query.ExactMatch,
 		Scheme:      *this.Scheme.ExactMatch,
 	}
+}
 
+type MatchError struct {
+	ClosestMiss                       *ClosestMiss
+	error                             string
+	MatchedOnAllButHeadersAtLeastOnce bool
+}
+
+func NewMatchErrorWithClosestMiss(closestMiss * ClosestMiss, error string, matchedOnAllButHeadersAtLeastOnce bool) * MatchError {
+	return &MatchError{
+		ClosestMiss:                       closestMiss,
+		error:                             error,
+		MatchedOnAllButHeadersAtLeastOnce: matchedOnAllButHeadersAtLeastOnce,
+	}
+}
+
+func NewMatchError(error string, matchedOnAllButHeadersAtLeastOnce bool) * MatchError {
+	return &MatchError{
+		error:                             error,
+		MatchedOnAllButHeadersAtLeastOnce: matchedOnAllButHeadersAtLeastOnce,
+	}
+}
+
+func (this MatchError) Error() string {
+	return this.error
 }

--- a/functional-tests/core/ft_cache_test.go
+++ b/functional-tests/core/ft_cache_test.go
@@ -1,7 +1,6 @@
 package hoverfly_test
 
 import (
-	"encoding/json"
 	"io/ioutil"
 
 	"github.com/SpectoLabs/hoverfly/functional-tests"
@@ -43,7 +42,7 @@ var _ = Describe("Hoverfly cache", func() {
 	})
 
 	It("should preload the cache with exact match request matcher when put into simulate mode", func() {
-		hoverfly.ImportSimulation(functional_tests.JsonPayload)
+		hoverfly.ImportSimulation(functional_tests.JsonPayloadPreloadCache)
 
 		hoverfly.SetMode("simulate")
 
@@ -62,42 +61,34 @@ var _ = Describe("Hoverfly cache", func() {
 		Expect(cacheView.Cache).To(HaveLen(0))
 	})
 
-	It("should not stop matching on headers by caching the same request twice with different headers", func() {
+	It("should not cache hits when matching on headers", func() {
 		hoverfly.ImportSimulation(functional_tests.ExactMatchPayload)
 
 		hoverfly.SetMode("simulate")
 
-		req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/cache")
+		req := sling.New().Get("http://test-server.com/path1").Add("Header", "value1")
 
-		res := functional_tests.DoRequest(req)
+		res := hoverfly.Proxy(req)
 		Expect(res.StatusCode).To(Equal(200))
 
 		responseBytes, err := ioutil.ReadAll(res.Body)
 		Expect(err).To(BeNil())
 
-		var responseJson map[string]interface{}
-		json.Unmarshal(responseBytes, &responseJson)
-
-		Expect(responseJson["cache"]).To(HaveLen(1))
-
-		req = sling.New().Get("http://test-server.com/path1").Add("Header", "value1")
-
-		res = hoverfly.Proxy(req)
-		Expect(res.StatusCode).To(Equal(200))
-
-		responseBytes, err = ioutil.ReadAll(res.Body)
-		Expect(err).To(BeNil())
-
 		Expect(responseBytes).To(Equal([]byte("exact match 1")))
 
-		req = sling.New().Get("http://test-server.com/path1").Add("Header", "value2")
+		Expect(hoverfly.GetCache().Cache).To(BeEmpty())
+	})
 
-		res = hoverfly.Proxy(req)
-		Expect(res.StatusCode).To(Equal(200))
+	It("should not cache misses when matched on all fields but headers", func() {
+		hoverfly.ImportSimulation(functional_tests.ExactMatchPayload)
 
-		responseBytes, err = ioutil.ReadAll(res.Body)
-		Expect(err).To(BeNil())
+		hoverfly.SetMode("simulate")
 
-		Expect(responseBytes).To(Equal([]byte("exact match 2")))
+		req := sling.New().Get("http://test-server.com/path1").Add("Header", "miss")
+
+		res := hoverfly.Proxy(req)
+		Expect(res.StatusCode).To(Equal(502))
+
+		Expect(hoverfly.GetCache().Cache).To(BeEmpty())
 	})
 })

--- a/functional-tests/core/ft_simulate_mode_test.go
+++ b/functional-tests/core/ft_simulate_mode_test.go
@@ -249,4 +249,62 @@ Which if hit would have given the following response:
 }`
 		Expect(string(body)).To(Equal(expected))
 	})
+
+	It("should no longer cause issue #607", func() {
+		hoverfly.ImportSimulation(functional_tests.JsonPayload)
+
+		// Match
+		i := sling.New().Get("https://domain.com/billing/v1/servicequotes/123456?saleschannel=RETAIL")
+		i.Set("Accept", "application/json")
+		i.Set("Activityid", "ChangeMSISDN_CR_PushtoBill(Get)-200")
+		i.Set("Applicationid", "ACUI")
+		i.Set("Authorization", "Bearer token")
+		i.Set("Cache-Control", "no-cache")
+		i.Set("Channelid", "RETAIL")
+		i.Set("Content-Length", "0")
+		i.Set("Content-Type", "application/json")
+		i.Set("Interactionid", "123456787")
+		i.Set("Senderid", "ACUI")
+		i.Set("User-Agent", "curl/7.54.0")
+		i.Set("Workflowid", "CHANGEMSISDN")
+
+		resp := hoverfly.Proxy(i)
+		Expect(resp.StatusCode).To(Equal(200))
+
+		// Miss
+		i = sling.New().Get("https://domain.com/billing/v1/servicequotes/123456?saleschannel=RETAIL")
+		i.Set("Accept", "application/json")
+		i.Set("Activityid", "ChangeMSISDN_Procedural(Get)-200")
+		i.Set("Applicationid", "ACUI")
+		i.Set("Authorization", "Bearer token")
+		i.Set("Cache-Control", "no-cache")
+		i.Set("Channelid", "RETAIL")
+		i.Set("Content-Length", "0")
+		i.Set("Content-Type", "application/json")
+		i.Set("Interactionid", "123456787")
+		i.Set("Senderid", "ACUI")
+		i.Set("User-Agent", "curl/7.54.0")
+		i.Set("Workflowid", "CHANGEMSISDN")
+
+		resp = hoverfly.Proxy(i)
+		Expect(resp.StatusCode).To(Equal(503))
+
+		// Match again
+		i = sling.New().Get("https://domain.com/billing/v1/servicequotes/123456?saleschannel=RETAIL")
+		i.Set("Accept", "application/json")
+		i.Set("Activityid", "ChangeMSISDN_CR_PushtoBill(Get)-200")
+		i.Set("Applicationid", "ACUI")
+		i.Set("Authorization", "Bearer token")
+		i.Set("Cache-Control", "no-cache")
+		i.Set("Channelid", "RETAIL")
+		i.Set("Content-Length", "0")
+		i.Set("Content-Type", "application/json")
+		i.Set("Interactionid", "123456787")
+		i.Set("Senderid", "ACUI")
+		i.Set("User-Agent", "curl/7.54.0")
+		i.Set("Workflowid", "CHANGEMSISDN")
+
+		resp = hoverfly.Proxy(i)
+		Expect(resp.StatusCode).To(Equal(200))
+	})
 })

--- a/functional-tests/testdata.go
+++ b/functional-tests/testdata.go
@@ -96,6 +96,66 @@ var JsonPayload = `{
     }
 }`
 
+var JsonPayloadPreloadCache = `{
+    "data": {
+        "pairs": [
+            {
+                "response": {
+                    "status": 200,
+                    "body": "exact match",
+                    "encodedBody": false,
+                    "headers": {
+                        "Header": [
+                            "value1",
+                            "value2"
+                        ]
+                    }
+                },
+                "request": {
+                    "path": {
+						"exactMatch": "/path1"
+                    },
+                    "method": {
+						"exactMatch": "GET"
+                    },
+                    "destination": {
+						"exactMatch": "test-server.com"
+                    },
+                    "scheme": {
+						"exactMatch": "http"
+                    },
+                    "query": {
+						"exactMatch": ""
+                    },
+                    "body": {
+						"exactMatch": ""
+                    }
+                }
+            },
+            {
+                "response": {
+                    "status": 200,
+                    "body": "destination matched",
+                    "encodedBody": false
+                },
+                "request": {
+                    "destination": {
+                        "exactMatch": "destination-server.com"
+                    }
+                }
+            }
+        ],
+        "globalActions": {
+            "delays": []
+        }
+    },
+    "meta": {
+        "schemaVersion": "v2",
+        "hoverflyVersion": "v0.10.2",
+        "timeExported": "2017-02-23T12:43:48Z"
+    }
+}`
+
 var JsonPayloadWithDelays = `{
     "data": {
         "pairs": [
@@ -801,9 +861,6 @@ var Issue607 = `
 						],
 						"Channelid": [
 							"RETAIL"
-						],
-						"Content-Length": [
-							"0"
 						],
 						"Content-Type": [
 							"application/json"

--- a/functional-tests/testdata.go
+++ b/functional-tests/testdata.go
@@ -736,3 +736,102 @@ var SingleRequestMatcherToResponse = `{
 		"timeExported": "2017-02-23T12:43:48Z"
 	}
 }`
+
+var Issue607 = `
+	{
+	"data": {
+		"pairs": [
+			{
+				"response": {
+					"status": 200,
+					"body": "",
+					"encodedBody": false,
+					"headers": {
+						"Connection": [
+							"keep-alive"
+						],
+						"Content-Type": [
+							"application/json"
+						],
+						"Date": [
+							"Tue, 13 Jun 2017 17:54:51 GMT"
+						],
+						"Hoverfly": [
+							"Was-Here"
+						],
+						"Transfer-Encoding": [
+							"chunked"
+						]
+					}
+				},
+				"request": {
+					"path": {
+						"exactMatch": "/billing/v1/servicequotes/123456"
+					},
+					"method": {
+						"exactMatch": "GET"
+					},
+					"destination": {
+						"exactMatch": "domain.com"
+					},
+					"scheme": {
+						"exactMatch": "https"
+					},
+					"query": {
+						"exactMatch": "saleschannel=RETAIL"
+					},
+					"body": {
+						"jsonMatch": ""
+					},
+					"headers": {
+						"Accept": [
+							"application/json"
+						],
+						"Activityid": [
+							"ChangeMSISDN_CR_PushtoBill(Get)-200"
+						],
+						"Applicationid": [
+							"ACUI"
+						],
+						"Authorization": [
+							"Bearer token"
+						],
+						"Cache-Control": [
+							"no-cache"
+						],
+						"Channelid": [
+							"RETAIL"
+						],
+						"Content-Length": [
+							"0"
+						],
+						"Content-Type": [
+							"application/json"
+						],
+						"Interactionid": [
+							"123456787"
+						],
+						"Senderid": [
+							"ACUI"
+						],
+						"User-Agent": [
+							"curl/7.54.0"
+						],
+						"Workflowid": [
+							"CHANGEMSISDN"
+						]
+					}
+				}
+			}
+		],
+		"globalActions": {
+			"delays": []
+		}
+	},
+	"meta": {
+		"schemaVersion": "v2",
+		"hoverflyVersion": "v0.12.0",
+		"timeExported": "2017-06-13T10:55:12-07:00"
+	}
+}
+`


### PR DESCRIPTION
Whenever there is a miss, if it matched on everything in a matcher apart from headers, then it is no longer cached. This is because the same request with different headers will have the same hash, but needs to be checked against header matchers.

Simplified caching hits by no longer caching hits if there is header matching in the matcher and removing the header field.