### PR TITLE
Removing flags from global

### DIFF
--- a/functional-tests/hoverctl/import_export_test.go
+++ b/functional-tests/hoverctl/import_export_test.go
@@ -167,7 +167,7 @@ var _ = Describe("When I use hoverctl", func() {
 
 				fileName := functional_tests.GenerateFileName()
 				// Export the data
-				output := functional_tests.Run(hoverctlBinary, "export", fileName, "--admin-port="+hoverfly.GetAdminPort())
+				output := functional_tests.Run(hoverctlBinary, "export", fileName)
 
 				Expect(output).To(ContainSubstring("Successfully exported simulation to " + fileName))
 
@@ -186,7 +186,7 @@ var _ = Describe("When I use hoverctl", func() {
 				hoverfly.ImportSimulation(v3HoverflyDataWithMultiplePairs)
 				fileName := functional_tests.GenerateFileName()
 				// Export the data
-				output := functional_tests.Run(hoverctlBinary, "export", fileName, "--admin-port="+hoverfly.GetAdminPort(), "--url-pattern=my-test.com")
+				output := functional_tests.Run(hoverctlBinary, "export", fileName, "--url-pattern=my-test.com")
 
 				Expect(output).To(ContainSubstring("Successfully exported simulation to " + fileName))
 
@@ -206,7 +206,7 @@ var _ = Describe("When I use hoverctl", func() {
 				err := ioutil.WriteFile(fileName, []byte(v3HoverflyData), 0644)
 				Expect(err).To(BeNil())
 
-				output := functional_tests.Run(hoverctlBinary, "import", fileName, "--admin-port="+hoverfly.GetAdminPort())
+				output := functional_tests.Run(hoverctlBinary, "import", fileName)
 
 				Expect(output).To(ContainSubstring("Successfully imported simulation from " + fileName))
 
@@ -223,7 +223,7 @@ var _ = Describe("When I use hoverctl", func() {
 				}))
 				defer ts.Close()
 
-				output := functional_tests.Run(hoverctlBinary, "import", ts.URL, "--admin-port="+hoverfly.GetAdminPort())
+				output := functional_tests.Run(hoverctlBinary, "import", ts.URL)
 
 				Expect(output).To(ContainSubstring("Successfully imported simulation from " + ts.URL))
 

--- a/functional-tests/hoverctl/logs_test.go
+++ b/functional-tests/hoverctl/logs_test.go
@@ -29,7 +29,7 @@ var _ = Describe("When I use hoverctl", func() {
 		It("should return the logs", func() {
 			functional_tests.Run(hoverctlBinary, "start", "--admin-port="+adminPort, "--proxy-port="+proxyPort)
 
-			output := functional_tests.Run(hoverctlBinary, "logs", "--json", "--admin-port="+adminPort, "--proxy-port="+proxyPort)
+			output := functional_tests.Run(hoverctlBinary, "logs", "--json")
 
 			Expect(output).To(ContainSubstring(`"Destination":".","Mode":"simulate","ProxyPort":"` + proxyPort + `","level":"info","msg":"Proxy prepared..."`))
 		})
@@ -49,7 +49,7 @@ var _ = Describe("When I use hoverctl", func() {
 		It("should return the logs", func() {
 			functional_tests.Run(hoverctlBinary, "start", "--admin-port="+adminPort, "--proxy-port="+proxyPort)
 
-			output := functional_tests.Run(hoverctlBinary, "logs", "--admin-port="+adminPort, "--proxy-port="+proxyPort)
+			output := functional_tests.Run(hoverctlBinary, "logs")
 
 			Expect(output).To(ContainSubstring("Proxy prepared..."))
 			Expect(output).To(ContainSubstring("=."))

--- a/functional-tests/hoverctl/state_store_test.go
+++ b/functional-tests/hoverctl/state_store_test.go
@@ -30,12 +30,12 @@ var _ = Describe("When I use hoverctl", func() {
 			Describe("when the state is empty", func() {
 
 				It("Returns empty when getting all", func() {
-					output := functional_tests.Run(hoverctlBinary, "state-store", "get-all", "--admin-port="+hoverfly.GetAdminPort())
+					output := functional_tests.Run(hoverctlBinary, "state-store", "get-all")
 					Expect(output).To(ContainSubstring("The state for Hoverfly is empty"))
 				})
 
 				It("Returns empty for missing key", func() {
-					output := functional_tests.Run(hoverctlBinary, "state-store", "get", "foo", "--admin-port="+hoverfly.GetAdminPort())
+					output := functional_tests.Run(hoverctlBinary, "state-store", "get", "foo")
 					Expect(output).To(ContainSubstring("State is not set for the key: foo"))
 				})
 
@@ -44,30 +44,30 @@ var _ = Describe("When I use hoverctl", func() {
 			Describe("when mutating state", func() {
 
 				It("Can set, get, and get-all and delete state", func() {
-					output := functional_tests.Run(hoverctlBinary, "state-store", "set", "foo", "bar", "--admin-port="+hoverfly.GetAdminPort())
+					output := functional_tests.Run(hoverctlBinary, "state-store", "set", "foo", "bar")
 					Expect(output).To(ContainSubstring("Successfully set state key and value:\n\"foo\"=\"bar\""))
 
-					output = functional_tests.Run(hoverctlBinary, "state-store", "get", "foo", "--admin-port="+hoverfly.GetAdminPort())
+					output = functional_tests.Run(hoverctlBinary, "state-store", "get", "foo")
 					Expect(output).To(ContainSubstring("State of \"foo\":\nbar"))
 
-					output = functional_tests.Run(hoverctlBinary, "state-store", "set", "cheese", "ham", "--admin-port="+hoverfly.GetAdminPort())
+					output = functional_tests.Run(hoverctlBinary, "state-store", "set", "cheese", "ham")
 					Expect(output).To(ContainSubstring("Successfully set state key and value:\n\"cheese\"=\"ham\""))
 
-					output = functional_tests.Run(hoverctlBinary, "state-store", "get", "cheese", "--admin-port="+hoverfly.GetAdminPort())
+					output = functional_tests.Run(hoverctlBinary, "state-store", "get", "cheese")
 					Expect(output).To(ContainSubstring("State of \"cheese\":\nham"))
 
-					output = functional_tests.Run(hoverctlBinary, "state-store", "get-all", "--admin-port="+hoverfly.GetAdminPort())
+					output = functional_tests.Run(hoverctlBinary, "state-store", "get-all")
 					Expect(output).To(ContainSubstring("State of Hoverfly:\n"))
 					Expect(output).To(ContainSubstring(`"cheese"="ham"`))
 					Expect(output).To(ContainSubstring(`"foo"="bar"`))
 
-					output = functional_tests.Run(hoverctlBinary, "state-store", "delete-all", "--admin-port="+hoverfly.GetAdminPort())
+					output = functional_tests.Run(hoverctlBinary, "state-store", "delete-all")
 					Expect(output).To(ContainSubstring("State has been deleted"))
 
-					output = functional_tests.Run(hoverctlBinary, "state-store", "get-all", "--admin-port="+hoverfly.GetAdminPort())
+					output = functional_tests.Run(hoverctlBinary, "state-store", "get-all")
 					Expect(output).To(ContainSubstring("The state for Hoverfly is empty"))
 
-					output = functional_tests.Run(hoverctlBinary, "state-store", "get", "foo", "--admin-port="+hoverfly.GetAdminPort())
+					output = functional_tests.Run(hoverctlBinary, "state-store", "get", "foo")
 					Expect(output).To(ContainSubstring("State is not set for the key: foo"))
 				})
 

--- a/hoverctl/cmd/login.go
+++ b/hoverctl/cmd/login.go
@@ -37,6 +37,8 @@ target in the hoverctl configuration file.
 			// is used instead of 8888 which is set in wrapper.NewTarget()
 			hostFlag, err := cmd.Flags().GetString("host")
 			handleIfError(err)
+			adminPortFlag, err := cmd.Flags().GetInt("admin-port")
+			handleIfError(err)
 			if adminPortFlag == 0 && (hostFlag != "" && !wrapper.IsLocal(hostFlag)) {
 				adminPortFlag = 443
 			}
@@ -73,6 +75,7 @@ func init() {
 	RootCmd.AddCommand(loginCmd)
 
 	loginCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
+	loginCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	loginCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 	loginCmd.Flags().StringVar(&username, "username", "", "Username to authenticate against Hoverfly with")
 	loginCmd.Flags().StringVar(&password, "password", "", "Password to autenticate against Hoverfly with")

--- a/hoverctl/cmd/login.go
+++ b/hoverctl/cmd/login.go
@@ -35,6 +35,8 @@ target in the hoverctl configuration file.
 
 			// If the host is set to a remote instance, the default HTTPS port
 			// is used instead of 8888 which is set in wrapper.NewTarget()
+			hostFlag, err := cmd.Flags().GetString("host")
+			handleIfError(err)
 			if adminPortFlag == 0 && (hostFlag != "" && !wrapper.IsLocal(hostFlag)) {
 				adminPortFlag = 443
 			}
@@ -71,7 +73,7 @@ func init() {
 	RootCmd.AddCommand(loginCmd)
 
 	loginCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
-
+	loginCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 	loginCmd.Flags().StringVar(&username, "username", "", "Username to authenticate against Hoverfly with")
 	loginCmd.Flags().StringVar(&password, "password", "", "Password to autenticate against Hoverfly with")
 }

--- a/hoverctl/cmd/login.go
+++ b/hoverctl/cmd/login.go
@@ -39,6 +39,8 @@ target in the hoverctl configuration file.
 			handleIfError(err)
 			adminPortFlag, err := cmd.Flags().GetInt("admin-port")
 			handleIfError(err)
+			proxyPortFlag, err := cmd.Flags().GetInt("proxy-port")
+			handleIfError(err)
 			if adminPortFlag == 0 && (hostFlag != "" && !wrapper.IsLocal(hostFlag)) {
 				adminPortFlag = 443
 			}
@@ -76,6 +78,7 @@ func init() {
 
 	loginCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
 	loginCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
+	loginCmd.Flags().Int("proxy-port", 0, "A port number for the Hoverfly proxy. Overrides the default Hoverfly proxy port (8500)")
 	loginCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 	loginCmd.Flags().StringVar(&username, "username", "", "Username to authenticate against Hoverfly with")
 	loginCmd.Flags().StringVar(&password, "password", "", "Password to autenticate against Hoverfly with")

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -10,7 +10,6 @@ import (
 )
 
 var targetNameFlag string
-var proxyPortFlag int
 
 var force, verbose, setDefaultTargetFlag bool
 
@@ -51,9 +50,6 @@ func init() {
 		"A name for an instance of Hoverfly you are trying to communicate with. Overrides the default target (default)")
 	RootCmd.PersistentFlags().BoolVar(&setDefaultTargetFlag, "set-default", false,
 		"Sets the current target as the default target for hoverctl")
-
-	RootCmd.PersistentFlags().IntVar(&proxyPortFlag, "proxy-port", 0,
-		"A port number for the Hoverfly proxy. Overrides the default Hoverfly proxy port (8500)")
 
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Verbose logging from hoverctl")
 

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -10,7 +10,7 @@ import (
 )
 
 var targetNameFlag string
-var adminPortFlag, proxyPortFlag int
+var proxyPortFlag int
 
 var force, verbose, setDefaultTargetFlag bool
 
@@ -52,8 +52,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&setDefaultTargetFlag, "set-default", false,
 		"Sets the current target as the default target for hoverctl")
 
-	RootCmd.PersistentFlags().IntVar(&adminPortFlag, "admin-port", 0,
-		"A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	RootCmd.PersistentFlags().IntVar(&proxyPortFlag, "proxy-port", 0,
 		"A port number for the Hoverfly proxy. Overrides the default Hoverfly proxy port (8500)")
 

--- a/hoverctl/cmd/root.go
+++ b/hoverctl/cmd/root.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var targetNameFlag, hostFlag string
+var targetNameFlag string
 var adminPortFlag, proxyPortFlag int
 
 var force, verbose, setDefaultTargetFlag bool
@@ -56,8 +56,6 @@ func init() {
 		"A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	RootCmd.PersistentFlags().IntVar(&proxyPortFlag, "proxy-port", 0,
 		"A port number for the Hoverfly proxy. Overrides the default Hoverfly proxy port (8500)")
-	RootCmd.PersistentFlags().StringVar(&hostFlag, "host", "",
-		"A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Verbose logging from hoverctl")
 

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -41,6 +41,8 @@ hoverctl configuration file.
 			if config.GetTarget(newTargetFlag) != nil {
 				handleIfError(fmt.Errorf("Target %s already exists\n\nUse a different target name or run `hoverctl targets update %[1]s`", newTargetFlag))
 			}
+			hostFlag, err := cmd.Flags().GetString("host")
+			handleIfError(err)
 			target = configuration.NewTarget(newTargetFlag, hostFlag, adminPortFlag, proxyPortFlag)
 		}
 
@@ -106,6 +108,8 @@ hoverctl configuration file.
 func init() {
 	RootCmd.AddCommand(startCmd)
 	startCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
+
+	startCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 
 	startCmd.Flags().String("cache", "", "A path to a persisted Hoverfly cache. If the cache doesn't exist, Hoverfly will create it")
 	startCmd.Flags().Bool("disable-cache", false, "Disables the request response cache on Hoverfly")

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -37,6 +37,9 @@ hoverctl configuration file.
 
 		newTargetFlag, _ := cmd.Flags().GetString("new-target")
 
+		adminPortFlag, err := cmd.Flags().GetInt("admin-port")
+		handleIfError(err)
+
 		if newTargetFlag != "" {
 			if config.GetTarget(newTargetFlag) != nil {
 				handleIfError(fmt.Errorf("Target %s already exists\n\nUse a different target name or run `hoverctl targets update %[1]s`", newTargetFlag))
@@ -83,7 +86,7 @@ hoverctl configuration file.
 			target.Password = password
 		}
 
-		err := wrapper.Start(target)
+		err = wrapper.Start(target)
 		handleIfError(err)
 
 		data := [][]string{
@@ -109,6 +112,7 @@ func init() {
 	RootCmd.AddCommand(startCmd)
 	startCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
 
+	startCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	startCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 
 	startCmd.Flags().String("cache", "", "A path to a persisted Hoverfly cache. If the cache doesn't exist, Hoverfly will create it")

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -39,6 +39,8 @@ hoverctl configuration file.
 
 		adminPortFlag, err := cmd.Flags().GetInt("admin-port")
 		handleIfError(err)
+		proxyPortFlag, err := cmd.Flags().GetInt("proxy-port")
+		handleIfError(err)
 
 		if newTargetFlag != "" {
 			if config.GetTarget(newTargetFlag) != nil {
@@ -113,6 +115,7 @@ func init() {
 	startCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
 
 	startCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
+	startCmd.Flags().Int("proxy-port", 0, "A port number for the Hoverfly proxy. Overrides the default Hoverfly proxy port (8500)")
 	startCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 
 	startCmd.Flags().String("cache", "", "A path to a persisted Hoverfly cache. If the cache doesn't exist, Hoverfly will create it")

--- a/hoverctl/cmd/targets.go
+++ b/hoverctl/cmd/targets.go
@@ -79,6 +79,8 @@ Create target"
 		handleIfError(err)
 		adminPortFlag, err := cmd.Flags().GetInt("admin-port")
 		handleIfError(err)
+		proxyPortFlag, err := cmd.Flags().GetInt("proxy-port")
+		handleIfError(err)
 
 		newTarget := configuration.NewTarget(args[0], hostFlag, adminPortFlag, proxyPortFlag)
 
@@ -107,6 +109,8 @@ Update target
 		hostFlag, err := cmd.Flags().GetString("host")
 		handleIfError(err)
 		adminPortFlag, err := cmd.Flags().GetInt("admin-port")
+		handleIfError(err)
+		proxyPortFlag, err := cmd.Flags().GetInt("proxy-port")
 		handleIfError(err)
 
 		newTarget := configuration.NewTarget(args[0], hostFlag, adminPortFlag, proxyPortFlag)
@@ -160,7 +164,9 @@ func init() {
 	targetsCmd.AddCommand(targetsDefaultCmd)
 
 	targetsNewCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
+	targetsNewCmd.Flags().Int("proxy-port", 0, "A port number for the Hoverfly proxy. Overrides the default Hoverfly proxy port (8500)")
 	targetsNewCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 	targetsUpdateCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
+	targetsUpdateCmd.Flags().Int("proxy-port", 0, "A port number for the Hoverfly proxy. Overrides the default Hoverfly proxy port (8500)")
 	targetsUpdateCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 }

--- a/hoverctl/cmd/targets.go
+++ b/hoverctl/cmd/targets.go
@@ -75,6 +75,9 @@ Create target"
 			handleIfError(fmt.Errorf("Target %s already exists\n\nUse a different target name or run `hoverctl targets update %[1]s`", args[0]))
 		}
 
+		hostFlag, err := cmd.Flags().GetString("host")
+		handleIfError(err)
+
 		newTarget := configuration.NewTarget(args[0], hostFlag, adminPortFlag, proxyPortFlag)
 
 		config.NewTarget(*newTarget)
@@ -98,6 +101,9 @@ Update target
 		if config.GetTarget(args[0]) == nil {
 			handleIfError(fmt.Errorf("Target %s does not exist\n\nUse a different target name or run `hoverctl targets create %[1]s`", args[0]))
 		}
+
+		hostFlag, err := cmd.Flags().GetString("host")
+		handleIfError(err)
 
 		newTarget := configuration.NewTarget(args[0], hostFlag, adminPortFlag, proxyPortFlag)
 
@@ -148,4 +154,7 @@ func init() {
 	targetsCmd.AddCommand(targetsNewCmd)
 	targetsCmd.AddCommand(targetsUpdateCmd)
 	targetsCmd.AddCommand(targetsDefaultCmd)
+
+	targetsNewCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
+	targetsUpdateCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 }

--- a/hoverctl/cmd/targets.go
+++ b/hoverctl/cmd/targets.go
@@ -77,6 +77,8 @@ Create target"
 
 		hostFlag, err := cmd.Flags().GetString("host")
 		handleIfError(err)
+		adminPortFlag, err := cmd.Flags().GetInt("admin-port")
+		handleIfError(err)
 
 		newTarget := configuration.NewTarget(args[0], hostFlag, adminPortFlag, proxyPortFlag)
 
@@ -103,6 +105,8 @@ Update target
 		}
 
 		hostFlag, err := cmd.Flags().GetString("host")
+		handleIfError(err)
+		adminPortFlag, err := cmd.Flags().GetInt("admin-port")
 		handleIfError(err)
 
 		newTarget := configuration.NewTarget(args[0], hostFlag, adminPortFlag, proxyPortFlag)
@@ -155,6 +159,8 @@ func init() {
 	targetsCmd.AddCommand(targetsUpdateCmd)
 	targetsCmd.AddCommand(targetsDefaultCmd)
 
+	targetsNewCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	targetsNewCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
+	targetsUpdateCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	targetsUpdateCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
 }


### PR DESCRIPTION
As mentioned in #695, the `--host`, `--admin-flag` and `--proxy-flag` were listed in the hoverctl help text as being global flags, which they weren't'.

This PR should now list them in the help text under the commands they are used for, as opposed to being listed as a global flag.