### PR TITLE
Switching queries to be keyed like headers

### DIFF
--- a/core/handlers/v2/simulation_views_test.go
+++ b/core/handlers/v2/simulation_views_test.go
@@ -53,7 +53,7 @@ func Test_NewSimulationViewFromResponseBody_CanCreateSimulationFromV3Payload(t *
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Headers).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Method).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Path).To(HaveLen(0))
-	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(0))
+	Expect(simulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Scheme).To(HaveLen(0))
 
 	Expect(simulation.RequestResponsePairs[0].Response.Body).To(Equal("exact match"))
@@ -112,7 +112,7 @@ func Test_NewSimulationViewFromResponseBody_CanCreateSimulationFromV2Payload(t *
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Headers).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Method).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Path).To(HaveLen(0))
-	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(0))
+	Expect(simulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Scheme).To(HaveLen(0))
 
 	Expect(simulation.RequestResponsePairs[0].Response.Body).To(Equal("exact match"))
@@ -203,7 +203,7 @@ func Test_NewSimulationViewFromResponseBody_CanCreateSimulationFromV1Payload(t *
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Headers).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Method).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Path).To(HaveLen(0))
-	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(0))
+	Expect(simulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(0))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Scheme).To(HaveLen(0))
 
 	Expect(simulation.RequestResponsePairs[0].Response.Body).To(Equal("exact match"))

--- a/core/handlers/v2/simulation_views_upgrade.go
+++ b/core/handlers/v2/simulation_views_upgrade.go
@@ -110,14 +110,14 @@ func upgradeV1(originalSimulation SimulationViewV1) SimulationViewV5 {
 
 		pair := RequestMatcherResponsePairViewV5{
 			RequestMatcher: RequestMatcherViewV5{
-				Scheme:        schemeMatchers,
-				Method:        methodMatchers,
-				Destination:   destinationMatchers,
-				Path:          pathMatchers,
-				Query:         queryMatchers,
-				Body:          bodyMatchers,
-				Headers:       headersWithMatchers,
-				RequiresState: nil,
+				Scheme:          schemeMatchers,
+				Method:          methodMatchers,
+				Destination:     destinationMatchers,
+				Path:            pathMatchers,
+				Body:            bodyMatchers,
+				Headers:         headersWithMatchers,
+				RequiresState:   nil,
+				DepricatedQuery: queryMatchers,
 			},
 			Response: ResponseDetailsViewV5{
 				Body:             pairV1.Response.Body,
@@ -178,14 +178,14 @@ func upgradeV2(originalSimulation SimulationViewV2) SimulationViewV5 {
 
 		requestResponsePair := RequestMatcherResponsePairViewV5{
 			RequestMatcher: RequestMatcherViewV5{
-				Destination:   destinationMatchers,
-				Headers:       headersWithMatchers,
-				Method:        methodMatchers,
-				Path:          pathMatchers,
-				Query:         queryMatchers,
-				Scheme:        schemeMatchers,
-				Body:          bodyMatchers,
-				RequiresState: nil,
+				Destination:     destinationMatchers,
+				Headers:         headersWithMatchers,
+				Method:          methodMatchers,
+				Path:            pathMatchers,
+				Scheme:          schemeMatchers,
+				Body:            bodyMatchers,
+				RequiresState:   nil,
+				DepricatedQuery: queryMatchers,
 			},
 			Response: ResponseDetailsViewV5{
 				Body:             requestResponsePairV2.Response.Body,
@@ -266,12 +266,12 @@ func upgradeV4(originalSimulation SimulationViewV4) SimulationViewV5 {
 				Destination:         destinationMatchers,
 				Method:              methodMatchers,
 				Path:                pathMatchers,
-				Query:               queryMatchers,
 				Scheme:              schemeMatchers,
 				Body:                bodyMatchers,
 				Headers:             headersWithMatchers,
 				QueriesWithMatchers: queriesWithMatchers,
 				RequiresState:       requestResponsePairV2.RequestMatcher.RequiresState,
+				DepricatedQuery:     queryMatchers,
 			},
 			Response: ResponseDetailsViewV5{
 				Body:             requestResponsePairV2.Response.Body,

--- a/core/handlers/v2/simulation_views_upgrade.go
+++ b/core/handlers/v2/simulation_views_upgrade.go
@@ -263,15 +263,15 @@ func upgradeV4(originalSimulation SimulationViewV4) SimulationViewV5 {
 
 		requestResponsePair := RequestMatcherResponsePairViewV5{
 			RequestMatcher: RequestMatcherViewV5{
-				Destination:         destinationMatchers,
-				Method:              methodMatchers,
-				Path:                pathMatchers,
-				Scheme:              schemeMatchers,
-				Body:                bodyMatchers,
-				Headers:             headersWithMatchers,
-				QueriesWithMatchers: queriesWithMatchers,
-				RequiresState:       requestResponsePairV2.RequestMatcher.RequiresState,
-				DepricatedQuery:     queryMatchers,
+				Destination:     destinationMatchers,
+				Method:          methodMatchers,
+				Path:            pathMatchers,
+				Scheme:          schemeMatchers,
+				Body:            bodyMatchers,
+				Headers:         headersWithMatchers,
+				Query:           queriesWithMatchers,
+				RequiresState:   requestResponsePairV2.RequestMatcher.RequiresState,
+				DepricatedQuery: queryMatchers,
 			},
 			Response: ResponseDetailsViewV5{
 				Body:             requestResponsePairV2.Response.Body,

--- a/core/handlers/v2/simulation_views_upgrade_test.go
+++ b/core/handlers/v2/simulation_views_upgrade_test.go
@@ -76,9 +76,9 @@ func Test_upgradeV1_ReturnsAnUpgradedSimulation(t *testing.T) {
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path[0].Matcher).To(Equal(matchers.Exact))
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path[0].Value).To(Equal("/path"))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal(matchers.Exact))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("query=query"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal(matchers.Exact))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("query=query"))
 
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Headers).To(HaveKeyWithValue("Test", []MatcherViewV5{
 		{
@@ -151,9 +151,9 @@ func Test_upgradeV1_HandlesTemplates(t *testing.T) {
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path[0].Matcher).To(Equal(matchers.Glob))
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path[0].Value).To(Equal("/path"))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal(matchers.Glob))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("query=query"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal(matchers.Glob))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("query=query"))
 
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Headers).To(BeEmpty())
 }
@@ -189,7 +189,7 @@ func Test_upgradeV1_HandlesIncompleteRequest(t *testing.T) {
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Body).To(HaveLen(0))
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Destination).To(HaveLen(0))
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path).To(HaveLen(0))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(0))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(0))
 
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Method).To(HaveLen(1))
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Method[0].Matcher).To(Equal(matchers.Exact))
@@ -228,9 +228,9 @@ func Test_upgradeV1_Upgrade_UnescapesRequestQueryParameters(t *testing.T) {
 	upgradedSimulation := upgradeV1(v1Simulation)
 
 	Expect(upgradedSimulation.RequestResponsePairs).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal("exact"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("q=10 Downing Street London"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal("exact"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("q=10 Downing Street London"))
 }
 
 func Test_upgradeV2_ReturnsAnUpgradedSimulation(t *testing.T) {
@@ -301,9 +301,9 @@ func Test_upgradeV2_ReturnsAnUpgradedSimulation(t *testing.T) {
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path[0].Matcher).To(Equal("json"))
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path[0].Value).To(Equal("*"))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal(matchers.Exact))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("query=query"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal(matchers.Exact))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("query=query"))
 
 	Expect(upgradedSimulation.RequestResponsePairs[0].Response.Status).To(Equal(200))
 	Expect(upgradedSimulation.RequestResponsePairs[0].Response.Templated).To(BeFalse())
