### PR TITLE
adding listen-on-host flag to hoverctl

### DIFF
--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -55,6 +55,7 @@ hoverctl configuration file.
 		target.Webserver = len(args) > 0
 		target.CachePath, _ = cmd.Flags().GetString("cache")
 		target.DisableCache, _ = cmd.Flags().GetBool("disable-cache")
+		target.ListenOnHost, _ = cmd.Flags().GetString("listen-on-host")
 
 		target.CertificatePath, _ = cmd.Flags().GetString("certificate")
 		target.KeyPath, _ = cmd.Flags().GetString("key")
@@ -113,6 +114,7 @@ func init() {
 	startCmd.Flags().Bool("disable-tls", false, "Disables TLS verification")
 	startCmd.Flags().String("upstream-proxy", "", "A host for which Hoverfly will proxy its requests to")
 	startCmd.Flags().Bool("https-only", false, "Disables insecure HTTP traffic in Hoverfly")
+	startCmd.Flags().String("listen-on-host", "", "Binds hoverfly listener to a host")
 
 	startCmd.Flags().Bool("auth", false, "Enable authenticiation on Hoverfly")
 	startCmd.Flags().String("username", "", "Username to authenticate Hoverfly")

--- a/hoverctl/configuration/target.go
+++ b/hoverctl/configuration/target.go
@@ -17,6 +17,7 @@ type Target struct {
 	Webserver    bool   `yaml:",omitempty"`
 	CachePath    string `yaml:",omitempty"`
 	DisableCache bool   `yaml:",omitempty"`
+	ListenOnHost string `yaml:",omitempty"`
 
 	CertificatePath string `yaml:",omitempty"`
 	KeyPath         string `yaml:",omitempty"`
@@ -118,6 +119,10 @@ func (this Target) BuildFlags() Flags {
 
 	if this.DisableCache {
 		flags = append(flags, "-disable-cache")
+	}
+
+	if this.ListenOnHost != "" {
+		flags = append(flags, "-listen-on-host="+this.ListenOnHost)
 	}
 
 	if this.CertificatePath != "" {

--- a/hoverctl/configuration/target_test.go
+++ b/hoverctl/configuration/target_test.go
@@ -208,6 +208,17 @@ func Test_Target_BuildFlags_DbTypeSetsTheDbFlag(t *testing.T) {
 	Expect(unit.BuildFlags()[1]).To(Equal("-db-path=cache.db"))
 }
 
+func Test_Target_BuildFlags_ListenOnSetsListenOnHostFlag(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := Target{
+		ListenOnHost: "0.0.0.0",
+	}
+
+	Expect(unit.BuildFlags()).To(HaveLen(1))
+	Expect(unit.BuildFlags()[0]).To(Equal("-listen-on-host=0.0.0.0"))
+}
+
 func Test_Target_BuildFlags_CertificateSetsCertFlag(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/hoverctl/wrapper/hoverfly.go
+++ b/hoverctl/wrapper/hoverfly.go
@@ -29,7 +29,7 @@ const (
 	v2ApiMiddleware  = "/api/v2/hoverfly/middleware"
 	v2ApiCache       = "/api/v2/cache"
 	v2ApiLogs        = "/api/v2/logs"
-	v2ApiHoverfly 	 = "/api/v2/hoverfly"
+	v2ApiHoverfly    = "/api/v2/hoverfly"
 
 	v2ApiShutdown = "/api/v2/shutdown"
 	v2ApiHealth   = "/api/health"


### PR DESCRIPTION
hoverctl is missing some flags. This PR adds the -listen-on-host flag so you can specify the host binding. 

see https://github.com/SpectoLabs/hoverfly/issues/693 for more info on why this is being added