### PR TITLE
Build master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,23 @@ test:
     - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && make test"
 
 deployment:
+  master:
+    branch: master
+    commands:
+      - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && GIT_TAG_NAME=master-$CIRCLE_BUILD_NUM make build" 
+      - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly && docker build -t spectolabs/hoverfly:master  -f core/Dockerfile ."
+      - "docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS"
+      - "docker push spectolabs/hoverfly:master"
+      - go get github.com/mitchellh/gox
+      - "echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json"
+      - "sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update"
+      - "/opt/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json"
+      - "/opt/google-cloud-sdk/bin/gcloud config set project $GCLOUD_PROJECT"
+      - "GIT_TAG_NAME=master-$CIRCLE_BUILD_NUM SHELL=/bin/bash $GOPATH/src/github.com/SpectoLabs/hoverfly/build-release.sh" 
+      - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly/target && for f in hoverfly_bundle*;do gsutil cp $f gs://hoverfly-master-builds/$(date +%Y%m%d%H%M)/$f; done"
+      - "cd $GOPATH/src/github.com/SpectoLabs/hoverfly/target && for f in hoverfly_bundle*;do gsutil cp $f gs://hoverfly-master-builds/latest/$f; done"
+      - "gsutil -m acl set -R -a public-read gs://hoverfly-master-builds"
+
   release:
     tag: /v[0-9]+(\.[0-9]+)*/
     commands:


### PR DESCRIPTION
On successful master builds, binaries will be published along with a `master` Docker image

[Linux 32 bit](https://storage.googleapis.com/hoverfly-master-builds/latest/hoverfly_bundle_linux_386.zip)
[Linux 64 bit](https://storage.googleapis.com/hoverfly-master-builds/latest/hoverfly_bundle_linux_amd64.zip)
[OSX 64 bit](https://storage.googleapis.com/hoverfly-master-builds/latest/hoverfly_bundle_OSX_amd64.zip)
[Windows 32 bit](https://storage.googleapis.com/hoverfly-master-builds/latest/hoverfly_bundle_windows_386.zip)
[Windows 64 bit](https://storage.googleapis.com/hoverfly-master-builds/latest/hoverfly_bundle_windows_amd64.zip)

[Docker Hub `master` image](https://hub.docker.com/r/spectolabs/hoverfly/tags/)