@@ -345,9 +345,9 @@ func Test_upgradeV2_UnescapesExactMatchRequestQueryParameters(t *testing.T) {
 	upgradedSimulation := upgradeV2(v2Simulation)
 
 	Expect(upgradedSimulation.RequestResponsePairs).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal(matchers.Exact))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("q=10 Downing Street London"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal(matchers.Exact))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("q=10 Downing Street London"))
 }
 
 func Test_upgradeV2_UnescapesGlobMatchRequestQueryParameters(t *testing.T) {
@@ -380,9 +380,9 @@ func Test_upgradeV2_UnescapesGlobMatchRequestQueryParameters(t *testing.T) {
 
 	Expect(upgradedSimulation.RequestResponsePairs).To(HaveLen(1))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal(matchers.Glob))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("q=* London"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal(matchers.Glob))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("q=* London"))
 }
 
 func Test_upgradeV2_Upgrade_KeepsEncodedResponsesEncoded(t *testing.T) {
@@ -449,11 +449,11 @@ func Test_upgradeV2_HandlesMultipleMatchers(t *testing.T) {
 
 	Expect(upgradedSimulation.RequestResponsePairs).To(HaveLen(1))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(2))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal(matchers.Exact))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("testexact"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[1].Matcher).To(Equal(matchers.Glob))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[1].Value).To(Equal("testglob"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(2))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal(matchers.Exact))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("testexact"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[1].Matcher).To(Equal(matchers.Glob))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[1].Value).To(Equal("testglob"))
 }
 
 func Test_upgradeV4_ReturnsAnUpgradedSimulation(t *testing.T) {
@@ -524,9 +524,9 @@ func Test_upgradeV4_ReturnsAnUpgradedSimulation(t *testing.T) {
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path[0].Matcher).To(Equal("json"))
 	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Path[0].Value).To(Equal("*"))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal("exact"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("query=query"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal("exact"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("query=query"))
 
 	Expect(upgradedSimulation.RequestResponsePairs[0].Response.Status).To(Equal(200))
 	Expect(upgradedSimulation.RequestResponsePairs[0].Response.Templated).To(BeFalse())
@@ -601,9 +601,9 @@ func Test_upgradeV4_UnescapesExactMatchRequestQueryParameters(t *testing.T) {
 	upgradedSimulation := upgradeV4(v4Simulation)
 
 	Expect(upgradedSimulation.RequestResponsePairs).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal("exact"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("q=10 Downing Street London"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal("exact"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("q=10 Downing Street London"))
 }
 
 func Test_upgradeV4_UnescapesGlobMatchRequestQueryParameters(t *testing.T) {
@@ -636,9 +636,9 @@ func Test_upgradeV4_UnescapesGlobMatchRequestQueryParameters(t *testing.T) {
 
 	Expect(upgradedSimulation.RequestResponsePairs).To(HaveLen(1))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal("glob"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("q=* London"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal("glob"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("q=* London"))
 }
 
 func Test_upgradeV4_HandlesMultipleMatchers(t *testing.T) {
@@ -672,11 +672,11 @@ func Test_upgradeV4_HandlesMultipleMatchers(t *testing.T) {
 
 	Expect(upgradedSimulation.RequestResponsePairs).To(HaveLen(1))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(2))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Matcher).To(Equal("exact"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[0].Value).To(Equal("testexact"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[1].Matcher).To(Equal("glob"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query[1].Value).To(Equal("testglob"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(HaveLen(2))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Matcher).To(Equal("exact"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[0].Value).To(Equal("testexact"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[1].Matcher).To(Equal("glob"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery[1].Value).To(Equal("testglob"))
 }
 
 func Test_upgradeV4_HandlesNewHeaders(t *testing.T) {

--- a/core/handlers/v2/simulation_views_upgrade_test.go
+++ b/core/handlers/v2/simulation_views_upgrade_test.go
@@ -839,10 +839,10 @@ func Test_upgradeV4_HandlesNewQueries(t *testing.T) {
 
 	Expect(upgradedSimulation.RequestResponsePairs).To(HaveLen(1))
 
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.QueriesWithMatchers).To(HaveLen(1))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.QueriesWithMatchers["test"]).To(HaveLen(2))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.QueriesWithMatchers["test"][0].Matcher).To(Equal("exact"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.QueriesWithMatchers["test"][0].Value).To(Equal("testexact"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.QueriesWithMatchers["test"][1].Matcher).To(Equal("glob"))
-	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.QueriesWithMatchers["test"][1].Value).To(Equal("testglob"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query).To(HaveLen(1))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query["test"]).To(HaveLen(2))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query["test"][0].Matcher).To(Equal("exact"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query["test"][0].Value).To(Equal("testexact"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query["test"][1].Matcher).To(Equal("glob"))
+	Expect(upgradedSimulation.RequestResponsePairs[0].RequestMatcher.Query["test"][1].Value).To(Equal("testglob"))
 }

--- a/core/handlers/v2/simulation_views_v5..go
+++ b/core/handlers/v2/simulation_views_v5..go
@@ -25,11 +25,11 @@ type RequestMatcherViewV5 struct {
 	Method              []MatcherViewV5            `json:"method,omitempty"`
 	Destination         []MatcherViewV5            `json:"destination,omitempty"`
 	Scheme              []MatcherViewV5            `json:"scheme,omitempty"`
-	Query               []MatcherViewV5            `json:"query,omitempty"`
 	Body                []MatcherViewV5            `json:"body,omitempty"`
 	Headers             map[string][]MatcherViewV5 `json:"headers,omitempty"`
 	QueriesWithMatchers map[string][]MatcherViewV5 `json:"queriesWithMatchers,omitempty"`
 	RequiresState       map[string]string          `json:"requiresState,omitempty"`
+	DepricatedQuery     []MatcherViewV5            `json:"depricatedQuery,omitempty"`
 }
 
 type MatcherViewV5 struct {

--- a/core/handlers/v2/simulation_views_v5..go
+++ b/core/handlers/v2/simulation_views_v5..go
@@ -21,15 +21,15 @@ type RequestMatcherResponsePairViewV5 struct {
 
 // RequestDetailsView is used when marshalling and unmarshalling RequestDetails
 type RequestMatcherViewV5 struct {
-	Path                []MatcherViewV5            `json:"path,omitempty"`
-	Method              []MatcherViewV5            `json:"method,omitempty"`
-	Destination         []MatcherViewV5            `json:"destination,omitempty"`
-	Scheme              []MatcherViewV5            `json:"scheme,omitempty"`
-	Body                []MatcherViewV5            `json:"body,omitempty"`
-	Headers             map[string][]MatcherViewV5 `json:"headers,omitempty"`
-	QueriesWithMatchers map[string][]MatcherViewV5 `json:"queriesWithMatchers,omitempty"`
-	RequiresState       map[string]string          `json:"requiresState,omitempty"`
-	DepricatedQuery     []MatcherViewV5            `json:"depricatedQuery,omitempty"`
+	Path            []MatcherViewV5            `json:"path,omitempty"`
+	Method          []MatcherViewV5            `json:"method,omitempty"`
+	Destination     []MatcherViewV5            `json:"destination,omitempty"`
+	Scheme          []MatcherViewV5            `json:"scheme,omitempty"`
+	Body            []MatcherViewV5            `json:"body,omitempty"`
+	Headers         map[string][]MatcherViewV5 `json:"headers,omitempty"`
+	Query           map[string][]MatcherViewV5 `json:"query,omitempty"`
+	RequiresState   map[string]string          `json:"requiresState,omitempty"`
+	DepricatedQuery []MatcherViewV5            `json:"depricatedQuery,omitempty"`
 }
 
 type MatcherViewV5 struct {

--- a/core/handlers/v2/simulation_views_validation.go
+++ b/core/handlers/v2/simulation_views_validation.go
@@ -450,7 +450,8 @@ var SimulationViewV5Schema = map[string]interface{}{
 		"response":              responseDefinitionV4,
 		"field-matchers":        requestFieldMatchersV5Definition,
 		"headers":               headersDefinition,
-		"request-headers":       headersV5Definition,
+		"request-headers":       v5MatchersMapDefinition,
+		"request-queries":       v5MatchersMapDefinition,
 		"delay":                 delaysDefinition,
 		"meta":                  metaDefinition,
 	},
@@ -478,10 +479,7 @@ var requestV5Definition = map[string]interface{}{
 			},
 		},
 		"query": map[string]interface{}{
-			"type": "array",
-			"items": map[string]interface{}{
-				"$ref": "#/definitions/field-matchers",
-			},
+			"$ref": "#/definitions/request-queries",
 		},
 		"body": map[string]interface{}{
 			"type": "array",
@@ -511,7 +509,7 @@ var requestFieldMatchersV5Definition = map[string]interface{}{
 	},
 }
 
-var headersV5Definition = map[string]interface{}{
+var v5MatchersMapDefinition = map[string]interface{}{
 	"type": "object",
 	"additionalProperties": map[string]interface{}{
 		"type": "array",

--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -150,6 +150,16 @@ func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.Respon
 		}
 	}
 
+	queries := map[string][]models.RequestFieldMatchers{}
+	for key, values := range request.Query {
+		queries[key] = []models.RequestFieldMatchers{
+			{
+				Matcher: matchers.Exact,
+				Value:   strings.Join(values, "&"),
+			},
+		}
+	}
+
 	pair := models.RequestMatcherResponsePair{
 		RequestMatcher: models.RequestMatcher{
 			Path: []models.RequestFieldMatchers{
@@ -176,14 +186,9 @@ func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.Respon
 					Value:   request.Scheme,
 				},
 			},
-			Query: []models.RequestFieldMatchers{
-				{
-					Matcher: matchers.Exact,
-					Value:   request.QueryString(),
-				},
-			},
-			Body:    body,
-			Headers: requestHeaders,
+			QueriesWithMatchers: queries,
+			Body:                body,
+			Headers:             requestHeaders,
 		},
 		Response: *response,
 	}

--- a/core/hoverfly_funcs_test.go
+++ b/core/hoverfly_funcs_test.go
@@ -596,9 +596,13 @@ func Test_Hoverfly_Save_SavesRequestAndResponseToSimulation(t *testing.T) {
 	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Path).To(HaveLen(1))
 	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Path[0].Matcher).To(Equal("exact"))
 	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Path[0].Value).To(Equal("/testpath"))
-	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Query[0].Matcher).To(Equal("exact"))
-	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Query[0].Value).To(Equal("query=test"))
+	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.QueriesWithMatchers).To(HaveLen(1))
+	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.QueriesWithMatchers).To(HaveKeyWithValue("query", []models.RequestFieldMatchers{
+		{
+			Matcher: matchers.Exact,
+			Value:   "test",
+		},
+	}))
 	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Scheme).To(HaveLen(1))
 	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Scheme[0].Matcher).To(Equal("exact"))
 	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Scheme[0].Value).To(Equal("http"))
@@ -765,11 +769,7 @@ func Test_Hoverfly_Save_SavesIncompleteRequestAndResponseToSimulation(t *testing
 		Value:   "",
 	}))
 
-	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Query).To(HaveLen(1))
-	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Query[0]).To(Equal(models.RequestFieldMatchers{
-		Matcher: "exact",
-		Value:   "",
-	}))
+	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.QueriesWithMatchers).To(HaveLen(0))
 
 	Expect(unit.Simulation.GetMatchingPairs()[0].RequestMatcher.Headers).To(HaveLen(0))
 

--- a/core/hoverfly_service_test.go
+++ b/core/hoverfly_service_test.go
@@ -140,7 +140,7 @@ func Test_Hoverfly_GetSimulation_ReturnsASingleRequestResponsePair(t *testing.T)
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Destination[0].Value).To(Equal("test.com"))
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Path).To(BeNil())
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Method).To(BeNil())
-	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Query).To(BeNil())
+	Expect(simulation.RequestResponsePairs[0].RequestMatcher.DepricatedQuery).To(BeNil())
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Scheme).To(BeNil())
 	Expect(simulation.RequestResponsePairs[0].RequestMatcher.Headers).To(HaveLen(0))
 

