### PR TITLE
Added filtering to journal

### DIFF
--- a/core/handlers/v2/journal_handler.go
+++ b/core/handlers/v2/journal_handler.go
@@ -62,7 +62,7 @@ func (this *JournalHandler) Post(response http.ResponseWriter, request *http.Req
 		handlers.WriteErrorResponse(response, err.Error(), http.StatusBadRequest)
 		return
 	} else if journalEntryFilterView.Request == nil {
-		handlers.WriteErrorResponse(response, "Malformed JSON", http.StatusBadRequest)
+		handlers.WriteErrorResponse(response, "No \"request\" object in search parameters", http.StatusBadRequest)
 		return
 	}
 

--- a/core/handlers/v2/journal_handler_test.go
+++ b/core/handlers/v2/journal_handler_test.go
@@ -172,7 +172,7 @@ func Test_JournalHandler_Post_MalformedJson_EmptyRequest(t *testing.T) {
 	errorView, err := unmarshalErrorView(response.Body)
 	Expect(err).To(BeNil())
 
-	Expect(errorView.Error).To(Equal("Malformed JSON"))
+	Expect(errorView.Error).To(Equal("No \"request\" object in search parameters"))
 }
 
 func Test_JournalHandler_Post_JournalError(t *testing.T) {

--- a/core/handlers/v2/views.go
+++ b/core/handlers/v2/views.go
@@ -73,3 +73,7 @@ type JournalEntryView struct {
 	TimeStarted string               `json:"timeStarted"`
 	Latency     time.Duration        `json:"latency"`
 }
+
+type JournalEntryFilterView struct {
+	Request RequestMatcherViewV2 `json:"request"`
+}

--- a/core/handlers/v2/views.go
+++ b/core/handlers/v2/views.go
@@ -75,5 +75,5 @@ type JournalEntryView struct {
 }
 
 type JournalEntryFilterView struct {
-	Request RequestMatcherViewV2 `json:"request"`
+	Request *RequestMatcherViewV2 `json:"request"`
 }

--- a/functional-tests/core/ft_api_v2_journal_test.go
+++ b/functional-tests/core/ft_api_v2_journal_test.go
@@ -206,7 +206,7 @@ var _ = Describe("/api/v2/journal", func() {
 				err = json.Unmarshal(responseJson, &errorView)
 				Expect(err).To(BeNil())
 
-				Expect(errorView.Error).To(Equal("Malformed JSON"))
+				Expect(errorView.Error).To(Equal("No \"request\" object in search parameters"))
 			})
 		})
 


### PR DESCRIPTION
You can now filter the journal by sending a POST request to `/api/v2/journal`. 

```
{
  "request": {
    "destination": {
      "globMatch": "*hoverfly*"
    }
  }
}
```

Currently it will only accept the request field. Though we plan to later support filtering based on other fields available on journal entries.