### PR TITLE
Default matcher

### DIFF
--- a/core/matching/field_matcher.go
+++ b/core/matching/field_matcher.go
@@ -16,9 +16,9 @@ func FieldMatcher(fields []models.RequestFieldMatchers, toMatch string) *FieldMa
 	for _, field := range fields {
 		if matchers.Matchers[field.Matcher](field.Value, toMatch) {
 			if field.Matcher == matchers.Exact {
-				fieldMatch.MatchScore = fieldMatch.MatchScore + 2
+				fieldMatch.Score = fieldMatch.Score + 2
 			} else {
-				fieldMatch.MatchScore = fieldMatch.MatchScore + 1
+				fieldMatch.Score = fieldMatch.Score + 1
 			}
 		} else {
 			fieldMatch.Matched = false
@@ -30,12 +30,12 @@ func FieldMatcher(fields []models.RequestFieldMatchers, toMatch string) *FieldMa
 
 func FieldMatchWithNoScore(matched bool) *FieldMatch {
 	return &FieldMatch{
-		Matched:    matched,
-		MatchScore: 0,
+		Matched: matched,
+		Score:   0,
 	}
 }
 
 type FieldMatch struct {
-	Matched    bool
-	MatchScore int
+	Matched bool
+	Score   int
 }

--- a/core/matching/field_matcher.go
+++ b/core/matching/field_matcher.go
@@ -28,13 +28,6 @@ func FieldMatcher(fields []models.RequestFieldMatchers, toMatch string) *FieldMa
 	return fieldMatch
 }
 
-func FieldMatchWithNoScore(matched bool) *FieldMatch {
-	return &FieldMatch{
-		Matched: matched,
-		Score:   0,
-	}
-}
-
 type FieldMatch struct {
 	Matched bool
 	Score   int

--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -7,138 +7,156 @@ import (
 	"github.com/SpectoLabs/hoverfly/core/matching/matchers"
 	"github.com/SpectoLabs/hoverfly/core/models"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 )
 
-func Test_FieldMatcher_MatchesTrue_WithNilMatchers(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher(nil, "test").Matched).To(BeTrue())
+type fieldMatcherTest struct {
+	name        string
+	matchers    []models.RequestFieldMatchers
+	toMatch     string
+	equals      types.GomegaMatcher
+	scoreEquals types.GomegaMatcher
 }
 
-func Test_FieldMatcher_MatchesTrueWithDefaultMatcherWhichIsExactMatch(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Value: `test`,
+var fieldMatcherTests = []fieldMatcherTest{
+	{
+		name:        "MatchesTrue_WithNilMatchers",
+		matchers:    nil,
+		toMatch:     "test",
+		equals:      BeTrue(),
+		scoreEquals: Equal(0),
+	},
+	{
+		name: "MatchesTrueWithDefaultMatcherWhichIsExactMatch",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Value: `test`,
+			},
 		},
-	}, `test`).Matched).To(BeTrue())
-}
-
-func Test_FieldMatcher_MatchesTrueWithJsonMatch(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Matcher: matchers.Json,
-			Value:   `{"test":true}`,
+		toMatch: "test",
+		equals:  BeTrue(),
+	},
+	{
+		name: "MatchesTrueWithJsonMatch",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Json,
+				Value:   `{"test":true}`,
+			},
 		},
-	}, `{"test": true}`).Matched).To(BeTrue())
-}
-
-func Test_FieldMatcher_MatchesFalseWithJsonMatch(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Matcher: matchers.Json,
-			Value:   `{"test":true}`,
+		toMatch: `{"test":true}`,
+		equals:  BeTrue(),
+	},
+	{
+		name: "MatchesFalseWithJsonMatch",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Json,
+				Value:   `{"test":true}`,
+			},
 		},
-	}, `{"test": [ ] }`).Matched).To(BeFalse())
-}
-
-func Test_FieldMatcher_MatchesTrueWithXmlMatch(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Matcher: matchers.Xml,
-			Value:   `<document></document>`,
+		toMatch: "test",
+		equals:  BeFalse(),
+	},
+	{
+		name: "MatchesTrueWithXmlMatch",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Xml,
+				Value:   `<document></document>`,
+			},
 		},