--- a/core/import_test.go
+++ b/core/import_test.go
@@ -221,7 +221,7 @@ func TestImportRequestResponsePairs_CanImportASinglePair(t *testing.T) {
 					Value:   "scheme",
 				},
 			},
-			Query: []v2.MatcherViewV5{
+			DepricatedQuery: []v2.MatcherViewV5{
 				{
 					Matcher: matchers.Exact,
 					Value:   "",
@@ -342,7 +342,7 @@ func TestImportImportRequestResponsePairs_CanImportAMultiplePairsAndSetTemplateE
 					Value:   "scheme",
 				},
 			},
-			Query: []v2.MatcherViewV5{
+			DepricatedQuery: []v2.MatcherViewV5{
 				{
 					Matcher: matchers.Exact,
 					Value:   "",
@@ -640,7 +640,7 @@ func TestImportImportRequestResponsePairs_CanImportASingleBase64EncodedPair(t *t
 					Value:   "scheme",
 				},
 			},
-			Query: []v2.MatcherViewV5{
+			DepricatedQuery: []v2.MatcherViewV5{
 				{
 					Matcher: matchers.Exact,
 					Value:   "",

--- a/core/journal/journal.go
+++ b/core/journal/journal.go
@@ -147,7 +147,7 @@ func (this Journal) GetFilteredEntries(journalEntryFilterView v2.JournalEntryFil
 		Method:      models.NewRequestFieldMatchersFromView(journalEntryFilterView.Request.Method),
 		Destination: models.NewRequestFieldMatchersFromView(journalEntryFilterView.Request.Destination),
 		Scheme:      models.NewRequestFieldMatchersFromView(journalEntryFilterView.Request.Scheme),
-		Query:       models.NewRequestFieldMatchersFromView(journalEntryFilterView.Request.Query),
+		Query:       models.NewRequestFieldMatchersFromView(journalEntryFilterView.Request.DepricatedQuery),
 		Body:        models.NewRequestFieldMatchersFromView(journalEntryFilterView.Request.Body),
 		Headers:     models.NewRequestFieldMatchersFromMapView(journalEntryFilterView.Request.Headers),
 	}

--- a/core/journal/journal_test.go
+++ b/core/journal/journal_test.go
@@ -604,7 +604,7 @@ func Test_Journal_GetFilteredEntries_WillFilterOnRequestFields(t *testing.T) {
 
 	Expect(unit.GetFilteredEntries(v2.JournalEntryFilterView{
 		Request: &v2.RequestMatcherViewV5{
-			Query: []v2.MatcherViewV5{
+			DepricatedQuery: []v2.MatcherViewV5{
 				{
 					Matcher: matchers.Exact,
 					Value:   "one=1&two=2",
@@ -615,7 +615,7 @@ func Test_Journal_GetFilteredEntries_WillFilterOnRequestFields(t *testing.T) {
 
 	Expect(unit.GetFilteredEntries(v2.JournalEntryFilterView{
 		Request: &v2.RequestMatcherViewV5{
-			Query: []v2.MatcherViewV5{
+			DepricatedQuery: []v2.MatcherViewV5{
 				{
 					Matcher: matchers.Glob,
 					Value:   "one=1*",
@@ -626,7 +626,7 @@ func Test_Journal_GetFilteredEntries_WillFilterOnRequestFields(t *testing.T) {
 
 	Expect(unit.GetFilteredEntries(v2.JournalEntryFilterView{
 		Request: &v2.RequestMatcherViewV5{
-			Query: []v2.MatcherViewV5{
+			DepricatedQuery: []v2.MatcherViewV5{
 				{
 					Matcher: matchers.Exact,
 					Value:   "does-not-match",

--- a/core/matching/first_match_strategy_test.go
+++ b/core/matching/first_match_strategy_test.go
@@ -485,7 +485,7 @@ func Test_FirstMatchStrategy_RequestMatcherResponsePairCanBeConvertedToARequestR
 	Expect(pairView.RequestMatcher.Destination).To(BeNil())
 	Expect(pairView.RequestMatcher.Path).To(BeNil())
 	Expect(pairView.RequestMatcher.Scheme).To(BeNil())
-	Expect(pairView.RequestMatcher.Query).To(BeNil())
+	Expect(pairView.RequestMatcher.DepricatedQuery).To(BeNil())
 
 	Expect(pairView.Response.Body).To(Equal("request matched"))
 }
@@ -605,7 +605,7 @@ func Test_FirstMatchStrategy_RequestMatcherResponsePair_ConvertToRequestResponse
 	Expect(pairView.RequestMatcher.Destination).To(BeNil())
 	Expect(pairView.RequestMatcher.Path).To(BeNil())
 	Expect(pairView.RequestMatcher.Scheme).To(BeNil())
-	Expect(pairView.RequestMatcher.Query).To(BeNil())
+	Expect(pairView.RequestMatcher.DepricatedQuery).To(BeNil())
 
 	Expect(pairView.Response.Body).To(Equal("request matched"))
 }

--- a/core/matching/first_match_strategy_test.go
+++ b/core/matching/first_match_strategy_test.go
@@ -485,7 +485,8 @@ func Test_FirstMatchStrategy_RequestMatcherResponsePairCanBeConvertedToARequestR
 	Expect(pairView.RequestMatcher.Destination).To(BeNil())
 	Expect(pairView.RequestMatcher.Path).To(BeNil())
 	Expect(pairView.RequestMatcher.Scheme).To(BeNil())
-	Expect(pairView.RequestMatcher.DepricatedQuery).To(BeNil())
+	Expect(pairView.RequestMatcher.Query).To(HaveLen(0))
+	Expect(pairView.RequestMatcher.Headers).To(HaveLen(0))
 
 	Expect(pairView.Response.Body).To(Equal("request matched"))
 }
@@ -605,7 +606,8 @@ func Test_FirstMatchStrategy_RequestMatcherResponsePair_ConvertToRequestResponse
 	Expect(pairView.RequestMatcher.Destination).To(BeNil())
 	Expect(pairView.RequestMatcher.Path).To(BeNil())
 	Expect(pairView.RequestMatcher.Scheme).To(BeNil())
-	Expect(pairView.RequestMatcher.DepricatedQuery).To(BeNil())
+	Expect(pairView.RequestMatcher.Query).To(HaveLen(0))
+	Expect(pairView.RequestMatcher.Headers).To(HaveLen(0))
 
 	Expect(pairView.Response.Body).To(Equal("request matched"))
 }

--- a/core/matching/query_matching.go
+++ b/core/matching/query_matching.go
@@ -13,6 +13,10 @@ func QueryMatching(requestMatcher models.RequestMatcher, toMatch map[string][]st
 
 	requestMatcherQueriesWithMatchers := requestMatcher.QueriesWithMatchers
 
+	for key, value := range toMatch {
+		toMatch[strings.ToLower(key)] = value
+	}
+
 	for matcherQueryKey, matcherQueryValue := range requestMatcherQueriesWithMatchers {
 		matcherHeaderValueMatched := false
 

--- a/core/matching/query_matching_test.go
+++ b/core/matching/query_matching_test.go
@@ -117,6 +117,38 @@ var queryMatchingTests = []queryMatchingTest{
 		equals:      BeFalse(),
 		matchEquals: Equal(2),
 	},
+	{
+		name: "Can handle different cases 1",
+		queriesWithMatchers: map[string][]models.RequestFieldMatchers{
+			"urlPattern": {
+				{
+					Matcher: matchers.Glob,
+					Value:   "test-(.+).com",
+				},
+			},
+		},
+		toMatchQueries: map[string][]string{
+			"urlPattern": {"test-(.+).com"},
+		},
+		equals:      BeTrue(),
+		matchEquals: Equal(1),
+	},
+	{
+		name: "Can handle different cases 2",
+		queriesWithMatchers: map[string][]models.RequestFieldMatchers{
+			"urlPattern": {
+				{
+					Matcher: matchers.Glob,
+					Value:   "test-(.+).com",
+				},
+			},
+		},
+		toMatchQueries: map[string][]string{
+			"URLPATTERN": {"test-(.+).com"},
+		},
+		equals:      BeTrue(),
+		matchEquals: Equal(1),
+	},
 }
 
 func Test_QueryMatching(t *testing.T) {

--- a/core/matching/strongest_match_strategy_test.go
+++ b/core/matching/strongest_match_strategy_test.go
@@ -1442,10 +1442,12 @@ func Test_ShouldReturnMessageForClosestMiss(t *testing.T) {
 					Value:   "miss",
 				},
 			},
-			DepricatedQuery: []v2.MatcherViewV5{
-				{
-					Matcher: matchers.Exact,
-					Value:   "hit",
+			Query: map[string][]v2.MatcherViewV5{
+				"query": []v2.MatcherViewV5{
+					{
+						Matcher: matchers.Exact,
+						Value:   "hit",
+					},
 				},
 			},
 			Scheme: []v2.MatcherViewV5{
@@ -1538,12 +1540,14 @@ The matcher which came closest was:
             }
         ]
     },
-    "depricatedQuery": [
-        {
-            "matcher": "exact",
-            "value": "hit"
-        }
-    ]
+    "query": {
+        "query": [
+            {
+                "matcher": "exact",
+                "value": "hit"
+            }
+        ]
+    }
 }
 
 But it did not match on the following fields:

--- a/core/matching/strongest_match_strategy_test.go
+++ b/core/matching/strongest_match_strategy_test.go
@@ -1442,7 +1442,7 @@ func Test_ShouldReturnMessageForClosestMiss(t *testing.T) {
 					Value:   "miss",
 				},
 			},
-			Query: []v2.MatcherViewV5{
+			DepricatedQuery: []v2.MatcherViewV5{
 				{
 					Matcher: matchers.Exact,
 					Value:   "hit",
@@ -1524,12 +1524,6 @@ The matcher which came closest was:
             "value": "hit"
         }
     ],
-    "query": [
-        {
-            "matcher": "exact",
-            "value": "hit"
-        }
-    ],
     "body": [
         {
             "matcher": "glob",
@@ -1543,7 +1537,13 @@ The matcher which came closest was:
                 "value": "miss"
             }
         ]
-    }
+    },
+    "depricatedQuery": [
+        {
+            "matcher": "exact",
+            "value": "hit"
+        }
+    ]
 }
 
 But it did not match on the following fields:

--- a/core/models/request_matcher.go
+++ b/core/models/request_matcher.go
@@ -51,10 +51,10 @@ type RequestMatcherResponsePair struct {
 }
 
 func NewRequestMatcherResponsePairFromView(view *v2.RequestMatcherResponsePairViewV5) *RequestMatcherResponsePair {
-	for i, matcher := range view.RequestMatcher.Query {
+	for i, matcher := range view.RequestMatcher.DepricatedQuery {
 		if matcher.Matcher == matchers.Exact {
 			sortedQuery := util.SortQueryString(matcher.Value.(string))
-			view.RequestMatcher.Query[i].Value = sortedQuery
+			view.RequestMatcher.DepricatedQuery[i].Value = sortedQuery
 		}
 	}
 
@@ -64,7 +64,7 @@ func NewRequestMatcherResponsePairFromView(view *v2.RequestMatcherResponsePairVi
 			Method:              NewRequestFieldMatchersFromView(view.RequestMatcher.Method),
 			Destination:         NewRequestFieldMatchersFromView(view.RequestMatcher.Destination),
 			Scheme:              NewRequestFieldMatchersFromView(view.RequestMatcher.Scheme),
-			Query:               NewRequestFieldMatchersFromView(view.RequestMatcher.Query),
+			Query:               NewRequestFieldMatchersFromView(view.RequestMatcher.DepricatedQuery),
 			Body:                NewRequestFieldMatchersFromView(view.RequestMatcher.Body),
 			Headers:             NewRequestFieldMatchersFromMapView(view.RequestMatcher.Headers),
 			QueriesWithMatchers: NewRequestFieldMatchersFromMapView(view.RequestMatcher.QueriesWithMatchers),
@@ -150,7 +150,7 @@ func (this *RequestMatcherResponsePair) BuildView() v2.RequestMatcherResponsePai
 			Method:              method,
 			Destination:         destination,
 			Scheme:              scheme,
-			Query:               query,
+			DepricatedQuery:     query,
 			Body:                body,
 			Headers:             headersWithMatchers,
 			QueriesWithMatchers: queriesWithMatchers,

--- a/core/models/request_matcher.go
+++ b/core/models/request_matcher.go
@@ -67,7 +67,7 @@ func NewRequestMatcherResponsePairFromView(view *v2.RequestMatcherResponsePairVi
 			Query:               NewRequestFieldMatchersFromView(view.RequestMatcher.DepricatedQuery),
 			Body:                NewRequestFieldMatchersFromView(view.RequestMatcher.Body),
 			Headers:             NewRequestFieldMatchersFromMapView(view.RequestMatcher.Headers),
-			QueriesWithMatchers: NewRequestFieldMatchersFromMapView(view.RequestMatcher.QueriesWithMatchers),
+			QueriesWithMatchers: NewRequestFieldMatchersFromMapView(view.RequestMatcher.Query),
 			RequiresState:       view.RequestMatcher.RequiresState,
 		},
 		Response: NewResponseDetailsFromResponse(view.Response),
@@ -146,15 +146,15 @@ func (this *RequestMatcherResponsePair) BuildView() v2.RequestMatcherResponsePai
 
 	return v2.RequestMatcherResponsePairViewV5{
 		RequestMatcher: v2.RequestMatcherViewV5{
-			Path:                path,
-			Method:              method,
-			Destination:         destination,
-			Scheme:              scheme,
-			DepricatedQuery:     query,
-			Body:                body,
-			Headers:             headersWithMatchers,
-			QueriesWithMatchers: queriesWithMatchers,
-			RequiresState:       this.RequestMatcher.RequiresState,
+			Path:            path,
+			Method:          method,
+			Destination:     destination,
+			Scheme:          scheme,
+			DepricatedQuery: query,
+			Body:            body,
+			Headers:         headersWithMatchers,
+			Query:           queriesWithMatchers,
+			RequiresState:   this.RequestMatcher.RequiresState,
 		},
 		Response: this.Response.ConvertToResponseDetailsViewV5(),
 	}

--- a/core/models/request_matcher_test.go
+++ b/core/models/request_matcher_test.go
@@ -132,7 +132,7 @@ func Test_NewRequestMatcherResponsePairFromView_SortsQuery(t *testing.T) {
 
 	unit := models.NewRequestMatcherResponsePairFromView(&v2.RequestMatcherResponsePairViewV5{
 		RequestMatcher: v2.RequestMatcherViewV5{
-			Query: []v2.MatcherViewV5{
+			DepricatedQuery: []v2.MatcherViewV5{
 				{
 					Matcher: matchers.Exact,
 					Value:   "b=b&a=a",

--- a/core/models/request_matcher_test.go
+++ b/core/models/request_matcher_test.go
@@ -127,7 +127,7 @@ func Test_NewRequestMatcherResponsePairFromView_LeavesQueriesWithMatchersNil(t *
 	Expect(unit.RequestMatcher.QueriesWithMatchers).To(BeNil())
 }
 
-func Test_NewRequestMatcherResponsePairFromView_SortsQuery(t *testing.T) {
+func Test_NewRequestMatcherResponsePairFromView_SortsDepricatedQuery(t *testing.T) {
 	RegisterTestingT(t)
 
 	unit := models.NewRequestMatcherResponsePairFromView(&v2.RequestMatcherResponsePairViewV5{

--- a/core/models/request_matcher_test.go
+++ b/core/models/request_matcher_test.go
@@ -65,7 +65,7 @@ func Test_NewRequestMatcherResponsePairFromView_BuildsPair(t *testing.T) {
 					},
 				},
 			},
-			QueriesWithMatchers: map[string][]v2.MatcherViewV5{
+			Query: map[string][]v2.MatcherViewV5{
 				"Query": {
 					{
 						Matcher: matchers.Exact,

--- a/examples/simulations/hoverfly.io.json
+++ b/examples/simulations/hoverfly.io.json
@@ -70,12 +70,7 @@
 							"value": "http"
 						}
 					],
-					"query": [
-						{
-							"matcher": "exact",
-							"value": ""
-						}
-					],
+					"query": {},
 					"body": [
 						{
 							"matcher": "exact",
@@ -171,12 +166,7 @@
 							"value": "https"
 						}
 					],
-					"query": [
-						{
-							"matcher": "exact",
-							"value": ""
-						}
-					],
+					"query": {},
 					"body": [
 						{
 							"matcher": "exact",

--- a/functional-tests/core/ft_api_v2_simulation_test.go
+++ b/functional-tests/core/ft_api_v2_simulation_test.go
@@ -87,7 +87,7 @@ var _ = Describe("/api/v2/simulation", func() {
 			Expect(pathMatchers[0].GetString("matcher")).Should(Equal("exact"))
 			Expect(pathMatchers[0].GetString("value")).Should(Equal("/path1"))
 
-			queryMatchers, err := pairOneRequest.GetObjectArray("query")
+			queryMatchers, err := pairOneRequest.GetObjectArray("depricatedQuery")
 			Expect(err).To(BeNil())
 
 			Expect(queryMatchers[0].GetString("matcher")).Should(Equal("exact"))

--- a/functional-tests/core/ft_api_v2_simulation_test.go
+++ b/functional-tests/core/ft_api_v2_simulation_test.go
@@ -87,12 +87,6 @@ var _ = Describe("/api/v2/simulation", func() {
 			Expect(pathMatchers[0].GetString("matcher")).Should(Equal("exact"))
 			Expect(pathMatchers[0].GetString("value")).Should(Equal("/path1"))
 
-			queryMatchers, err := pairOneRequest.GetObjectArray("depricatedQuery")
-			Expect(err).To(BeNil())
-
-			Expect(queryMatchers[0].GetString("matcher")).Should(Equal("exact"))
-			Expect(queryMatchers[0].GetString("value")).Should(Equal(""))
-
 			schemeMatchers, err := pairOneRequest.GetObjectArray("scheme")
 			Expect(err).To(BeNil())
 

--- a/functional-tests/core/ft_capture_mode_test.go
+++ b/functional-tests/core/ft_capture_mode_test.go
@@ -86,12 +86,6 @@ var _ = Describe("When I run Hoverfly", func() {
 							Value:   "http",
 						},
 					},
-					Query: []v2.MatcherViewV5{
-						{
-							Matcher: matchers.Exact,
-							Value:   "",
-						},
-					},
 					Body: []v2.MatcherViewV5{
 						{
 							Matcher: matchers.Exact,

--- a/functional-tests/hoverctl/import_export_test.go
+++ b/functional-tests/hoverctl/import_export_test.go
@@ -60,7 +60,7 @@ var _ = Describe("When I use hoverctl", func() {
 									"value": "http"
 								}
 							],
-							"query": [
+							"depricatedQuery": [
 								{
 									"matcher": "exact",
 									"value": ""
@@ -131,7 +131,7 @@ var _ = Describe("When I use hoverctl", func() {
 									"value": "http"
 								}
 							],
-							"query": [
+							"depricatedQuery": [
 								{
 									"matcher": "exact",
 									"value": ""
@@ -194,7 +194,7 @@ var _ = Describe("When I use hoverctl", func() {
 				}
 			}`
 
-		hoverflySimulation = `"pairs":[{"request":{"path":[{"matcher":"exact","value":"/api/bookings"}],"method":[{"matcher":"exact","value":"POST"}],"destination":[{"matcher":"exact","value":"www.my-test.com"}],"scheme":[{"matcher":"exact","value":"http"}],"query":[{"matcher":"exact","value":""}],"body":[{"matcher":"exact","value":"{\"flightId\": \"1\"}"}],"headers":{"Content-Type":[{"matcher":"exact","value":"application/json"}]}},"response":{"status":201,"body":"","encodedBody":false,"headers":{"Location":["http://localhost/api/bookings/1"]},"templated":false}}],"globalActions":{"delays":[]}}`
+		hoverflySimulation = `"pairs":[{"request":{"path":[{"matcher":"exact","value":"/api/bookings"}],"method":[{"matcher":"exact","value":"POST"}],"destination":[{"matcher":"exact","value":"www.my-test.com"}],"scheme":[{"matcher":"exact","value":"http"}],"body":[{"matcher":"exact","value":"{\"flightId\": \"1\"}"}],"headers":{"Content-Type":[{"matcher":"exact","value":"application/json"}]},"depricatedQuery":[{"matcher":"exact","value":""}]},"response":{"status":201,"body":"","encodedBody":false,"headers":{"Location":["http://localhost/api/bookings/1"]},"templated":false}}],"globalActions":{"delays":[]}}`
 
 		hoverflyMeta = `"meta":{"schemaVersion":"v5","hoverflyVersion":"v\d+.\d+.\d+","timeExported":`
 	)

--- a/functional-tests/hoverctl/import_export_test.go
+++ b/functional-tests/hoverctl/import_export_test.go
@@ -60,12 +60,6 @@ var _ = Describe("When I use hoverctl", func() {
 									"value": "http"
 								}
 							],
-							"depricatedQuery": [
-								{
-									"matcher": "exact",
-									"value": ""
-								}
-							],
 							"body": [
 								{
 									"matcher": "exact",
@@ -131,12 +125,6 @@ var _ = Describe("When I use hoverctl", func() {
 									"value": "http"
 								}
 							],
-							"depricatedQuery": [
-								{
-									"matcher": "exact",
-									"value": ""
-								}
-							],
 							"body": [
 								{
 									"matcher": "exact",
@@ -194,7 +182,7 @@ var _ = Describe("When I use hoverctl", func() {
 				}
 			}`
 
-		hoverflySimulation = `"pairs":[{"request":{"path":[{"matcher":"exact","value":"/api/bookings"}],"method":[{"matcher":"exact","value":"POST"}],"destination":[{"matcher":"exact","value":"www.my-test.com"}],"scheme":[{"matcher":"exact","value":"http"}],"body":[{"matcher":"exact","value":"{\"flightId\": \"1\"}"}],"headers":{"Content-Type":[{"matcher":"exact","value":"application/json"}]},"depricatedQuery":[{"matcher":"exact","value":""}]},"response":{"status":201,"body":"","encodedBody":false,"headers":{"Location":["http://localhost/api/bookings/1"]},"templated":false}}],"globalActions":{"delays":[]}}`
+		hoverflySimulation = `"pairs":[{"request":{"path":[{"matcher":"exact","value":"/api/bookings"}],"method":[{"matcher":"exact","value":"POST"}],"destination":[{"matcher":"exact","value":"www.my-test.com"}],"scheme":[{"matcher":"exact","value":"http"}],"body":[{"matcher":"exact","value":"{\"flightId\": \"1\"}"}],"headers":{"Content-Type":[{"matcher":"exact","value":"application/json"}]}},"response":{"status":201,"body":"","encodedBody":false,"headers":{"Location":["http://localhost/api/bookings/1"]},"templated":false}}],"globalActions":{"delays":[]}}`
 
 		hoverflyMeta = `"meta":{"schemaVersion":"v5","hoverflyVersion":"v\d+.\d+.\d+","timeExported":`
 	)

--- a/functional-tests/testdata/delays.go
+++ b/functional-tests/testdata/delays.go
@@ -29,7 +29,7 @@ var Delays = `{
 							"value": "http"
 						}
 					],
-					"query": [
+					"depricatedQuery": [
 						{
 							"matcher": "exact",
 							"value": ""

--- a/functional-tests/testdata/exact_match.go
+++ b/functional-tests/testdata/exact_match.go
@@ -29,7 +29,7 @@ var ExactMatch = `{
 							"value": "http"
 						}
 					],
-					"query": [
+					"depricatedQuery": [
 						{
 							"matcher": "exact",
 							"value": ""
@@ -88,7 +88,7 @@ var ExactMatch = `{
 							"value": "http"
 						}
 					],
-					"query": [
+					"depricatedQuery": [
 						{
 							"matcher": "exact",
 							"value": ""

--- a/functional-tests/testdata/issue_607.go
+++ b/functional-tests/testdata/issue_607.go
@@ -29,7 +29,7 @@ var Issue607 = `{
 							"value": "https"
 						}
 					],
-					"query": [
+					"depricatedQuery": [
 						{
 							"matcher": "exact",
 							"value": "saleschannel=RETAIL"

--- a/functional-tests/testdata/json_get_and_post.go
+++ b/functional-tests/testdata/json_get_and_post.go
@@ -29,12 +29,6 @@ var JsonGetAndPost = `{
 							"value": "http"
 						}
 					],
-					"query": [
-						{
-							"matcher": "exact",
-							"value": ""
-						}
-					],
 					"body": [
 						{
 							"matcher": "exact",
@@ -79,12 +73,6 @@ var JsonGetAndPost = `{
 						{
 							"matcher": "exact",
 							"value": "http"
-						}
-					],
-					"query": [
-						{
-							"matcher": "exact",
-							"value": ""
 						}
 					],
 					"body": [

--- a/functional-tests/testdata/json_payload.go
+++ b/functional-tests/testdata/json_payload.go
@@ -29,12 +29,6 @@ var JsonPayload = `{
 							"value": "http"
 						}
 					],
-					"depricatedQuery": [
-						{
-							"matcher": "exact",
-							"value": ""
-						}
-					],
 					"body": [
 						{
 							"matcher": "exact",

--- a/functional-tests/testdata/json_payload.go
+++ b/functional-tests/testdata/json_payload.go
@@ -29,7 +29,7 @@ var JsonPayload = `{
 							"value": "http"
 						}
 					],
-					"query": [
+					"depricatedQuery": [
 						{
 							"matcher": "exact",
 							"value": ""

--- a/functional-tests/testdata/json_payload_v1.go
+++ b/functional-tests/testdata/json_payload_v1.go
@@ -45,7 +45,7 @@ var V5JsonPayload = `{
 							"value": "http"
 						}
 					],
-					"query": [
+					"depricatedQuery": [
 						{
 							"matcher": "exact",
 							"value": ""

--- a/functional-tests/testdata/preload_cache.go
+++ b/functional-tests/testdata/preload_cache.go
@@ -29,7 +29,7 @@ var PreloadCache = `{
 							"value": "http"
 						}
 					],
-					"query": [
+					"depricatedQuery": [
 						{
 							"matcher": "exact",
 							"value": ""

--- a/functional-tests/testdata/query_matchers.go
+++ b/functional-tests/testdata/query_matchers.go
@@ -5,7 +5,7 @@ var QueryMatchers = `{
 		"pairs": [
 			{
 				"request": {
-					"queriesWithMatchers": {
+					"query": {
 						"test": [
 							{
 								"matcher": "exact",
@@ -23,7 +23,7 @@ var QueryMatchers = `{
 			},
 			{
 				"request": {
-					"queriesWithMatchers": {
+					"query": {
 						"test": [
 							{
 								"matcher": "exact",

--- a/hoverctl/wrapper/logs_test.go
+++ b/hoverctl/wrapper/logs_test.go
@@ -272,7 +272,7 @@ func Test_GetLogs_FiltersByDateWhenFilterTimeProvided(t *testing.T) {
 								Value:   "/api/v2/logs",
 							},
 						},
-						Query: []v2.MatcherViewV5{
+						DepricatedQuery: []v2.MatcherViewV5{
 							{
 								Matcher: matchers.Exact,
 								Value:   "from=684552180",

--- a/hoverctl/wrapper/logs_test.go
+++ b/hoverctl/wrapper/logs_test.go
@@ -272,10 +272,12 @@ func Test_GetLogs_FiltersByDateWhenFilterTimeProvided(t *testing.T) {
 								Value:   "/api/v2/logs",
 							},
 						},
-						DepricatedQuery: []v2.MatcherViewV5{
-							{
-								Matcher: matchers.Exact,
-								Value:   "from=684552180",
+						Query: map[string][]v2.MatcherViewV5{
+							"from": []v2.MatcherViewV5{
+								{
+									Matcher: matchers.Exact,
+									Value:   "684552180",
+								},
 							},
 						},
 					},

--- a/hoverctl/wrapper/simulation_test.go
+++ b/hoverctl/wrapper/simulation_test.go
@@ -69,10 +69,12 @@ func Test_ExportSimulation_WithUrlPattern(t *testing.T) {
 								Value:   "/api/v2/simulation",
 							},
 						},
-						DepricatedQuery: []v2.MatcherViewV5{
-							{
-								Matcher: matchers.Exact,
-								Value:   "urlPattern=test-(.+).com",
+						Query: map[string][]v2.MatcherViewV5{
+							"urlPattern": []v2.MatcherViewV5{
+								{
+									Matcher: matchers.Exact,
+									Value:   "test-(.+).com",
+								},
 							},
 						},
 					},

--- a/hoverctl/wrapper/simulation_test.go
+++ b/hoverctl/wrapper/simulation_test.go
@@ -69,7 +69,7 @@ func Test_ExportSimulation_WithUrlPattern(t *testing.T) {
 								Value:   "/api/v2/simulation",
 							},
 						},
-						Query: []v2.MatcherViewV5{
+						DepricatedQuery: []v2.MatcherViewV5{
 							{
 								Matcher: matchers.Exact,
 								Value:   "urlPattern=test-(.+).com",

--- a/schema.json
+++ b/schema.json
@@ -72,10 +72,7 @@
 					"type": "array"
 				},
 				"query": {
-					"items": {
-						"$ref": "#/definitions/field-matchers"
-					},
-					"type": "array"
+					"$ref": "#/definitions/request-queries"
 				},
 				"requiresState": {
 					"patternProperties": {
@@ -95,6 +92,15 @@
 			"type": "object"
 		},
 		"request-headers": {
+			"additionalProperties": {
+				"items": {
+					"$ref": "#/definitions/field-matchers"
+				},
+				"type": "array"
+			},
+			"type": "object"
+		},
+		"request-queries": {
 			"additionalProperties": {
 				"items": {
 					"$ref": "#/definitions/field-matchers"


### PR DESCRIPTION
Moving old queries to `depricatedQuery` field.