### PR TITLE
Fix failing test when local timezone is not UTC

### DIFF
--- a/core/journal/journal_test.go
+++ b/core/journal/journal_test.go
@@ -421,11 +421,11 @@ func Test_Journal_GetEntries_FilteredByTimeWindow(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		request, _ := http.NewRequest("GET", "http://hoverfly.io/path?id="+strconv.Itoa(i), nil)
-		unit.NewEntry(request, response, "test-mode", time.Date(2018, 2, 1, 2, 0, i, 0, time.Local))
+		unit.NewEntry(request, response, "test-mode", time.Date(2018, 2, 1, 2, 0, i, 0, time.UTC))
 	}
 
-	fromQuery := time.Date(2018, 2, 1, 2, 0, 1, 0, time.Local)
-	toQuery := time.Date(2018, 2, 1, 2, 0, 3, 0, time.Local)
+	fromQuery := time.Date(2018, 2, 1, 2, 0, 1, 0, time.UTC)
+	toQuery := time.Date(2018, 2, 1, 2, 0, 3, 0, time.UTC)
 
 	journalView, err := unit.GetEntries(0, 25, &fromQuery, &toQuery, "")
 	entries := journalView.Journal


### PR DESCRIPTION
The test failing if run locally with non UTC local timezone, the pull request change test to use UTC

````
=== RUN   Test_Journal_GetEntries_FilteredByTimeWindow                                                                                                                                                    [689/1343]
--- FAIL: Test_Journal_GetEntries_FilteredByTimeWindow (0.00s)
        testing_t_support.go:22: 
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:69 +0x1ed
                github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).To(0xc4201e3ec0, 0x8f6580, 0xc420206540, 0x0, 0x0, 0x0, 0xc4201e3ec0)
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:35 +0xae
                github.com/SpectoLabs/hoverfly/core/journal_test.Test_Journal_GetEntries_FilteredByTimeWindow(0xc42015b0e0)
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/core/journal/journal_test.go:434 +0x764
                testing.tRunner(0xc42015b0e0, 0x8b8a50)
                        /usr/lib/go-1.10/src/testing/testing.go:777 +0xd0
                created by testing.(*T).Run
                        /usr/lib/go-1.10/src/testing/testing.go:824 +0x2e0

                Expected
                    <string>: 2018-02-01T02:00:01.000-06:00
                to equal
                    <string>: 2018-02-01T02:00:01.000Z
        testing_t_support.go:22: 
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:69 +0x1ed
                github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).To(0xc4201e3f80, 0x8f6580, 0xc420206700, 0x0, 0x0, 0x0, 0xc4201e3f80)
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:35 +0xae
                github.com/SpectoLabs/hoverfly/core/journal_test.Test_Journal_GetEntries_FilteredByTimeWindow(0xc42015b0e0)
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/core/journal/journal_test.go:435 +0x855
                testing.tRunner(0xc42015b0e0, 0x8b8a50)
                        /usr/lib/go-1.10/src/testing/testing.go:777 +0xd0
                created by testing.(*T).Run
                        /usr/lib/go-1.10/src/testing/testing.go:824 +0x2e0

                Expected
                    <string>: 2018-02-01T02:00:02.000-06:00
                to equal
                    <string>: 2018-02-01T02:00:02.000Z
        testing_t_support.go:22: 
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:69 +0x1ed
                github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).To(0xc42023a040, 0x8f6580, 0xc4202068c0, 0x0, 0x0, 0x0, 0xc42023a040)
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:35 +0xae
                github.com/SpectoLabs/hoverfly/core/journal_test.Test_Journal_GetEntries_FilteredByTimeWindow(0xc42015b0e0)
                        /home/xiangzhu/.local/go/packages/src/github.com/SpectoLabs/hoverfly/core/journal/journal_test.go:436 +0x941
                testing.tRunner(0xc42015b0e0, 0x8b8a50)
                        /usr/lib/go-1.10/src/testing/testing.go:777 +0xd0
                created by testing.(*T).Run
                        /usr/lib/go-1.10/src/testing/testing.go:824 +0x2e0

                Expected
                    <string>: 2018-02-01T02:00:03.000-06:00
                to equal
                    <string>: 2018-02-01T02:00:03.000Z

````