-	}, `<document></document>`).Matched).To(BeTrue())
-}
-
-func Test_FieldMatcher_MatchesFalseWithXmlMatch(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Matcher: matchers.Xml,
-			Value:   "<document></document>",
+		toMatch: `<document></document>`,
+		equals:  BeTrue(),
+	},
+	{
+		name: "MatchesFalseWithXmlMatch",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Xml,
+				Value:   "<document></document>",
+			},
 		},
-	}, `<document>
+		toMatch: `<document>
 		<test>data</test>
-	</document>`).Matched).To(BeFalse())
+	</document>`,
+		equals: BeFalse(),
+	},
+	{
+		name:     "MatchesTrue_WithMatchersNotDefined",
+		matchers: []models.RequestFieldMatchers{},
+		toMatch:  "test",
+		equals:   BeTrue(),
+	},
+	{
+		name: "WithExactMatch_ScoresDouble(",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Exact,
+				Value:   "test",
+			},
+		},
+		toMatch:     "test",
+		scoreEquals: Equal(2),
+	},
+	{
+		name: "WithMultipleMatchers_MatchesOnBoth",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Exact,
+				Value:   "test",
+			},
+			{
+				Matcher: matchers.Exact,
+				Value:   "test",
+			},
+		},
+		toMatch: "test",
+		equals:  BeTrue(),
+	},
+	{
+		name: "WithMultipleMatchers_MatchesOne",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Exact,
+				Value:   "test",
+			},
+			{
+				Matcher: matchers.Exact,
+				Value:   "nottest",
+			},
+		},
+		toMatch: "test",
+		equals:  BeFalse(),
+	},
+	{
+		name: "FieldMatcher_WithMultipleMatchers_ScoresDouble",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Exact,
+				Value:   "test",
+			},
+			{
+				Matcher: matchers.Exact,
+				Value:   "test",
+			},
+		},
+		toMatch:     "test",
+		scoreEquals: Equal(4),
+	},
 }
 
-func Test_FieldMatcher_MatchesTrue_WithMatchersNotDefined(t *testing.T) {
+func Test_FieldMatcher(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{}, "test").Matched).To(BeTrue())
-}
+	for _, test := range fieldMatcherTests {
+		result := matching.FieldMatcher(test.matchers, test.toMatch)
+		if test.equals != nil {
+			Expect(result.Matched).To(test.equals, test.name)
+		}
+		if test.scoreEquals != nil {
+			Expect(result.MatchScore).To(test.scoreEquals, test.name)
+		}
+	}
 
-func Test_FieldMatcher_WithExactMatch_ScoresDouble(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Matcher: matchers.Exact,
-			Value:   "testtesttest",
-		},
-	}, `testtesttest`).MatchScore).To(Equal(2))
-}
-
-func Test_FieldMatcher_WithMultipleMatchers_MatchesOnBoth(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Matcher: matchers.Exact,
-			Value:   "test",
-		},
-		{
-			Matcher: matchers.Exact,
-			Value:   "test",
-		},
-	}, `test`).Matched).To(BeTrue())
-}
-
-func Test_FieldMatcher_WithMultipleMatchers_FailsOnOne(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Matcher: matchers.Exact,
-			Value:   "test",
-		},
-		{
-			Matcher: matchers.Exact,
-			Value:   "nottest",
-		},
-	}, `test`).Matched).To(BeFalse())
-}
-
-func Test_FieldMatcher_WithMultipleMatchers_ScoresDouble(t *testing.T) {
-	RegisterTestingT(t)
-
-	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
-		{
-			Matcher: matchers.Exact,
-			Value:   "test",
-		},
-		{
-			Matcher: matchers.Exact,
-			Value:   "test",
-		},
-	}, `test`).MatchScore).To(Equal(4))
-}
-
-func Test_FieldMatcher_CountZero_WhenFieldIsNil(t *testing.T) {
-	RegisterTestingT(t)
-
-	// Glob, regex, and exact
-	matcher := matching.FieldMatcher(nil, `testtesttest`)
-
-	Expect(matcher.Matched).To(BeTrue())
-	Expect(matcher.MatchScore).To(Equal(0))
 }

--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -15,6 +15,16 @@ func Test_FieldMatcher_MatchesTrue_WithNilMatchers(t *testing.T) {
 	Expect(matching.FieldMatcher(nil, "test").Matched).To(BeTrue())
 }
 
