### PR TITLE
Fix map copy

### DIFF
--- a/core/matching/state_matcher.go
+++ b/core/matching/state_matcher.go
@@ -1,6 +1,9 @@
 package matching
 
-import "github.com/SpectoLabs/hoverfly/core/state"
+import (
+	"github.com/SpectoLabs/hoverfly/core/state"
+	"github.com/SpectoLabs/hoverfly/core/util"
+)
 
 func StateMatcher(currentState *state.State, requiredState map[string]string) *FieldMatch {
 
@@ -15,13 +18,13 @@ func StateMatcher(currentState *state.State, requiredState map[string]string) *F
 	}
 
 	currentState.RWMutex.RLock()
-	copy_state := currentState.State
+	copyState := util.CopyMap(currentState.State)
 	currentState.RWMutex.RUnlock()
 	for key, value := range requiredState {
-		if _, ok := copy_state[key]; !ok {
+		if _, ok := copyState[key]; !ok {
 			matched = false
 		}
-		if copy_state[key] != value {
+		if copyState[key] != value {
 			matched = false
 		} else {
 			score++

--- a/core/matching/strongest_match_strategy.go
+++ b/core/matching/strongest_match_strategy.go
@@ -3,6 +3,7 @@ package matching
 import (
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/state"
+	"github.com/SpectoLabs/hoverfly/core/util"
 )
 
 type StrongestMatchStrategy struct {
@@ -63,14 +64,14 @@ func (s *StrongestMatchStrategy) PostMatching(req models.RequestDetails, request
 		s.closestMissScore = s.score
 		view := matchingPair.BuildView()
 		state.RWMutex.RLock()
-		copy_state := state.State
+		copyState := util.CopyMap(state.State)
 		state.RWMutex.RUnlock()
 		s.closestMiss = &models.ClosestMiss{
 			RequestDetails: req,
 			RequestMatcher: view.RequestMatcher,
 			Response:       view.Response,
 			MissedFields:   s.missedFields,
-			State:          copy_state,
+			State:          copyState,
 		}
 	}
 

--- a/core/util/util.go
+++ b/core/util/util.go
@@ -156,3 +156,11 @@ func MinifyXml(toMinify string) (string, error) {
 
 	return minifier.String("application/xml", toMinify)
 }
+
+func CopyMap(originalMap map[string]string) map[string]string {
+	newMap := make(map[string]string)
+	for key, value := range originalMap {
+		newMap[key] = value
+	}
+	return newMap
+}

--- a/core/util/util_test.go
+++ b/core/util/util_test.go
@@ -192,3 +192,21 @@ func Test_MinifyXml_SimplifiesXmlString(t *testing.T) {
 		<document></document>
 	</xml>`)).To(Equal(`<xml><document/></xml>`))
 }
+
+func Test_CopyMap(t *testing.T) {
+	RegisterTestingT(t)
+
+	originalMap := make(map[string]string)
+	originalMap["first"] = "1"
+	originalMap["second"] = "2"
+
+	newMap := CopyMap(originalMap)
+
+	delete(originalMap, "first")
+	originalMap["second"] = ""
+	originalMap["third"] = "3"
+
+	Expect(newMap).To(HaveLen(2))
+	Expect(newMap["first"]).To(Equal("1"))
+	Expect(newMap["second"]).To(Equal("2"))
+}


### PR DESCRIPTION
Fixed an issue with concurrent access to map under load. Copy a map by value instead of by reference.