### PR TITLE
Maintain existing state instead of overwriting

### DIFF
--- a/core/models/simulation.go
+++ b/core/models/simulation.go
@@ -78,7 +78,7 @@ func (this *Simulation) AddPairInSequence(pair *RequestMatcherResponsePair, stat
 			if sequenceState == "" {
 				sequenceState = "1"
 				nextSequenceState = "2"
-				state.SetState(map[string]string{sequenceKey: "1"})
+				state.PatchState(map[string]string{sequenceKey: "1"})
 
 			} else {
 				currentSequenceState, _ := strconv.Atoi(sequenceState)


### PR DESCRIPTION
I raised this issue yesterday (https://github.com/SpectoLabs/hoverfly/issues/764), this branch seems to fix it.
After some debugging it seemed like the entire state was being overwritten each time a new sequence is added. I'm new to Hoverfly and new to Go, so feedback is very welcome 😄 
I ran through the existing tests and it didn't seem to cause any new failures.