### PR TITLE
Default remote target protocol should be HTTP

### DIFF
--- a/functional-tests/hoverctl/login_test.go
+++ b/functional-tests/hoverctl/login_test.go
@@ -57,13 +57,13 @@ var _ = Describe("hoverctl login", func() {
 		It("should error nicely if username is missing", func() {
 			output := functional_tests.Run(hoverctlBinary, "login", "-f", "--password", functional_tests.HoverflyPassword)
 
-			Expect(output).To(ContainSubstring("Missing username or password"))
+			Expect(output).To(ContainSubstring("missing username or password"))
 		})
 
 		It("should error nicely if password is missing", func() {
 			output := functional_tests.Run(hoverctlBinary, "login", "-f", "--username", functional_tests.HoverflyUsername)
 
-			Expect(output).To(ContainSubstring("Missing username or password"))
+			Expect(output).To(ContainSubstring("missing username or password"))
 		})
 	})
 

--- a/hoverctl/cmd/login.go
+++ b/hoverctl/cmd/login.go
@@ -33,8 +33,6 @@ target in the hoverctl configuration file.
 				handleIfError(fmt.Errorf("Target %s already exists\n\nUse a different target name or run `hoverctl targets update %[1]s`", newTargetFlag))
 			}
 
-			// If the host is set to a remote instance, the default HTTPS port
-			// is used instead of 8888 which is set in wrapper.NewTarget()
 			hostFlag, err := cmd.Flags().GetString("host")
 			handleIfError(err)
 			adminPortFlag, err := cmd.Flags().GetInt("admin-port")
@@ -53,7 +51,7 @@ target in the hoverctl configuration file.
 		}
 
 		if username == "" || password == "" {
-			handleIfError(errors.New("Missing username or password"))
+			handleIfError(errors.New("missing username or password"))
 		}
 
 		token, err := wrapper.Login(*target, username, password)
@@ -76,7 +74,7 @@ func init() {
 	loginCmd.Flags().String("new-target", "", "A name for a new target that hoverctl will create and associate the Hoverfly instance to")
 	loginCmd.Flags().Int("admin-port", 0, "A port number for the Hoverfly API/GUI. Overrides the default Hoverfly admin port (8888)")
 	loginCmd.Flags().Int("proxy-port", 0, "A port number for the Hoverfly proxy. Overrides the default Hoverfly proxy port (8500)")
-	loginCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost)")
+	loginCmd.Flags().String("host", "", "A host on which a Hoverfly instance is running. Overrides the default Hoverfly host (localhost). HTTP protocol is assumed if scheme is not specified.")
 	loginCmd.Flags().StringVar(&username, "username", "", "Username to authenticate against Hoverfly with")
-	loginCmd.Flags().StringVar(&password, "password", "", "Password to autenticate against Hoverfly with")
+	loginCmd.Flags().StringVar(&password, "password", "", "Password to authenticate against Hoverfly with")
 }

--- a/hoverctl/cmd/login.go
+++ b/hoverctl/cmd/login.go
@@ -41,9 +41,6 @@ target in the hoverctl configuration file.
 			handleIfError(err)
 			proxyPortFlag, err := cmd.Flags().GetInt("proxy-port")
 			handleIfError(err)
-			if adminPortFlag == 0 && (hostFlag != "" && !wrapper.IsLocal(hostFlag)) {
-				adminPortFlag = 443
-			}
 
 			target = configuration.NewTarget(newTargetFlag, hostFlag, adminPortFlag, proxyPortFlag)
 		}

--- a/hoverctl/wrapper/hoverfly.go
+++ b/hoverctl/wrapper/hoverfly.go
@@ -14,9 +14,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/SpectoLabs/hoverfly/core/handlers"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
-	"github.com/SpectoLabs/hoverfly/core/util"
 	"github.com/SpectoLabs/hoverfly/hoverctl/configuration"
 	"github.com/kardianos/osext"
 )
@@ -78,38 +76,6 @@ func UnmarshalToInterface(response *http.Response, v interface{}) error {
 	return json.Unmarshal(body, v)
 }
 
