### PR TITLE
Warn users when importing simulations with header problems

### DIFF
--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -50,12 +50,6 @@ func ContentLengthMismatchError() *HoverflyError {
 	}
 }
 
-func ContentLengthAndTransferEncodingHeaderError() *HoverflyError {
-	return &HoverflyError{
-		Message: "Response contains both Content-Length and Transfer-Encoding headers, which is invalid. Please remove one of these headers.",
-	}
-}
-
 func MiddlewareNotSetError() *HoverflyError {
 	return &HoverflyError{
 		Message: "Cannot execute middleware as middleware has not been correctly set",

--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -44,12 +44,6 @@ func MatchingFailedError(closestMiss *models.ClosestMiss) *HoverflyError {
 	}
 }
 
-func ContentLengthMismatchError() *HoverflyError {
-	return &HoverflyError{
-		Message: "Response contains incorrect Content-Length header. Please correct or remove header.",
-	}
-}
-
 func MiddlewareNotSetError() *HoverflyError {
 	return &HoverflyError{
 		Message: "Cannot execute middleware as middleware has not been correctly set",

--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -22,3 +22,9 @@ func MatchingFailedError(closestMiss *models.ClosestMiss) *HoverflyError {
 		StatusCode: 412,
 	}
 }
+
+func ContentLengthMismatchError() *HoverflyError {
+	return &HoverflyError{
+		Message: "Response contains incorrect Content-Length header. Please correct or remove header.",
+	}
+}

--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -49,3 +49,9 @@ func ContentLengthMismatchError() *HoverflyError {
 		Message: "Response contains incorrect Content-Length header. Please correct or remove header.",
 	}
 }
+
+func ContentLengthAndTransferEncodingHeaderError() *HoverflyError {
+	return &HoverflyError{
+		Message: "Response contains both Content-Length and Transfer-Encoding headers, which is invalid. Please remove one of these headers.",
+	}
+}

--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -11,6 +11,27 @@ func (err HoverflyError) Error() string {
 	return err.Message
 }
 
+func NoCacheSetError() *HoverflyError {
+	return &HoverflyError{
+		Message:    "No cache set",
+		StatusCode: 412,
+	}
+}
+
+func RecordedRequestNotInCacheError() *HoverflyError {
+	return &HoverflyError{
+		Message:    "Could not find recorded request in cache",
+		StatusCode: 412,
+	}
+}
+
+func DecodePayloadError() *HoverflyError {
+	return &HoverflyError{
+		Message:    "Failed to decode payload from cache",
+		StatusCode: 500,
+	}
+}
+
 func MatchingFailedError(closestMiss *models.ClosestMiss) *HoverflyError {
 	message := "Could not find a match for request, create or record a valid matcher first!"
 

--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -55,3 +55,9 @@ func ContentLengthAndTransferEncodingHeaderError() *HoverflyError {
 		Message: "Response contains both Content-Length and Transfer-Encoding headers, which is invalid. Please remove one of these headers.",
 	}
 }
+
+func MiddlewareNotSetError() *HoverflyError {
+	return &HoverflyError{
+		Message: "Cannot execute middleware as middleware has not been correctly set",
+	}
+}

--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -3,8 +3,7 @@ package errors
 import "github.com/SpectoLabs/hoverfly/core/models"
 
 type HoverflyError struct {
-	Message    string
-	StatusCode int
+	Message string
 }
 
 func (err HoverflyError) Error() string {
@@ -13,22 +12,19 @@ func (err HoverflyError) Error() string {
 
 func NoCacheSetError() *HoverflyError {
 	return &HoverflyError{
-		Message:    "No cache set",
-		StatusCode: 412,
+		Message: "No cache set",
 	}
 }
 
 func RecordedRequestNotInCacheError() *HoverflyError {
 	return &HoverflyError{
-		Message:    "Could not find recorded request in cache",
-		StatusCode: 412,
+		Message: "Could not find recorded request in cache",
 	}
 }
 
 func DecodePayloadError() *HoverflyError {
 	return &HoverflyError{
-		Message:    "Failed to decode payload from cache",
-		StatusCode: 500,
+		Message: "Failed to decode payload from cache",
 	}
 }
 
@@ -39,8 +35,7 @@ func MatchingFailedError(closestMiss *models.ClosestMiss) *HoverflyError {
 		message = message + closestMiss.GetMessage()
 	}
 	return &HoverflyError{
-		Message:    message,
-		StatusCode: 412,
+		Message: message,
 	}
 }
 

--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -1,0 +1,24 @@
+package errors
+
+import "github.com/SpectoLabs/hoverfly/core/models"
+
+type HoverflyError struct {
+	Message    string
+	StatusCode int
+}
+
+func (err HoverflyError) Error() string {
+	return err.Message
+}
+
+func MatchingFailedError(closestMiss *models.ClosestMiss) *HoverflyError {
+	message := "Could not find a match for request, create or record a valid matcher first!"
+
+	if closestMiss != nil {
+		message = message + closestMiss.GetMessage()
+	}
+	return &HoverflyError{
+		Message:    message,
+		StatusCode: 412,
+	}
+}

--- a/core/handlers/v2/simulation_views.go
+++ b/core/handlers/v2/simulation_views.go
@@ -150,6 +150,7 @@ func BuildSimulationView(pairViews []RequestMatcherResponsePairViewV5, delayView
 
 const deprecatedQueryMessage = "Usage of deprecated field `deprecatedQuery` on data.pairs[%v].request.deprecatedQuery, please update your simulation to use `query` field"
 const deprecatedQueryDocs = "https://hoverfly.readthedocs.io/en/latest/pages/troubleshooting/troubleshooting.html#why-does-my-simulation-have-a-deprecatedquery-field"
+const ContentLengthAndTransferEncodingMessage = "Response contains both Content-Length and Transfer-Encoding headers on data.pairs[%v].response, please remove one of these headers"
 
 type SimulationImportResult struct {
 	err             error                     `json:"error,omitempty"`
@@ -175,4 +176,12 @@ func (s *SimulationImportResult) AddDeprecatedQueryWarning(requestNumber int) {
 		s.WarningMessages = []SimulationImportWarning{}
 	}
 	s.WarningMessages = append(s.WarningMessages, SimulationImportWarning{Message: warning, DocsLink: deprecatedQueryDocs})
+}
+
+func (s *SimulationImportResult) AddContentLengthAndTransferEncodingWarning(requestNumber int) {
+	warning := fmt.Sprintf("WARNING: %s", fmt.Sprintf(ContentLengthAndTransferEncodingMessage, requestNumber))
+	if s.WarningMessages == nil {
+		s.WarningMessages = []SimulationImportWarning{}
+	}
+	s.WarningMessages = append(s.WarningMessages, SimulationImportWarning{Message: warning})
 }

--- a/core/handlers/v2/simulation_views.go
+++ b/core/handlers/v2/simulation_views.go
@@ -151,6 +151,7 @@ func BuildSimulationView(pairViews []RequestMatcherResponsePairViewV5, delayView
 const deprecatedQueryMessage = "Usage of deprecated field `deprecatedQuery` on data.pairs[%v].request.deprecatedQuery, please update your simulation to use `query` field"
 const deprecatedQueryDocs = "https://hoverfly.readthedocs.io/en/latest/pages/troubleshooting/troubleshooting.html#why-does-my-simulation-have-a-deprecatedquery-field"
 const ContentLengthAndTransferEncodingMessage = "Response contains both Content-Length and Transfer-Encoding headers on data.pairs[%v].response, please remove one of these headers"
+const ContentLengthMismatchMessage = "Response contains incorrect Content-Length header on data.pairs[%v].response, please correct or remove header"
 
 type SimulationImportResult struct {
 	err             error                     `json:"error,omitempty"`
@@ -180,6 +181,14 @@ func (s *SimulationImportResult) AddDeprecatedQueryWarning(requestNumber int) {
 
 func (s *SimulationImportResult) AddContentLengthAndTransferEncodingWarning(requestNumber int) {
 	warning := fmt.Sprintf("WARNING: %s", fmt.Sprintf(ContentLengthAndTransferEncodingMessage, requestNumber))
+	if s.WarningMessages == nil {
+		s.WarningMessages = []SimulationImportWarning{}
+	}
+	s.WarningMessages = append(s.WarningMessages, SimulationImportWarning{Message: warning})
+}
+
+func (s *SimulationImportResult) AddContentLengthMismatchWarning(requestNumber int) {
+	warning := fmt.Sprintf("WARNING: %s", fmt.Sprintf(ContentLengthMismatchMessage, requestNumber))
 	if s.WarningMessages == nil {
 		s.WarningMessages = []SimulationImportWarning{}
 	}

--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -95,6 +96,15 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 	}
 	if response.RemovesState != nil {
 		hf.state.RemoveState(response.RemovesState)
+	}
+
+	if len(response.Headers["Content-Length"]) > 0 {
+		contentLength, err := strconv.Atoi(response.Headers["Content-Length"][0])
+		if err == nil && contentLength != len(response.Body) {
+			return nil, &matching.MatchingError{
+				Description: "Response contains incorrect Content-Length header. Please correct or remove header.",
+			}
+		}
 	}
 
 	return &response, nil

--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -102,9 +102,7 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 	if len(response.Headers["Content-Length"]) > 0 {
 		contentLength, err := strconv.Atoi(response.Headers["Content-Length"][0])
 		if err == nil && contentLength != len(response.Body) {
-			return nil, &errors.HoverflyError{
-				Message: "Response contains incorrect Content-Length header. Please correct or remove header.",
-			}
+			return nil, errors.ContentLengthMismatchError()
 		}
 	}
 

--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -97,15 +96,6 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 	}
 	if response.RemovesState != nil {
 		hf.state.RemoveState(response.RemovesState)
-	}
-
-	// Check to make sure if Content-Length header is present, it is correct
-	// If not, return Hoverfly error
-	if len(response.Headers["Content-Length"]) > 0 {
-		contentLength, err := strconv.Atoi(response.Headers["Content-Length"][0])
-		if err == nil && contentLength != len(response.Body) {
-			return nil, errors.ContentLengthMismatchError()
-		}
 	}
 
 	return &response, nil

--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -99,6 +99,14 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 		hf.state.RemoveState(response.RemovesState)
 	}
 
+	// Check to make sure if Content-Length and Transfer-Encodign header are present
+	// If they are, return Hoverfly error
+	if len(response.Headers["Content-Length"]) > 0 && len(response.Headers["Transfer-Encoding"]) > 0 {
+		return nil, errors.ContentLengthAndTransferEncodingHeaderError()
+	}
+
+	// Check to make sure if Content-Length header is present, it is correct
+	// If not, return Hoverfly error
 	if len(response.Headers["Content-Length"]) > 0 {
 		contentLength, err := strconv.Atoi(response.Headers["Content-Length"][0])
 		if err == nil && contentLength != len(response.Body) {

--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -99,12 +99,6 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 		hf.state.RemoveState(response.RemovesState)
 	}
 
-	// Check to make sure if Content-Length and Transfer-Encodign header are present
-	// If they are, return Hoverfly error
-	if len(response.Headers["Content-Length"]) > 0 && len(response.Headers["Transfer-Encoding"]) > 0 {
-		return nil, errors.ContentLengthAndTransferEncodingHeaderError()
-	}
-
 	// Check to make sure if Content-Length header is present, it is correct
 	// If not, return Hoverfly error
 	if len(response.Headers["Content-Length"]) > 0 {

--- a/core/hoverfly_funcs_test.go
+++ b/core/hoverfly_funcs_test.go
@@ -557,6 +557,38 @@ func Test_Hoverfly_GetResponse_GetNotRecordedRequest(t *testing.T) {
 
 	response, err := unit.GetResponse(requestDetails)
 	Expect(err).ToNot(BeNil())
+	Expect(err.Error()).To(Equal("Could not find a match for request, create or record a valid matcher first!"))
+
+	Expect(response).To(BeNil())
+}
+
+func Test_Hoverfly_GetResponse_Errors_ContentLengthMismatch(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewHoverflyWithConfiguration(&Configuration{})
+	unit.Simulation.AddPair(&models.RequestMatcherResponsePair{
+		RequestMatcher: models.RequestMatcher{
+			Destination: []models.RequestFieldMatchers{
+				{
+					Matcher: "exact",
+					Value:   "hoverfly.io",
+				},
+			},
+		},
+		Response: models.ResponseDetails{
+			Body: "1",
+			Headers: map[string][]string{
+				"Content-Length": []string{"42"},
+			},
+		},
+	})
+
+	response, err := unit.GetResponse(models.RequestDetails{
+		Destination: "hoverfly.io",
+	})
+
+	Expect(err).ToNot(BeNil())
+	Expect(err.Error()).To(Equal("Response contains incorrect Content-Length header. Please correct or remove header."))
 
 	Expect(response).To(BeNil())
 }

--- a/core/hoverfly_funcs_test.go
+++ b/core/hoverfly_funcs_test.go
@@ -562,37 +562,6 @@ func Test_Hoverfly_GetResponse_GetNotRecordedRequest(t *testing.T) {
 	Expect(response).To(BeNil())
 }
 
-func Test_Hoverfly_GetResponse_Errors_ContentLengthMismatch(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewHoverflyWithConfiguration(&Configuration{})
-	unit.Simulation.AddPair(&models.RequestMatcherResponsePair{
-		RequestMatcher: models.RequestMatcher{
-			Destination: []models.RequestFieldMatchers{
-				{
-					Matcher: "exact",
-					Value:   "hoverfly.io",
-				},
-			},
-		},
-		Response: models.ResponseDetails{
-			Body: "1",
-			Headers: map[string][]string{
-				"Content-Length": []string{"42"},
-			},
-		},
-	})
-
-	response, err := unit.GetResponse(models.RequestDetails{
-		Destination: "hoverfly.io",
-	})
-
-	Expect(err).ToNot(BeNil())
-	Expect(err.Error()).To(Equal("Response contains incorrect Content-Length header. Please correct or remove header."))
-
-	Expect(response).To(BeNil())
-}
-
 func Test_Hoverfly_Save_SavesRequestAndResponseToSimulation(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/hoverfly_funcs_test.go
+++ b/core/hoverfly_funcs_test.go
@@ -239,8 +239,8 @@ func Test_Hoverfly_GetResponse_WillCacheMisses(t *testing.T) {
 	_, err := unit.GetResponse(requestDetails)
 	Expect(err.Error()).To(Equal("Could not find a match for request, create or record a valid matcher first!"))
 
-	cachedResponse, err := unit.CacheMatcher.GetCachedResponse(&requestDetails)
-	Expect(err).To(BeNil())
+	cachedResponse, matchingErr := unit.CacheMatcher.GetCachedResponse(&requestDetails)
+	Expect(matchingErr).To(BeNil())
 
 	Expect(cachedResponse.MatchingPair).To(BeNil())
 	Expect(cachedResponse.ClosestMiss).To(BeNil())
@@ -282,8 +282,8 @@ func Test_Hoverfly_GetResponse_WillCacheClosestMiss(t *testing.T) {
 	_, err := unit.GetResponse(requestDetails)
 	Expect(err.Error()).ToNot(BeNil())
 
-	cachedResponse, err := unit.CacheMatcher.GetCachedResponse(&requestDetails)
-	Expect(err).To(BeNil())
+	cachedResponse, matchingErr := unit.CacheMatcher.GetCachedResponse(&requestDetails)
+	Expect(matchingErr).To(BeNil())
 
 	Expect(cachedResponse.MatchingPair).To(BeNil())
 	Expect(cachedResponse.ClosestMiss.RequestMatcher.Method[0].Matcher).To(Equal("exact"))

--- a/core/hoverfly_funcs_test.go
+++ b/core/hoverfly_funcs_test.go
@@ -593,38 +593,6 @@ func Test_Hoverfly_GetResponse_Errors_ContentLengthMismatch(t *testing.T) {
 	Expect(response).To(BeNil())
 }
 
-func Test_Hoverfly_GetResponse_Errors_ContentLengthAndTransferEncoding(t *testing.T) {
-	RegisterTestingT(t)
-
-	unit := NewHoverflyWithConfiguration(&Configuration{})
-	unit.Simulation.AddPair(&models.RequestMatcherResponsePair{
-		RequestMatcher: models.RequestMatcher{
-			Destination: []models.RequestFieldMatchers{
-				{
-					Matcher: "exact",
-					Value:   "hoverfly.io",
-				},
-			},
-		},
-		Response: models.ResponseDetails{
-			Body: "1",
-			Headers: map[string][]string{
-				"Content-Length":    []string{"42"},
-				"Transfer-Encoding": []string{"chunked"},
-			},
-		},
-	})
-
-	response, err := unit.GetResponse(models.RequestDetails{
-		Destination: "hoverfly.io",
-	})
-
-	Expect(err).ToNot(BeNil())
-	Expect(err.Error()).To(Equal("Response contains both Content-Length and Transfer-Encoding headers, which is invalid. Please remove one of these headers."))
-
-	Expect(response).To(BeNil())
-}
-
 func Test_Hoverfly_Save_SavesRequestAndResponseToSimulation(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/import.go
+++ b/core/import.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"io/ioutil"
@@ -154,6 +155,13 @@ func (hf *Hoverfly) importRequestResponsePairViews(pairViews []v2.RequestMatcher
 
 			if len(pairView.Response.Headers["Content-Length"]) > 0 && len(pairView.Response.Headers["Transfer-Encoding"]) > 0 {
 				importResult.AddContentLengthAndTransferEncodingWarning(i)
+			}
+
+			if len(pairView.Response.Headers["Content-Length"]) > 0 {
+				contentLength, err := strconv.Atoi(pairView.Response.Headers["Content-Length"][0])
+				if err == nil && contentLength != len(pairView.Response.Body) {
+					importResult.AddContentLengthMismatchWarning(i)
+				}
 			}
 
 			continue

--- a/core/import.go
+++ b/core/import.go
@@ -152,6 +152,10 @@ func (hf *Hoverfly) importRequestResponsePairViews(pairViews []v2.RequestMatcher
 				importResult.AddDeprecatedQueryWarning(i)
 			}
 
+			if len(pairView.Response.Headers["Content-Length"]) > 0 && len(pairView.Response.Headers["Transfer-Encoding"]) > 0 {
+				importResult.AddContentLengthAndTransferEncodingWarning(i)
+			}
+
 			continue
 		}
 

--- a/core/import_test.go
+++ b/core/import_test.go
@@ -707,4 +707,41 @@ func TestImportImportRequestResponsePairs_ReturnsWarningsIfDeprecatedQuerytSet(t
 	result := hv.importRequestResponsePairViews([]v2.RequestMatcherResponsePairViewV5{encodedPair})
 
 	Expect(result.WarningMessages).To(HaveLen(1))
+	Expect(result.WarningMessages[0].Message).To(ContainSubstring("data.pairs[0].request.deprecatedQuery"))
+}
+
+func TestImportImportRequestResponsePairs_ReturnsWarningsContentLengthAndTransferEncodingSet(t *testing.T) {
+	RegisterTestingT(t)
+
+	cache := cache.NewInMemoryCache()
+	cfg := Configuration{Webserver: false}
+	cacheMatcher := matching.CacheMatcher{RequestCache: cache, Webserver: cfg.Webserver}
+	hv := Hoverfly{Cfg: &cfg, CacheMatcher: cacheMatcher, Simulation: models.NewSimulation()}
+
+	RegisterTestingT(t)
+
+	encodedPair := v2.RequestMatcherResponsePairViewV5{
+		Response: v2.ResponseDetailsViewV5{
+			Status:      200,
+			Body:        base64String("hello_world"),
+			EncodedBody: true,
+			Headers: map[string][]string{
+				"Content-Length":    []string{"11"},
+				"Transfer-Encoding": []string{"chunked"},
+			},
+		},
+		RequestMatcher: v2.RequestMatcherViewV5{
+			Destination: []v2.MatcherViewV5{
+				v2.MatcherViewV5{
+					Matcher: "exact",
+					Value:   "hoverfly.io",
+				},
+			},
+		},
+	}
+
+	result := hv.importRequestResponsePairViews([]v2.RequestMatcherResponsePairViewV5{encodedPair})
+
+	Expect(result.WarningMessages).To(HaveLen(1))
+	Expect(result.WarningMessages[0].Message).To(ContainSubstring("Response contains both Content-Length and Transfer-Encoding headers on data.pairs[0].response"))
 }

--- a/core/matching/matcher.go
+++ b/core/matching/matcher.go
@@ -54,12 +54,3 @@ func isCachable(requestMatch *models.RequestMatcherResponsePair, matchedOnAllBut
 
 	return true
 }
-
-type MatchingError struct {
-	StatusCode  int
-	Description string
-}
-
-func (this MatchingError) Error() string {
-	return this.Description
-}

--- a/core/matching/matcher.go
+++ b/core/matching/matcher.go
@@ -63,15 +63,3 @@ type MatchingError struct {
 func (this MatchingError) Error() string {
 	return this.Description
 }
-
-func MissedError(miss *models.ClosestMiss) *MatchingError {
-	description := "Could not find a match for request, create or record a valid matcher first!"
-
-	if miss != nil {
-		description = description + miss.GetMessage()
-	}
-	return &MatchingError{
-		StatusCode:  412,
-		Description: description,
-	}
-}

--- a/core/middleware/middleware.go
+++ b/core/middleware/middleware.go
@@ -7,8 +7,7 @@ import (
 
 	"io/ioutil"
 
-	"fmt"
-
+	"github.com/SpectoLabs/hoverfly/core/errors"
 	"github.com/SpectoLabs/hoverfly/core/models"
 )
 
@@ -107,7 +106,7 @@ func (this *Middleware) SetRemote(remoteUrl string) error {
 
 func (this *Middleware) Execute(pair models.RequestResponsePair) (models.RequestResponsePair, error) {
 	if !this.IsSet() {
-		return pair, fmt.Errorf("Cannot execute middleware as middleware has not been correctly set")
+		return pair, errors.MiddlewareNotSetError()
 	}
 
 	if this.Remote == "" {

--- a/core/modes/diff_mode.go
+++ b/core/modes/diff_mode.go
@@ -3,6 +3,8 @@ package modes
 import (
 	"net/http"
 
+	"github.com/SpectoLabs/hoverfly/core/errors"
+
 	log "github.com/Sirupsen/logrus"
 
 	"bytes"
@@ -16,14 +18,13 @@ import (
 	"time"
 
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
-	"github.com/SpectoLabs/hoverfly/core/matching"
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/util"
 	"github.com/dsnet/compress/brotli"
 )
 
 type HoverflyDiff interface {
-	GetResponse(models.RequestDetails) (*models.ResponseDetails, *matching.MatchingError)
+	GetResponse(models.RequestDetails) (*models.ResponseDetails, *errors.HoverflyError)
 	DoRequest(*http.Request) (*http.Response, error)
 	AddDiff(requestView v2.SimpleRequestDefinitionView, diffReport v2.DiffReport)
 }

--- a/core/modes/diff_mode_test.go
+++ b/core/modes/diff_mode_test.go
@@ -1,7 +1,7 @@
 package modes
 
 import (
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -9,8 +9,8 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/SpectoLabs/hoverfly/core/errors"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
-	"github.com/SpectoLabs/hoverfly/core/matching"
 	"github.com/SpectoLabs/hoverfly/core/models"
 	. "github.com/onsi/gomega"
 )
@@ -20,7 +20,7 @@ type hoverflyDiffStub struct{}
 func (this hoverflyDiffStub) DoRequest(request *http.Request) (*http.Response, error) {
 	response := &http.Response{}
 	if request.Host == "error.com" {
-		return nil, errors.New("Could not reach error.com")
+		return nil, fmt.Errorf("Could not reach error.com")
 	}
 
 	if request.Host == "positive-match-with-same-response.com" {
@@ -43,7 +43,7 @@ func (this hoverflyDiffStub) DoRequest(request *http.Request) (*http.Response, e
 	return response, nil
 }
 
-func (this hoverflyDiffStub) GetResponse(requestDetails models.RequestDetails) (*models.ResponseDetails, *matching.MatchingError) {
+func (this hoverflyDiffStub) GetResponse(requestDetails models.RequestDetails) (*models.ResponseDetails, *errors.HoverflyError) {
 	if requestDetails.Destination == "positive-match-with-same-response.com" {
 		return &models.ResponseDetails{
 			Status:  200,
@@ -57,9 +57,9 @@ func (this hoverflyDiffStub) GetResponse(requestDetails models.RequestDetails) (
 			Headers: map[string][]string{"header": {"simulated"}, "source": {"simulation"}},
 		}, nil
 	} else {
-		return nil, &matching.MatchingError{
-			Description: "matching-error",
-			StatusCode:  500,
+		return nil, &errors.HoverflyError{
+			Message:    "matching-error",
+			StatusCode: 500,
 		}
 	}
 }

--- a/core/modes/diff_mode_test.go
+++ b/core/modes/diff_mode_test.go
@@ -58,8 +58,7 @@ func (this hoverflyDiffStub) GetResponse(requestDetails models.RequestDetails) (
 		}, nil
 	} else {
 		return nil, &errors.HoverflyError{
-			Message:    "matching-error",
-			StatusCode: 500,
+			Message: "matching-error",
 		}
 	}
 }

--- a/core/modes/simulate_mode.go
+++ b/core/modes/simulate_mode.go
@@ -3,13 +3,13 @@ package modes
 import (
 	"net/http"
 
+	"github.com/SpectoLabs/hoverfly/core/errors"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
-	"github.com/SpectoLabs/hoverfly/core/matching"
 	"github.com/SpectoLabs/hoverfly/core/models"
 )
 
 type HoverflySimulate interface {
-	GetResponse(models.RequestDetails) (*models.ResponseDetails, *matching.MatchingError)
+	GetResponse(models.RequestDetails) (*models.ResponseDetails, *errors.HoverflyError)
 	ApplyMiddleware(models.RequestResponsePair) (models.RequestResponsePair, error)
 }
 

--- a/core/modes/simulate_mode_test.go
+++ b/core/modes/simulate_mode_test.go
@@ -1,12 +1,12 @@
 package modes_test
 
 import (
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
 
-	"github.com/SpectoLabs/hoverfly/core/matching"
+	"github.com/SpectoLabs/hoverfly/core/errors"
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/modes"
 	. "github.com/onsi/gomega"
@@ -14,22 +14,22 @@ import (
 
 type hoverflySimulateStub struct{}
 
-func (this hoverflySimulateStub) GetResponse(requestDetails models.RequestDetails) (*models.ResponseDetails, *matching.MatchingError) {
+func (this hoverflySimulateStub) GetResponse(requestDetails models.RequestDetails) (*models.ResponseDetails, *errors.HoverflyError) {
 	if requestDetails.Destination == "positive-match.com" {
 		return &models.ResponseDetails{
 			Status: 200,
 		}, nil
 	} else {
-		return nil, &matching.MatchingError{
-			Description: "matching-error",
-			StatusCode:  500,
+		return nil, &errors.HoverflyError{
+			Message:    "matching-error",
+			StatusCode: 500,
 		}
 	}
 }
 
 func (this hoverflySimulateStub) ApplyMiddleware(pair models.RequestResponsePair) (models.RequestResponsePair, error) {
 	if pair.Request.Path == "middleware-error" {
-		return pair, errors.New("middleware-error")
+		return pair, fmt.Errorf("middleware-error")
 	}
 	return pair, nil
 }

--- a/core/modes/simulate_mode_test.go
+++ b/core/modes/simulate_mode_test.go
@@ -21,8 +21,7 @@ func (this hoverflySimulateStub) GetResponse(requestDetails models.RequestDetail
 		}, nil
 	} else {
 		return nil, &errors.HoverflyError{
-			Message:    "matching-error",
-			StatusCode: 500,
+			Message: "matching-error",
 		}
 	}
 }

--- a/core/modes/spy_mode.go
+++ b/core/modes/spy_mode.go
@@ -3,15 +3,16 @@ package modes
 import (
 	"net/http"
 
+	"github.com/SpectoLabs/hoverfly/core/errors"
+
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
-	"github.com/SpectoLabs/hoverfly/core/matching"
 	"github.com/SpectoLabs/hoverfly/core/models"
 )
 
 type HoverflySpy interface {
-	GetResponse(models.RequestDetails) (*models.ResponseDetails, *matching.MatchingError)
+	GetResponse(models.RequestDetails) (*models.ResponseDetails, *errors.HoverflyError)
 	ApplyMiddleware(models.RequestResponsePair) (models.RequestResponsePair, error)
 	DoRequest(*http.Request) (*http.Response, error)
 }

--- a/core/modes/spy_mode_test.go
+++ b/core/modes/spy_mode_test.go
@@ -35,8 +35,7 @@ func (this hoverflySpyStub) GetResponse(requestDetails models.RequestDetails) (*
 		}, nil
 	} else {
 		return nil, &errors.HoverflyError{
-			Message:    "matching-error",
-			StatusCode: 500,
+			Message: "matching-error",
 		}
 	}
 }

--- a/core/modes/spy_mode_test.go
+++ b/core/modes/spy_mode_test.go
@@ -2,12 +2,12 @@ package modes_test
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
 
-	"github.com/SpectoLabs/hoverfly/core/matching"
+	"github.com/SpectoLabs/hoverfly/core/errors"
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/modes"
 	. "github.com/onsi/gomega"
@@ -19,7 +19,7 @@ type hoverflySpyStub struct{}
 func (this hoverflySpyStub) DoRequest(request *http.Request) (*http.Response, error) {
 	response := &http.Response{}
 	if request.Host == "error.com" {
-		return nil, errors.New("Could not reach error.com")
+		return nil, fmt.Errorf("Could not reach error.com")
 	}
 
 	response.StatusCode = 200
@@ -28,22 +28,22 @@ func (this hoverflySpyStub) DoRequest(request *http.Request) (*http.Response, er
 	return response, nil
 }
 
-func (this hoverflySpyStub) GetResponse(requestDetails models.RequestDetails) (*models.ResponseDetails, *matching.MatchingError) {
+func (this hoverflySpyStub) GetResponse(requestDetails models.RequestDetails) (*models.ResponseDetails, *errors.HoverflyError) {
 	if requestDetails.Destination == "positive-match.com" {
 		return &models.ResponseDetails{
 			Status: 200,
 		}, nil
 	} else {
-		return nil, &matching.MatchingError{
-			Description: "matching-error",
-			StatusCode:  500,
+		return nil, &errors.HoverflyError{
+			Message:    "matching-error",
+			StatusCode: 500,
 		}
 	}
 }
 
 func (this hoverflySpyStub) ApplyMiddleware(pair models.RequestResponsePair) (models.RequestResponsePair, error) {
 	if pair.Request.Path == "middleware-error" {
-		return pair, errors.New("middleware-error")
+		return pair, fmt.Errorf("middleware-error")
 	}
 	return pair, nil
 }

--- a/functional-tests/core/ft_api_v2_simulation_test.go
+++ b/functional-tests/core/ft_api_v2_simulation_test.go
@@ -418,5 +418,17 @@ var _ = Describe("/api/v2/simulation", func() {
 			Expect(string(responseBody)).To(ContainSubstring("WARNING: Usage of deprecated field `deprecatedQuery` on data.pairs[1].request.deprecatedQuery, please update your simulation to use `query` field"))
 			Expect(string(responseBody)).To(ContainSubstring("https://hoverfly.readthedocs.io/en/latest/pages/troubleshooting/troubleshooting.html#why-does-my-simulation-have-a-deprecatedquery-field"))
 		})
+
+		It("should warn when importing responses with content length and encoding", func() {
+			request := sling.New().Put("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/simulation")
+			payload := bytes.NewBufferString(testdata.ContentLengthAndTransferEncoding)
+
+			request.Body(payload)
+			response := functional_tests.DoRequest(request)
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			responseBody, _ := ioutil.ReadAll(response.Body)
+			Expect(string(responseBody)).To(ContainSubstring("WARNING: Response contains both Content-Length and Transfer-Encoding headers on data.pairs[0].response, please remove one of these headers"))
+		})
 	})
 })

--- a/functional-tests/core/ft_api_v2_simulation_test.go
+++ b/functional-tests/core/ft_api_v2_simulation_test.go
@@ -430,5 +430,17 @@ var _ = Describe("/api/v2/simulation", func() {
 			responseBody, _ := ioutil.ReadAll(response.Body)
 			Expect(string(responseBody)).To(ContainSubstring("WARNING: Response contains both Content-Length and Transfer-Encoding headers on data.pairs[0].response, please remove one of these headers"))
 		})
+
+		It("should warn when importing responses with content length that is incorrect", func() {
+			request := sling.New().Put("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/simulation")
+			payload := bytes.NewBufferString(testdata.IncorrectContentLength)
+
+			request.Body(payload)
+			response := functional_tests.DoRequest(request)
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			responseBody, _ := ioutil.ReadAll(response.Body)
+			Expect(string(responseBody)).To(ContainSubstring("WARNING: Response contains incorrect Content-Length header on data.pairs[0].response, please correct or remove header"))
+		})
 	})
 })

--- a/functional-tests/core/ft_proxy_https_test.go
+++ b/functional-tests/core/ft_proxy_https_test.go
@@ -126,17 +126,14 @@ var _ = Describe("When I run Hoverfly", func() {
 				}
 			}`)
 			response := hoverfly.Proxy(sling.New().Get("https://hoverfly.io/path"))
-			Expect(response.StatusCode).To(Equal(http.StatusBadGateway))
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
 
 			body, err := ioutil.ReadAll(response.Body)
 			Expect(err).To(BeNil())
-			Expect(string(body)).To(ContainSubstring(`Hoverfly Error!`))
-			Expect(string(body)).To(ContainSubstring(`There was an error when matching`))
-			Expect(string(body)).To(ContainSubstring(`Got error: Response contains incorrect Content-Length header. Please correct or remove header.`))
+			Expect(string(body)).To(Equal("OK"))
 
-			// Not set or calculated
-			Expect(response.Header.Get("Content-length")).To(Equal(""))
-			// Is set, but not actually added by net/http when building struct
+			// These will always be empty as they are excluded by net/http
+			Expect(response.Header.Get("Content-Length")).To(Equal(""))
 			Expect(response.Header.Get("Transfer-Encoding")).To(Equal(""))
 		})
 	})

--- a/functional-tests/core/ft_proxy_test.go
+++ b/functional-tests/core/ft_proxy_test.go
@@ -114,16 +114,16 @@ var _ = Describe("When I run Hoverfly", func() {
 					"schemaVersion": "v3"
 				}
 			}`)
+
 			response := hoverfly.Proxy(sling.New().Get("http://hoverfly.io/path"))
-			Expect(response.StatusCode).To(Equal(http.StatusBadGateway))
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
 
 			body, err := ioutil.ReadAll(response.Body)
-			Expect(err).To(BeNil())
-			Expect(string(body)).To(ContainSubstring(`Hoverfly Error!`))
-			Expect(string(body)).To(ContainSubstring(`There was an error when matching`))
-			Expect(string(body)).To(ContainSubstring(`Got error: Response contains incorrect Content-Length header. Please correct or remove header.`))
+			Expect(err).To(Not(BeNil()))
+			Expect(err.Error()).To(Equal("unexpected EOF"))
+			Expect(string(body)).To(Equal("OK"))
 
-			Expect(response.Header.Get("Content-length")).To(Equal("145"))
+			Expect(response.Header.Get("Content-length")).To(Equal("5555"))
 			Expect(response.Header.Get("Transfer-Encoding")).To(Equal(""))
 		})
 
@@ -152,6 +152,7 @@ var _ = Describe("When I run Hoverfly", func() {
 					"schemaVersion": "v3"
 				}
 			}`)
+
 			response := hoverfly.Proxy(sling.New().Get("http://hoverfly.io/path"))
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 

--- a/functional-tests/core/ft_proxy_test.go
+++ b/functional-tests/core/ft_proxy_test.go
@@ -89,7 +89,7 @@ var _ = Describe("When I run Hoverfly", func() {
 			Expect(response.Header.Get("Transfer-Encoding")).To(Equal(""))
 		})
 
-		It("should not set Content-Length if not empty", func() {
+		It("should error if Content-Length is incorrect", func() {
 
 			hoverfly.ImportSimulation(`{
 				"data": {
@@ -115,14 +115,15 @@ var _ = Describe("When I run Hoverfly", func() {
 				}
 			}`)
 			response := hoverfly.Proxy(sling.New().Get("http://hoverfly.io/path"))
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
+			Expect(response.StatusCode).To(Equal(http.StatusBadGateway))
 
 			body, err := ioutil.ReadAll(response.Body)
-			Expect(err).To(Not(BeNil()))
-			Expect(err.Error()).To(Equal("unexpected EOF"))
-			Expect(string(body)).To(Equal("OK"))
+			Expect(err).To(BeNil())
+			Expect(string(body)).To(ContainSubstring(`Hoverfly Error!`))
+			Expect(string(body)).To(ContainSubstring(`There was an error when matching`))
+			Expect(string(body)).To(ContainSubstring(`Got error: Response contains incorrect Content-Length header. Please correct or remove header.`))
 
-			Expect(response.Header.Get("Content-length")).To(Equal("5555"))
+			Expect(response.Header.Get("Content-length")).To(Equal("145"))
 			Expect(response.Header.Get("Transfer-Encoding")).To(Equal(""))
 		})
 

--- a/functional-tests/testdata/content-length_and_transfer-encoding.go
+++ b/functional-tests/testdata/content-length_and_transfer-encoding.go
@@ -1,0 +1,36 @@
+package testdata
+
+var ContentLengthAndTransferEncoding = `{
+	"data": {
+		"pairs": [
+			{
+				"request": {
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "hoverfly.io"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "json match",
+					"encodedBody": false,
+					"templated": false,
+					"headers": {
+						"Content-Length": ["10"],
+						"Transfer-Encoding": ["chunked"]
+					}
+				}
+			}
+		],
+		"globalActions": {
+			"delays": []
+		}
+	},
+	"meta": {
+		"schemaVersion": "v5",
+		"hoverflyVersion": "v0.17.0",
+		"timeExported": "2018-05-03T15:11:24+01:00"
+	}
+}`

--- a/functional-tests/testdata/incorrect_content-length.go
+++ b/functional-tests/testdata/incorrect_content-length.go
@@ -1,0 +1,35 @@
+package testdata
+
+var IncorrectContentLength = `{
+	"data": {
+		"pairs": [
+			{
+				"request": {
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "hoverfly.io"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "json match",
+					"encodedBody": false,
+					"templated": false,
+					"headers": {
+						"Content-Length": ["10000000000"]
+					}
+				}
+			}
+		],
+		"globalActions": {
+			"delays": []
+		}
+	},
+	"meta": {
+		"schemaVersion": "v5",
+		"hoverflyVersion": "v0.17.0",
+		"timeExported": "2018-05-03T15:11:24+01:00"
+	}
+}`


### PR DESCRIPTION
Warn when:
 * Content-Length and Transfer-Encoding are set on a response
 * Content-Length does not match response body length``

I have also sneaked in some refactoring to errors. We have lots of different errors that kind of do the same thing, so I'm starting to unify errors.