### PR TITLE
Update middleware.go

### DIFF
--- a/hoverctl/cmd/middleware.go
+++ b/hoverctl/cmd/middleware.go
@@ -61,13 +61,14 @@ configuration will be shown.
 			middlewareScript := strings.Split(middleware.Script, "\n")
 			if verbose || len(middlewareScript) < 5 {
 				fmt.Println("Script: " + middleware.Script)
+			} else {
+				fmt.Println("Script: " + middlewareScript[0] + "\n" +
+					middlewareScript[1] + "\n" +
+					middlewareScript[2] + "\n" +
+					middlewareScript[3] + "\n" +
+					middlewareScript[4] + "\n" +
+					"...")
 			}
-			fmt.Println("Script: " + middlewareScript[0] + "\n" +
-				middlewareScript[1] + "\n" +
-				middlewareScript[2] + "\n" +
-				middlewareScript[3] + "\n" +
-				middlewareScript[4] + "\n" +
-				"...")
 		}
 
 		if middleware.Remote != "" {


### PR DESCRIPTION
When script has less than 5 lines I get this:
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/SpectoLabs/hoverfly/hoverctl/cmd.glob..func13(0xc98de0, 0xc4201415c0, 0x0, 0x4)
	/home/ubuntu/.go_workspace/src/github.com/SpectoLabs/hoverfly/hoverctl/cmd/middleware.go:67 +0x5c9
...