### PR TITLE
Remove './' characters from query if query contains ":"

### DIFF
--- a/core/models/payload.go
+++ b/core/models/payload.go
@@ -94,6 +94,14 @@ func NewRequestDetailsFromHttpRequest(req *http.Request) (RequestDetails, error)
 		Body:        string(reqBody),
 		Headers:     req.Header,
 	}
+
+	for key, value := range requestDetails.Query {
+		if strings.HasPrefix(key, "./") {
+			requestDetails.Query[key[2:]] = value
+			delete(requestDetails.Query, key)
+		}
+	}
+
 	return requestDetails, nil
 }
 

--- a/core/models/payload_test.go
+++ b/core/models/payload_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -223,6 +224,16 @@ func Test_NewRequestDetailsFromHttpRequest_SortsQueryString(t *testing.T) {
 	Expect(requestDetails.Query["a"]).To(ContainElement("a"))
 	Expect(requestDetails.Query["a"]).To(ContainElement("b"))
 	Expect(requestDetails.QueryString()).To(Equal("a=a&a=b"))
+}
+
+func Test_NewRequestDetailsFromHttpRequest_StripsArbitaryGolangColonEscaping(t *testing.T) {
+	RegisterTestingT(t)
+	request, _ := http.NewRequest("GET", "http://test.org/?a=b:c", nil)
+	fmt.Println(request.URL.RawQuery)
+	requestDetails, err := models.NewRequestDetailsFromHttpRequest(request)
+	Expect(err).To(BeNil())
+
+	Expect(requestDetails.Query["a"]).To(ContainElement("b:c"))
 }
 
 func Test_NewRequestDetailsFromHttpRequest_UsesRawPathIfAvailable(t *testing.T) {


### PR DESCRIPTION
If Golang finds a character that needs escaping, it will escape the whole query string, which is unnecessary as we need to forward the query on. 