### PR TITLE
Correct Response Example, and Put Body

### DIFF
--- a/docs/pages/reference/api/api.rst
+++ b/docs/pages/reference/api/api.rst
@@ -289,7 +289,8 @@ Gets the mode for the running instance of Hoverfly.
 ::
 
     {
-        mode: "simulate"
+        "mode": "capture",
+        "arguments": {}
     }
 
 --------------
@@ -303,7 +304,7 @@ Changes the mode of the running instance of Hoverfly.
 ::
 
     {
-        mode: "simulate"
+        "mode": "capture"
     }
 
 


### PR DESCRIPTION
Perhaps other API is impacted but in particular the mode PUT does not work as displayed in the example docs.
I've corrected that, and also included a realistic GET response