### PR TITLE
Add options to support capture request with 2way ssl authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ requests.db
 *.iml
 target
 
+# Vim
+*.swp
+*.swo
+
 core/cmd/hoverfly/hoverfly
 hoverctl/hoverctl
 functional-tests/core/bin/hoverfly

--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -103,6 +103,11 @@ var (
 	logsSize   = flag.Int("logs-size", 1000, "Set the amount of logs to be stored in memory (default \"1000\")")
 
 	journalSize = flag.Int("journal-size", 1000, "Set the size of request/response journal (default \"1000\")")
+
+	clientAuthenticationDestination = flag.String("client-authentication-destination", "", "Regular expression of desination with client authentication")
+	clientAuthenticationClientCert  = flag.String("client-authentication-client-cert", "", "Path to the client certification file used for authentication")
+	clientAuthenticationClientKey   = flag.String("client-authentication-client-key", "", "Path to the client key file used for authentication")
+	clientAuthenticationCACert      = flag.String("client-authentication-ca-cert", "", "Path to the ca cert file used for authentication")
 )
 
 var CA_CERT = []byte(`-----BEGIN CERTIFICATE-----
@@ -265,6 +270,11 @@ func main() {
 
 	cfg.HttpsOnly = *httpsOnly
 	cfg.PlainHttpTunneling = *plainHttpTunneling
+
+	cfg.ClientAuthenticationDestination = *clientAuthenticationDestination
+	cfg.ClientAuthenticationClientCert = *clientAuthenticationClientCert
+	cfg.ClientAuthenticationClientKey = *clientAuthenticationClientKey
+	cfg.ClientAuthenticationCACert = *clientAuthenticationCACert
 
 	// overriding default middleware setting
 	newMiddleware, err := mw.ConvertToNewMiddleware(*middleware)

--- a/core/settings.go
+++ b/core/settings.go
@@ -41,6 +41,11 @@ type Configuration struct {
 
 	PlainHttpTunneling bool
 
+	ClientAuthenticationDestination string
+	ClientAuthenticationClientCert  string
+	ClientAuthenticationClientKey   string
+	ClientAuthenticationCACert      string
+
 	ProxyControlWG sync.WaitGroup
 
 	mu sync.Mutex

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/SpectoLabs/hoverfly/hoverctl/configuration"
@@ -78,6 +80,19 @@ hoverctl configuration file.
 			target.PACFile = string(pacFileData)
 		}
 
+		if clientAuthenticationDestination, _ := cmd.Flags().GetString("client-authentication-destination"); clientAuthenticationDestination != "" {
+			_, err := regexp.Compile(clientAuthenticationDestination)
+
+			if err != nil {
+				handleIfError(errors.New("Client AuthenticationDestination regex pattern does not compile"))
+			}
+
+			target.ClientAuthenticationDestination = clientAuthenticationDestination
+		}
+		target.ClientAuthenticationClientCert, _ = cmd.Flags().GetString("client-authentication-client-cert")
+		target.ClientAuthenticationClientKey, _ = cmd.Flags().GetString("client-authentication-client-key")
+		target.ClientAuthenticationCACert, _ = cmd.Flags().GetString("client-authentication-ca-cert")
+
 		if enableAuth, _ := cmd.Flags().GetBool("auth"); enableAuth {
 			username, _ := cmd.Flags().GetString("username")
 			password, _ := cmd.Flags().GetString("password")
@@ -134,6 +149,11 @@ func init() {
 	startCmd.Flags().String("pac-file", "", "Configure upstream proxy by PAC file")
 	startCmd.Flags().Bool("https-only", false, "Disables insecure HTTP traffic in Hoverfly")
 	startCmd.Flags().String("listen-on-host", "", "Binds hoverfly listener to a host")
+
+	startCmd.Flags().String("client-authentication-destination", "", "Regular expression for hosts need client authentication")
+	startCmd.Flags().String("client-authentication-client-cert", "", "Path to client certificate file used for authentication")
+	startCmd.Flags().String("client-authentication-client-key", "", "Path to client key file used for authentication")
+	startCmd.Flags().String("client-authentication-ca-cert", "", "Path to ca cert file used for authentication")
 
 	startCmd.Flags().Bool("auth", false, "Enable authenticiation on Hoverfly")
 	startCmd.Flags().String("username", "", "Username to authenticate Hoverfly")

--- a/hoverctl/configuration/target.go
+++ b/hoverctl/configuration/target.go
@@ -27,6 +27,11 @@ type Target struct {
 	PACFile          string `yaml:",omitempty"`
 	HttpsOnly        bool   `yaml:",omitempty"`
 
+	ClientAuthenticationDestination string
+	ClientAuthenticationClientCert  string
+	ClientAuthenticationClientKey   string
+	ClientAuthenticationCACert      string
+
 	AuthEnabled bool
 	Username    string
 	Password    string
@@ -149,6 +154,22 @@ func (this Target) BuildFlags() Flags {
 	if this.AuthEnabled {
 		hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(this.Password), 10)
 		flags = append(flags, "-auth", "-username", this.Username, "-password-hash", string(hashedPassword))
+	}
+
+	if this.ClientAuthenticationDestination != "" {
+		flags = append(flags, "-client-authentication-destination="+this.ClientAuthenticationDestination)
+	}
+
+	if this.ClientAuthenticationClientCert != "" {
+		flags = append(flags, "-client-authentication-client-cert="+this.ClientAuthenticationClientCert)
+	}
+
+	if this.ClientAuthenticationClientKey != "" {
+		flags = append(flags, "-client-authentication-client-key="+this.ClientAuthenticationClientKey)
+	}
+
+	if this.ClientAuthenticationCACert != "" {
+		flags = append(flags, "-client-authentication-ca-cert="+this.ClientAuthenticationCACert)
 	}
 
 	return flags


### PR DESCRIPTION
Add options to make hoverfly support capture request using client SSL authentication. I think it's the same object as described in https://github.com/SpectoLabs/hoverfly/issues/201

With the new options, the request can be set to use client ssl cert and keys to authenticate if the request host matches provided pattern., and won't affect other requests. The default value of these options won't have any impact to exisiting logic, so it's a non breaking change.

We've been using the forked binary to capture data with client SSL authentication in our test. 