### PR TITLE
Fix regression where Hoverfly returns Transfer-Encoding and Content-Length

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -39,7 +39,7 @@
     ".",
     "ext/auth"
   ]
-  revision = "1dea5983e671e3bdefb224f2683e5c23678be35e"
+  revision = "dd7c138cbdded1cb839aad1adb64b79414f481ab"
 
 [[projects]]
   branch = "master"
@@ -385,6 +385,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6f8c9123a4fce5abf3b18d9bbff2447315b904934c46063bb35ab9e8574f1c93"
+  inputs-digest = "46e3c5cdaf532213d77c2fb54b22dc1511610a2396f3ccc45828a36dce8a3932"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@
 
 [[constraint]]
   name = "github.com/SpectoLabs/goproxy"
-  revision = "1dea5983e671e3bdefb224f2683e5c23678be35e"
+  revision = "dd7c138cbdded1cb839aad1adb64b79414f481ab"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/SpectoLabs/goproxy/https.go
+++ b/vendor/github.com/SpectoLabs/goproxy/https.go
@@ -243,11 +243,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				// Since we don't know the length of resp, return chunked encoded response
 				// TODO: use a more reasonable scheme
 
-				// Note from Benji
-				// The way we use goproxy, I do not think this is neede for us
-				// https://github.com/SpectoLabs/hoverfly/issues/697
-
-				// resp.Header.Del("Content-Length")
+				resp.Header.Del("Content-Length")
 				resp.Header.Set("Transfer-Encoding", "chunked")
 				if err := resp.Header.Write(rawClientTls); err != nil {
 					ctx.Warnf("Cannot write TLS response header from mitm'd client: %v", err)


### PR DESCRIPTION
This regression was identified in https://github.com/SpectoLabs/hoverfly/issues/727 and came about trying to fix issue https://github.com/SpectoLabs/hoverfly/issues/697