-func createAPIStateResponse(response *http.Response) APIStateSchema {
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		log.Debug(err.Error())
-	}
-
-	var apiResponse APIStateSchema
-
-	err = json.Unmarshal(body, &apiResponse)
-	if err != nil {
-		log.Debug(err.Error())
-	}
-
-	return apiResponse
-}
-
-func createMiddlewareSchema(response *http.Response) v2.MiddlewareView {
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		log.Debug(err.Error())
-	}
-
-	var middleware v2.MiddlewareView
-
-	err = json.Unmarshal(body, &middleware)
-	if err != nil {
-		log.Debug(err.Error())
-	}
-
-	return middleware
-}
-
 func Login(target configuration.Target, username, password string) (string, error) {
 	credentials := HoverflyAuthSchema{
 		Username: username,
@@ -163,11 +129,7 @@ func Login(target configuration.Target, username, password string) (string, erro
 
 func BuildURL(target configuration.Target, endpoint string) string {
 	if !strings.HasPrefix(target.Host, "http://") && !strings.HasPrefix(target.Host, "https://") {
-		//if IsLocal(target.Host) {
-			return fmt.Sprintf("http://%v:%v%v", target.Host, target.AdminPort, endpoint)
-		//} else {
-		//	return fmt.Sprintf("https://%v:%v%v", target.Host, target.AdminPort, endpoint)
-		//}
+		return fmt.Sprintf("http://%v:%v%v", target.Host, target.AdminPort, endpoint)
 	}
 	return fmt.Sprintf("%v:%v%v", target.Host, target.AdminPort, endpoint)
 }
@@ -337,21 +299,6 @@ func checkPorts(ports ...int) error {
 	}
 
 	return nil
-}
-
-func handlerError(response *http.Response) error {
-	responseBody, err := util.GetResponseBody(response)
-	if err != nil {
-		return errors.New("Error when communicating with Hoverfly")
-	}
-
-	var errorView handlers.ErrorView
-	err = json.Unmarshal([]byte(responseBody), &errorView)
-	if err != nil {
-		return errors.New("Error when communicating with Hoverfly")
-	}
-
-	return errors.New(errorView.Error)
 }
 
 func handleResponseError(response *http.Response, errorMessage string) error {

--- a/hoverctl/wrapper/hoverfly.go
+++ b/hoverctl/wrapper/hoverfly.go
@@ -163,11 +163,11 @@ func Login(target configuration.Target, username, password string) (string, erro
 
 func BuildURL(target configuration.Target, endpoint string) string {
 	if !strings.HasPrefix(target.Host, "http://") && !strings.HasPrefix(target.Host, "https://") {
-		if IsLocal(target.Host) {
+		//if IsLocal(target.Host) {
 			return fmt.Sprintf("http://%v:%v%v", target.Host, target.AdminPort, endpoint)
-		} else {
-			return fmt.Sprintf("https://%v:%v%v", target.Host, target.AdminPort, endpoint)
-		}
+		//} else {
+		//	return fmt.Sprintf("https://%v:%v%v", target.Host, target.AdminPort, endpoint)
+		//}
 	}
 	return fmt.Sprintf("%v:%v%v", target.Host, target.AdminPort, endpoint)
 }

--- a/hoverctl/wrapper/hoverfly_test.go
+++ b/hoverctl/wrapper/hoverfly_test.go
@@ -61,7 +61,7 @@ func Test_BuildUrl_AddsHostAdminPortAndPath_Https(t *testing.T) {
 	Expect(BuildURL(target, "/something")).To(Equal("https://localhost:1234/something"))
 }
 
-func Test_BuildUrl_AddsHttpIfHostIsLocalhost(t *testing.T) {
+func Test_BuildUrl_AddsHttpAsDefaultProtocol(t *testing.T) {
 	RegisterTestingT(t)
 
 	target := configuration.Target{
@@ -72,16 +72,6 @@ func Test_BuildUrl_AddsHttpIfHostIsLocalhost(t *testing.T) {
 	Expect(BuildURL(target, "/something")).To(Equal("http://localhost:1234/something"))
 }
 
-func Test_BuildUrl_AddsHttpIfHostIsExternal(t *testing.T) {
-	RegisterTestingT(t)
-
-	target := configuration.Target{
-		Host:      "test-instance.hoverfly.io",
-		AdminPort: 1234,
-	}
-
-	Expect(BuildURL(target, "/something")).To(Equal("https://test-instance.hoverfly.io:1234/something"))
-}
 
 func Test_Stop_SendsCorrectHTTPRequest(t *testing.T) {
 	RegisterTestingT(t)


### PR DESCRIPTION
When the scheme is missing in the host flag for a remote target, it should just default to HTTP. This is also common among other tools like `curl`. 

Users should override the default settings themselves if they are connecting to a remote Hoverfly Admin API runs on HTTPS.