+func Test_FieldMatcher_MatchesTrueWithDefaultMatcherWhichIsExactMatch(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matching.FieldMatcher([]models.RequestFieldMatchers{
+		{
+			Value: `test`,
+		},
+	}, `test`).Matched).To(BeTrue())
+}
+
 func Test_FieldMatcher_MatchesTrueWithJsonMatch(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -155,7 +155,7 @@ func Test_FieldMatcher(t *testing.T) {
 			Expect(result.Matched).To(test.equals, test.name)
 		}
 		if test.scoreEquals != nil {
-			Expect(result.MatchScore).To(test.scoreEquals, test.name)
+			Expect(result.Score).To(test.scoreEquals, test.name)
 		}
 	}
 

--- a/core/matching/header_matcher.go
+++ b/core/matching/header_matcher.go
@@ -16,7 +16,7 @@ func HeaderMatching(requestMatcher models.RequestMatcher, toMatch map[string][]s
 	// }
 
 	matched := true
-	var matchScore int
+	var score int
 
 	requestMatcherHeadersWithMatchers := requestMatcher.HeadersWithMatchers
 
@@ -36,7 +36,7 @@ func HeaderMatching(requestMatcher models.RequestMatcher, toMatch map[string][]s
 
 		fieldMatch := FieldMatcher(matcherHeaderValue, strings.Join(toMatchHeaderValues, ";"))
 		matcherHeaderValueMatched = fieldMatch.Matched
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		if !matcherHeaderValueMatched {
 			matched = false
@@ -61,7 +61,7 @@ func HeaderMatching(requestMatcher models.RequestMatcher, toMatch map[string][]s
 			for _, toMatchHeaderValue := range toMatchHeaderValues {
 				if glob.Glob(strings.ToLower(matcherHeaderValue), strings.ToLower(toMatchHeaderValue)) {
 					matcherHeaderValueMatched = true
-					matchScore++
+					score++
 				}
 			}
 
@@ -71,7 +71,7 @@ func HeaderMatching(requestMatcher models.RequestMatcher, toMatch map[string][]s
 		}
 	}
 	return &FieldMatch{
-		Matched:    matched,
-		MatchScore: matchScore,
+		Matched: matched,
+		Score:   score,
 	}
 }

--- a/core/matching/header_matcher_test.go
+++ b/core/matching/header_matcher_test.go
@@ -328,7 +328,7 @@ func Test_HeaderMatching(t *testing.T) {
 
 		Expect(result.Matched).To(test.equals, test.name)
 		if test.matchEquals != nil {
-			Expect(result.MatchScore).To(test.matchEquals, test.name)
+			Expect(result.Score).To(test.matchEquals, test.name)
 		}
 	}
 

--- a/core/matching/matchers/matchers.go
+++ b/core/matching/matchers/matchers.go
@@ -3,6 +3,9 @@ package matchers
 type MatcherFunc func(data interface{}, toMatch string) bool
 
 var Matchers = map[string]MatcherFunc{
+	// Default matcher
+	"": ExactMatch,
+
 	Exact:    ExactMatch,
 	Glob:     GlobMatch,
 	Json:     JsonMatch,

--- a/core/matching/query_matching.go
+++ b/core/matching/query_matching.go
@@ -9,7 +9,7 @@ import (
 func QueryMatching(requestMatcher models.RequestMatcher, toMatch map[string][]string) *FieldMatch {
 
 	matched := true
-	var matchScore int
+	var score int
 
 	requestMatcherQueriesWithMatchers := requestMatcher.QueriesWithMatchers
 
@@ -24,7 +24,7 @@ func QueryMatching(requestMatcher models.RequestMatcher, toMatch map[string][]st
 
 		fieldMatch := FieldMatcher(matcherQueryValue, strings.Join(toMatchQueryValues, ";"))
 		matcherHeaderValueMatched = fieldMatch.Matched
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		if !matcherHeaderValueMatched {
 			matched = false
@@ -32,7 +32,7 @@ func QueryMatching(requestMatcher models.RequestMatcher, toMatch map[string][]st
 	}
 
 	return &FieldMatch{
-		Matched:    matched,
-		MatchScore: matchScore,
+		Matched: matched,
+		Score:   score,
 	}
 }

--- a/core/matching/query_matching_test.go
+++ b/core/matching/query_matching_test.go
@@ -129,7 +129,7 @@ func Test_QueryMatching(t *testing.T) {
 
 		Expect(result.Matched).To(test.equals, test.name)
 		if test.matchEquals != nil {
-			Expect(result.MatchScore).To(test.matchEquals, test.name)
+			Expect(result.Score).To(test.matchEquals, test.name)
 		}
 	}
 

--- a/core/matching/state_matcher.go
+++ b/core/matching/state_matcher.go
@@ -21,7 +21,7 @@ func StateMatcher(currentState, requiredState map[string]string) *FieldMatch {
 	}
 
 	return &FieldMatch{
-		Matched:    matched,
-		MatchScore: score,
+		Matched: matched,
+		Score:   score,
 	}
 }

--- a/core/matching/state_matcher.go
+++ b/core/matching/state_matcher.go
@@ -6,7 +6,10 @@ func StateMatcher(currentState, requiredState map[string]string) *FieldMatch {
 	matched := true
 
 	if requiredState == nil || len(requiredState) == 0 {
-		return FieldMatchWithNoScore(true)
+		return &FieldMatch{
+			Matched: true,
+			Score:   0,
+		}
 	}
 
 	for key, value := range requiredState {

--- a/core/matching/state_matcher_test.go
+++ b/core/matching/state_matcher_test.go
@@ -12,7 +12,7 @@ func Test_StateMatcher_houldMatchIfBothCurrentAndRequiredStateAreNil(t *testing.
 	match := StateMatcher(nil, nil)
 
 	Expect(match.Matched).To(BeTrue())
-	Expect(match.MatchScore).To(Equal(0))
+	Expect(match.Score).To(Equal(0))
 }
 
 func Test_StateMatcher_ShouldMatchIfCurrentStateIsNilAndRequiredStateIsEmpty(t *testing.T) {
@@ -21,7 +21,7 @@ func Test_StateMatcher_ShouldMatchIfCurrentStateIsNilAndRequiredStateIsEmpty(t *
 	match := StateMatcher(nil, make(map[string]string))
 
 	Expect(match.Matched).To(BeTrue())
-	Expect(match.MatchScore).To(Equal(0))
+	Expect(match.Score).To(Equal(0))
 }
 
 func Test_StateMatcher_ShouldMatchIfCurrentStateIEmptyAndRequiredStateIsNil(t *testing.T) {
@@ -30,7 +30,7 @@ func Test_StateMatcher_ShouldMatchIfCurrentStateIEmptyAndRequiredStateIsNil(t *t
 	match := StateMatcher(make(map[string]string), nil)
 
 	Expect(match.Matched).To(BeTrue())
-	Expect(match.MatchScore).To(Equal(0))
+	Expect(match.Score).To(Equal(0))
 }
 
 func Test_StateMatcher_ShouldNotMatchIfRequiredStateLengthIsGreaterThanActualStateLength(t *testing.T) {
@@ -39,7 +39,7 @@ func Test_StateMatcher_ShouldNotMatchIfRequiredStateLengthIsGreaterThanActualSta
 	match := StateMatcher(make(map[string]string), map[string]string{"foo": "bar"})
 
 	Expect(match.Matched).To(BeFalse())
-	Expect(match.MatchScore).To(Equal(0))
+	Expect(match.Score).To(Equal(0))
 }
 
 func Test_StateMatcher_ShouldNotMatchIfLengthsAreTheSameButKeysAreDifferent(t *testing.T) {
@@ -50,7 +50,7 @@ func Test_StateMatcher_ShouldNotMatchIfLengthsAreTheSameButKeysAreDifferent(t *t
 		map[string]string{"adasd": "bar", "sadsad": "ham"})
 
 	Expect(match.Matched).To(BeFalse())
-	Expect(match.MatchScore).To(Equal(0))
+	Expect(match.Score).To(Equal(0))
 }
 
 func Test_StateMatcher_ShouldNotMatchIfKeysAreTheSameButValuesAreDifferent(t *testing.T) {
@@ -61,7 +61,7 @@ func Test_StateMatcher_ShouldNotMatchIfKeysAreTheSameButValuesAreDifferent(t *te
 		map[string]string{"foo": "adsad", "cheese": "ham"})
 
 	Expect(match.Matched).To(BeFalse())
-	Expect(match.MatchScore).To(Equal(1))
+	Expect(match.Score).To(Equal(1))
 }
 
 func Test_StateMatcher_ShouldMatchIsKeysAndValuesAreTheSame(t *testing.T) {
@@ -72,5 +72,5 @@ func Test_StateMatcher_ShouldMatchIsKeysAndValuesAreTheSame(t *testing.T) {
 		map[string]string{"foo": "bar", "cheese": "ham"})
 
 	Expect(match.Matched).To(BeTrue())
-	Expect(match.MatchScore).To(Equal(2))
+	Expect(match.Score).To(Equal(2))
 }

--- a/core/matching/strongest_match_strategy.go
+++ b/core/matching/strongest_match_strategy.go
@@ -21,7 +21,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 		// TODO: enable matching on scheme
 
 		missedFields := make([]string, 0)
-		var matchScore int
+		var score int
 		matched := true
 		matchedOnAllButHeaders := true
 		matchedOnAllButState := true
@@ -35,7 +35,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 			matched = false
 			missedFields = append(missedFields, "body")
 		}
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		if !webserver {
 			match := FieldMatcher(requestMatcher.Destination, req.Destination)
@@ -45,7 +45,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 				matched = false
 				missedFields = append(missedFields, "destination")
 			}
-			matchScore += match.MatchScore
+			score += match.Score
 		}
 
 		fieldMatch = FieldMatcher(requestMatcher.Path, req.Path)
@@ -55,7 +55,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 			matched = false
 			missedFields = append(missedFields, "path")
 		}
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		fieldMatch = FieldMatcher(requestMatcher.Query, req.QueryString())
 		if !fieldMatch.Matched {
@@ -64,7 +64,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 			matched = false
 			missedFields = append(missedFields, "query")
 		}
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		fieldMatch = FieldMatcher(requestMatcher.Method, req.Method)
 		if !fieldMatch.Matched {
@@ -73,7 +73,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 			matched = false
 			missedFields = append(missedFields, "method")
 		}
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		fieldMatch = HeaderMatching(requestMatcher, req.Headers)
 		if !fieldMatch.Matched {
@@ -81,7 +81,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 			matchedOnAllButState = false
 			missedFields = append(missedFields, "headers")
 		}
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		fieldMatch = QueryMatching(requestMatcher, req.Query)
 		if !fieldMatch.Matched {
@@ -89,7 +89,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 			matchedOnAllButState = false
 			missedFields = append(missedFields, "queries")
 		}
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		fieldMatch = StateMatcher(state, requestMatcher.RequiresState)
 		if !fieldMatch.Matched {
@@ -97,7 +97,7 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 			matchedOnAllButHeaders = false
 			missedFields = append(missedFields, "state")
 		}
-		matchScore += fieldMatch.MatchScore
+		score += fieldMatch.Score
 
 		// This only counts if there was actually a matcher for headers
 		if matchedOnAllButHeaders && requestMatcher.Headers != nil && len(requestMatcher.Headers) > 0 {
@@ -109,15 +109,15 @@ func StrongestMatchStrategy(req models.RequestDetails, webserver bool, simulatio
 			matchedOnAllButStateAtLeastOnce = true
 		}
 
-		if matched == true && matchScore >= strongestMatchScore {
+		if matched == true && score >= strongestMatchScore {
 			requestMatch = &models.RequestMatcherResponsePair{
 				RequestMatcher: requestMatcher,
 				Response:       matchingPair.Response,
 			}
-			strongestMatchScore = matchScore
+			strongestMatchScore = score
 			closestMiss = nil
-		} else if matched == false && requestMatch == nil && matchScore >= closestMissScore {
-			closestMissScore = matchScore
+		} else if matched == false && requestMatch == nil && score >= closestMissScore {
+			closestMissScore = score
 			view := matchingPair.BuildView()
 			closestMiss = &models.ClosestMiss{
 				RequestDetails: req,


### PR DESCRIPTION
If a user specifies a new matcher with a value and no type, then it will default to being of the type exact.
```
{
value: "something"
}
```