### PR TITLE
fix(#695): when hoverctl is initialized the custom parameters provided on command line are set

### DIFF
--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -92,6 +92,18 @@ func initConfig() {
 		fmt.Println("Current target: " + target.Name + "\n")
 	}
 
+	if adminPortFlag != 0 {
+		target.AdminPort = adminPortFlag
+	}
+
+	if proxyPortFlag != 0 {
+		target.ProxyPort = proxyPortFlag
+	}
+
+	if hostFlag != "" {
+		target.Host = hostFlag
+	}
+
 	var err error
 	hoverflyDirectory, err = configuration.NewHoverflyDirectory(*config)
 	handleIfError(err)


### PR DESCRIPTION
setting custom `admin-port`, `proxy-port` & `host` to be able to execute:
`hoverctl status --admin-port 12345 --host 10.0.0.1`