### PR TITLE
Caching parsed response template

### DIFF
--- a/core/benchmark_test.go
+++ b/core/benchmark_test.go
@@ -13,6 +13,7 @@ import (
 func BenchmarkProcessRequest(b *testing.B) {
 
 	RegisterTestingT(b)
+
 	hoverfly := NewHoverflyWithConfiguration(&Configuration{
 		Webserver: true,
 		ProxyPort: "8500",
@@ -20,55 +21,55 @@ func BenchmarkProcessRequest(b *testing.B) {
 		Mode:      "simulate",
 	})
 
-//	simulation := v2.SimulationViewV5{}
-//	_ = json.Unmarshal([]byte(`{
-//	"data": {
-//		"pairs": [{
-//			"response": {
-//				"status": 200,
-//				"body": "5iNe8dxWH5Ca8pZqAfEHv3rgC0SsvKNLu6o3K",
-//				"encodedBody": false,
-//				"headers": {
-//					"Accept-Ranges": ["bytes"],
-//					"Cache-Control": ["max-age=3600"],
-//					"Connection": ["keep-alive"],
-//					"Content-Type": ["text/html; charset=utf-8"],
-//					"Date": ["Tue, 30 May 2017 13:23:09 GMT"],
-//					"Etag": ["\"82b6bafbc0c4af5e3886d07802f4b62d\""],
-//					"Hoverfly": ["Was-Here"],
-//					"Last-Modified": ["Fri, 19 May 2017 10:59:12 GMT"],
-//					"Server": ["nginx"],
-//					"Strict-Transport-Security": ["max-age=31556926"],
-//					"Transfer-Encoding": ["chunked"],
-//					"Vary": ["Accept-Encoding"]
-//				}
-//			},
-//			"request": {
-//				"path": [{
-//					"matcher": "exact",
-//					"value": "/bar"
-//				}],
-//				"method": [{
-//					"matcher": "exact",
-//					"value": "GET"
-//				}],
-//				"query": {},
-//				"body": [{
-//					"matcher": "exact",
-//					"value": ""
-//				}]
-//			}
-//		}],
-//		"globalActions": {
-//			"delays": []
-//		}
-//	},
-//	"meta": {
-//		"schemaVersion": "v5",
-//		"hoverflyVersion": "v0.17.0",
-//		"timeExported": "2017-05-30T14:23:44+01:00"
-//	}
-//}`), &simulation)
+	simulation := v2.SimulationViewV5{}
+	_ = json.Unmarshal([]byte(`{
+	"data": {
+		"pairs": [{
+			"response": {
+				"status": 200,
+				"body": "5iNe8dxWH5Ca8pZqAfEHv3rgC0SsvKNLu6o3K",
+				"encodedBody": false,
+				"headers": {
+					"Accept-Ranges": ["bytes"],
+					"Cache-Control": ["max-age=3600"],
+					"Connection": ["keep-alive"],
+					"Content-Type": ["text/html; charset=utf-8"],
+					"Date": ["Tue, 30 May 2017 13:23:09 GMT"],
+					"Etag": ["\"82b6bafbc0c4af5e3886d07802f4b62d\""],
+					"Hoverfly": ["Was-Here"],
+					"Last-Modified": ["Fri, 19 May 2017 10:59:12 GMT"],
+					"Server": ["nginx"],
+					"Strict-Transport-Security": ["max-age=31556926"],
+					"Transfer-Encoding": ["chunked"],
+					"Vary": ["Accept-Encoding"]
+				}
+			},
+			"request": {
+				"path": [{
+					"matcher": "exact",
+					"value": "/bar"
+				}],
+				"method": [{
+					"matcher": "exact",
+					"value": "GET"
+				}],
+				"query": {},
+				"body": [{
+					"matcher": "exact",
+					"value": ""
+				}]
+			}
+		}],
+		"globalActions": {
+			"delays": []
+		}
+	},
+	"meta": {
+		"schemaVersion": "v5",
+		"hoverflyVersion": "v0.17.0",
+		"timeExported": "2017-05-30T14:23:44+01:00"
+	}
+}`), &simulation)
 
 	templated := v2.SimulationViewV5{}
 	_ = json.Unmarshal([]byte(`{
@@ -121,29 +122,31 @@ func BenchmarkProcessRequest(b *testing.B) {
 	}
 }`), &templated)
 
+	benchmarks := []struct{
+		name string
+		simulation v2.SimulationViewV5
+	} {
+		{"Simple simulation", simulation},
+		{"Templated simulation", templated},
+	}
 
 	fmt.Println(hoverfly.StartProxy())
 	time.Sleep(time.Second)
 	request, _ := http.NewRequest(http.MethodGet, "http://localhost:8500/bar", nil)
 	var resp *http.Response
-	//hoverfly.PutSimulation(simulation)
-	//
-	//b.Run("Simple simulation", func(b *testing.B) {
-	//
-	//	for n := 0; n < b.N; n++ {
-	//		resp = hoverfly.processRequest(request)
-	//	}
-	//})
 
+	for _, bm := range benchmarks {
+		hoverfly.DeleteSimulation()
+		hoverfly.PutSimulation(bm.simulation)
 
-	hoverfly.PutSimulation(templated)
+		b.Run(bm.name, func(b *testing.B) {
 
-	b.Run("Templated simulation", func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				resp = hoverfly.processRequest(request)
+			}
+		})
+	}
 
-		for n := 0; n < b.N; n++ {
-			resp = hoverfly.processRequest(request)
-		}
-	})
 
 	Expect(resp.StatusCode).To(Equal(200))
 

--- a/core/benchmark_test.go
+++ b/core/benchmark_test.go
@@ -20,14 +20,65 @@ func BenchmarkProcessRequest(b *testing.B) {
 		Mode:      "simulate",
 	})
 
-	simulation := v2.SimulationViewV5{}
+//	simulation := v2.SimulationViewV5{}
+//	_ = json.Unmarshal([]byte(`{
+//	"data": {
+//		"pairs": [{
+//			"response": {
+//				"status": 200,
+//				"body": "5iNe8dxWH5Ca8pZqAfEHv3rgC0SsvKNLu6o3K",
+//				"encodedBody": false,
+//				"headers": {
+//					"Accept-Ranges": ["bytes"],
+//					"Cache-Control": ["max-age=3600"],
+//					"Connection": ["keep-alive"],
+//					"Content-Type": ["text/html; charset=utf-8"],
+//					"Date": ["Tue, 30 May 2017 13:23:09 GMT"],
+//					"Etag": ["\"82b6bafbc0c4af5e3886d07802f4b62d\""],
+//					"Hoverfly": ["Was-Here"],
+//					"Last-Modified": ["Fri, 19 May 2017 10:59:12 GMT"],
+//					"Server": ["nginx"],
+//					"Strict-Transport-Security": ["max-age=31556926"],
+//					"Transfer-Encoding": ["chunked"],
+//					"Vary": ["Accept-Encoding"]
+//				}
+//			},
+//			"request": {
+//				"path": [{
+//					"matcher": "exact",
+//					"value": "/bar"
+//				}],
+//				"method": [{
+//					"matcher": "exact",
+//					"value": "GET"
+//				}],
+//				"query": {},
+//				"body": [{
+//					"matcher": "exact",
+//					"value": ""
+//				}]
+//			}
+//		}],
+//		"globalActions": {
+//			"delays": []
+//		}
+//	},
+//	"meta": {
+//		"schemaVersion": "v5",
+//		"hoverflyVersion": "v0.17.0",
+//		"timeExported": "2017-05-30T14:23:44+01:00"
+//	}
+//}`), &simulation)
+
+	templated := v2.SimulationViewV5{}
 	_ = json.Unmarshal([]byte(`{
 	"data": {
 		"pairs": [{
 			"response": {
 				"status": 200,
-				"body": "5iNe8dxWH5Ca8pZqAfEHv3rgC0SsvKNLu6o3K",
+				"body": "{\"st\": 1,\"sid\": 418,\"tt\": \"{{ Request.Path.[0] }}\",\"gr\": 0,\"uuid\": \"{{ randomUuid }}\",\"ip\": \"127.0.0.1\",\"ua\": \"user_agent\",\"tz\": -6,\"v\": 1}",
 				"encodedBody": false,
+				"templated": true,
 				"headers": {
 					"Accept-Ranges": ["bytes"],
 					"Cache-Control": ["max-age=3600"],
@@ -68,15 +119,26 @@ func BenchmarkProcessRequest(b *testing.B) {
 		"hoverflyVersion": "v0.17.0",
 		"timeExported": "2017-05-30T14:23:44+01:00"
 	}
-}`), &simulation)
+}`), &templated)
+
 
 	fmt.Println(hoverfly.StartProxy())
 	time.Sleep(time.Second)
-	hoverfly.PutSimulation(simulation)
 	request, _ := http.NewRequest(http.MethodGet, "http://localhost:8500/bar", nil)
 	var resp *http.Response
+	//hoverfly.PutSimulation(simulation)
+	//
+	//b.Run("Simple simulation", func(b *testing.B) {
+	//
+	//	for n := 0; n < b.N; n++ {
+	//		resp = hoverfly.processRequest(request)
+	//	}
+	//})
 
-	b.Run("Simple simulation", func(b *testing.B) {
+
+	hoverfly.PutSimulation(templated)
+
+	b.Run("Templated simulation", func(b *testing.B) {
 
 		for n := 0; n < b.N; n++ {
 			resp = hoverfly.processRequest(request)

--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -22,12 +22,6 @@ func RecordedRequestNotInCacheError() *HoverflyError {
 	}
 }
 
-func DecodePayloadError() *HoverflyError {
-	return &HoverflyError{
-		Message: "Failed to decode payload from cache",
-	}
-}
-
 func MatchingFailedError(closestMiss *models.ClosestMiss) *HoverflyError {
 	message := "Could not find a match for request, create or record a valid matcher first!"
 

--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -93,7 +93,7 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 		if cachedResponse != nil && cachedResponse.ResponseTemplate != nil {
 			template = cachedResponse.ResponseTemplate
 		} else {
-
+			// Parse and cache the template
 			template, _ = hf.templator.ParseTemplate(response.Body)
 			if cachedResponse != nil {
 				cachedResponse.ResponseTemplate = template
@@ -105,7 +105,7 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 		if err == nil {
 			response.Body = responseBody
 		} else {
-			log.Warn("Response Template " + err.Error())
+			log.Warnf("Failed to render response template: %s", err.Error())
 		}
 	}
 

--- a/core/hoverfly_funcs_test.go
+++ b/core/hoverfly_funcs_test.go
@@ -182,7 +182,7 @@ func Test_Hoverfly_GetResponse_WillCacheResponseIfNotInCache(t *testing.T) {
 	cachedRequestResponsePair, found := unit.CacheMatcher.RequestCache.Get("75b4ae6efa2a3f6d3ee6b9fed4d8c8c5")
 	Expect(found).To(BeTrue())
 
-	Expect(cachedRequestResponsePair.(models.CachedResponse).MatchingPair.Response.Body).To(Equal("response body"))
+	Expect(cachedRequestResponsePair.(*models.CachedResponse).MatchingPair.Response.Body).To(Equal("response body"))
 
 	unit.Simulation = models.NewSimulation()
 	response, err := unit.GetResponse(models.RequestDetails{

--- a/core/matching/cache_matcher.go
+++ b/core/matching/cache_matcher.go
@@ -68,7 +68,7 @@ func (this *CacheMatcher) GetAllResponses() (v2.CacheView, error) {
 	}
 
 	for key, value := range entries {
-		cachedResponse := value.(models.CachedResponse)
+		cachedResponse := value.(*models.CachedResponse)
 
 		var pair *v2.RequestMatcherResponsePairViewV5
 		var closestMiss *v2.ClosestMissView
@@ -126,7 +126,7 @@ func (this *CacheMatcher) SaveRequestMatcherResponsePair(request models.RequestD
 		cachedResponse.ClosestMiss = matchError.ClosestMiss
 	}
 
-	err := this.RequestCache.Set(key, cachedResponse)
+	err := this.RequestCache.Set(key, &cachedResponse)
 	return &cachedResponse, err
 }
 

--- a/core/matching/cache_matcher.go
+++ b/core/matching/cache_matcher.go
@@ -51,8 +51,8 @@ func (this *CacheMatcher) GetCachedResponse(req *models.RequestDetails) (*models
 		"destination": req.Destination,
 	}).Info("Response found interface{} cache")
 
-	response := cachedResponse.(models.CachedResponse)
-	return &response, nil
+	response := cachedResponse.(*models.CachedResponse)
+	return response, nil
 }
 
 func (this *CacheMatcher) GetAllResponses() (v2.CacheView, error) {
@@ -95,9 +95,9 @@ func (this *CacheMatcher) GetAllResponses() (v2.CacheView, error) {
 }
 
 // TODO: This would be easier to reason about if we had two methods, "CacheHit" and "CacheHit" in order to reduce bloating
-func (this *CacheMatcher) SaveRequestMatcherResponsePair(request models.RequestDetails, pair *models.RequestMatcherResponsePair, matchError *models.MatchError) error {
+func (this *CacheMatcher) SaveRequestMatcherResponsePair(request models.RequestDetails, pair *models.RequestMatcherResponsePair, matchError *models.MatchError) (*models.CachedResponse, error) {
 	if this.RequestCache == nil {
-		return errors.NoCacheSetError()
+		return nil, errors.NoCacheSetError()
 	}
 
 	var key string
@@ -126,7 +126,8 @@ func (this *CacheMatcher) SaveRequestMatcherResponsePair(request models.RequestD
 		cachedResponse.ClosestMiss = matchError.ClosestMiss
 	}
 
-	return this.RequestCache.Set(key, cachedResponse)
+	err := this.RequestCache.Set(key, cachedResponse)
+	return &cachedResponse, err
 }
 
 func (this *CacheMatcher) FlushCache() error {

--- a/core/matching/cache_matcher_test.go
+++ b/core/matching/cache_matcher_test.go
@@ -31,9 +31,10 @@ func Test_CacheMatcher_SaveRequestMatcherResponsePair_WillReturnErrorIfCacheIsNi
 	RegisterTestingT(t)
 	unit := matching.CacheMatcher{}
 
-	err := unit.SaveRequestMatcherResponsePair(models.RequestDetails{}, nil, nil)
+	cachedResponse, err := unit.SaveRequestMatcherResponsePair(models.RequestDetails{}, nil, nil)
 	Expect(err).ToNot(BeNil())
 	Expect(err.Error()).To(Equal("No cache set"))
+	Expect(cachedResponse).To(BeNil())
 }
 
 func Test_CacheMatcher_SaveRequestMatcherResponsePair_CanSaveNilPairs(t *testing.T) {
@@ -43,13 +44,10 @@ func Test_CacheMatcher_SaveRequestMatcherResponsePair_CanSaveNilPairs(t *testing
 		RequestCache: cache.NewDefaultLRUCache(),
 	}
 
-	err := unit.SaveRequestMatcherResponsePair(models.RequestDetails{}, nil, nil)
+	cachedResponse, err := unit.SaveRequestMatcherResponsePair(models.RequestDetails{}, nil, nil)
 	Expect(err).To(BeNil())
 
-	cachedResponse, found := unit.RequestCache.Get("d41d8cd98f00b204e9800998ecf8427e")
-	Expect(found).To(BeTrue())
-
-	Expect(cachedResponse.(models.CachedResponse).MatchingPair).To(BeNil())
+	Expect(cachedResponse.MatchingPair).To(BeNil())
 }
 
 func Test_CacheMatcher_FlushCache_WillReturnErrorIfCacheIsNil(t *testing.T) {

--- a/core/models/cached_response.go
+++ b/core/models/cached_response.go
@@ -1,7 +1,12 @@
 package models
 
+import (
+	"github.com/aymerick/raymond"
+)
+
 type CachedResponse struct {
 	Request      RequestDetails
 	MatchingPair *RequestMatcherResponsePair
 	ClosestMiss  *ClosestMiss
+	ResponseTemplate *raymond.Template
 }

--- a/core/templating/templating.go
+++ b/core/templating/templating.go
@@ -57,6 +57,16 @@ func NewTemplator() *Templator {
 	return &Templator{}
 }
 
+func (*Templator) ParseTemplate(responseBody string) (*raymond.Template, error) {
+
+	return raymond.Parse(responseBody)
+}
+
+func (*Templator) RenderTemplate(tpl *raymond.Template, requestDetails *models.RequestDetails, state map[string]string) (string, error) {
+	ctx := NewTemplatingDataFromRequest(requestDetails, state)
+	return tpl.Exec(ctx)
+}
+
 func (*Templator) ApplyTemplate(requestDetails *models.RequestDetails, state map[string]string, responseBody string) (string, error) {
 
 	t := NewTemplatingDataFromRequest(requestDetails, state)

--- a/core/templating/templating.go
+++ b/core/templating/templating.go
@@ -1,6 +1,7 @@
 package templating
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -63,21 +64,13 @@ func (*Templator) ParseTemplate(responseBody string) (*raymond.Template, error) 
 }
 
 func (*Templator) RenderTemplate(tpl *raymond.Template, requestDetails *models.RequestDetails, state map[string]string) (string, error) {
+	if tpl == nil {
+		return "", fmt.Errorf("template cannot be nil")
+	}
 	ctx := NewTemplatingDataFromRequest(requestDetails, state)
 	return tpl.Exec(ctx)
 }
 
-func (*Templator) ApplyTemplate(requestDetails *models.RequestDetails, state map[string]string, responseBody string) (string, error) {
-
-	t := NewTemplatingDataFromRequest(requestDetails, state)
-
-	if rendered, err := raymond.Render(responseBody, t); err == nil {
-		responseBody = rendered
-		return responseBody, nil
-	} else {
-		return "", err
-	}
-}
 
 func NewTemplatingDataFromRequest(requestDetails *models.RequestDetails, state map[string]string) *TemplatingData {
 	return &TemplatingData{

--- a/core/templating/templating_test.go
+++ b/core/templating/templating_test.go
@@ -99,7 +99,7 @@ func TestApplyTemplateWithQueryParams(t *testing.T) {
 		},
 	}
 
-	template, err := templating.NewTemplator().ApplyTemplate(requestDetails,
+	template, err := ApplyTemplate(requestDetails,
 		make(map[string]string),
 		`
 Scheme: {{ Request.Scheme }}
@@ -143,7 +143,7 @@ func TestTemplatingWithParametersWhichDoNotExistDoNotErrorAndAreEmpty(t *testing
 		Destination: "foo.com",
 	}
 
-	template, err := templating.NewTemplator().ApplyTemplate(requestDetails,
+	template, err := ApplyTemplate(requestDetails,
 		map[string]string{
 			"one": "A",
 			"two": "B",
@@ -190,13 +190,13 @@ State Two: B`))
 func TestTemplatingWithHelperMethodsForDates(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{iso8601DateTime}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{iso8601DateTime}}`)
 
 	Expect(err).To(BeNil())
 
 	Expect(template).To(Equal(time.Now().UTC().Format("2006-01-02T15:04:05Z07:00")))
 
-	template, err = templating.NewTemplator().ApplyTemplate(&models.RequestDetails{
+	template, err = ApplyTemplate(&models.RequestDetails{
 		Query: map[string][]string{
 			"plusDays": {"2"},
 		},
@@ -210,7 +210,7 @@ func TestTemplatingWithHelperMethodsForDates(t *testing.T) {
 func Test_ApplyTemplate_currentDateTime(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{currentDateTime "2006-01-02T15:04:05Z07:00"}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{currentDateTime "2006-01-02T15:04:05Z07:00"}}`)
 
 	Expect(err).To(BeNil())
 
@@ -220,7 +220,7 @@ func Test_ApplyTemplate_currentDateTime(t *testing.T) {
 func Test_ApplyTemplate_currentDateTimeAdd(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{currentDateTimeAdd "5m" "2006-01-02T15:04:05Z07:00"}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{currentDateTimeAdd "5m" "2006-01-02T15:04:05Z07:00"}}`)
 
 	Expect(err).To(BeNil())
 
@@ -230,7 +230,7 @@ func Test_ApplyTemplate_currentDateTimeAdd(t *testing.T) {
 func Test_ApplyTemplate_currentDateTimeSubtract(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{currentDateTimeSubtract "5m" "2006-01-02T15:04:05Z07:00"}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{currentDateTimeSubtract "5m" "2006-01-02T15:04:05Z07:00"}}`)
 
 	Expect(err).To(BeNil())
 
@@ -240,7 +240,7 @@ func Test_ApplyTemplate_currentDateTimeSubtract(t *testing.T) {
 func Test_ApplyTemplate_randomString(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomString}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomString}}`)
 
 	Expect(err).To(BeNil())
 
@@ -250,7 +250,7 @@ func Test_ApplyTemplate_randomString(t *testing.T) {
 func Test_ApplyTemplate_randomStringLength(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomStringLength 2}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomStringLength 2}}`)
 
 	Expect(err).To(BeNil())
 
@@ -261,7 +261,7 @@ func Test_ApplyTemplate_randomStringLength(t *testing.T) {
 func Test_ApplyTemplate_randomBoolean(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomBoolean}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomBoolean}}`)
 
 	Expect(err).To(BeNil())
 
@@ -271,7 +271,7 @@ func Test_ApplyTemplate_randomBoolean(t *testing.T) {
 func Test_ApplyTemplate_randomInteger(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomInteger}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomInteger}}`)
 
 	Expect(err).To(BeNil())
 
@@ -281,7 +281,7 @@ func Test_ApplyTemplate_randomInteger(t *testing.T) {
 func Test_ApplyTemplate_randomIntegerRange(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomIntegerRange 7 8}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomIntegerRange 7 8}}`)
 
 	Expect(err).To(BeNil())
 
@@ -291,7 +291,7 @@ func Test_ApplyTemplate_randomIntegerRange(t *testing.T) {
 func Test_ApplyTemplate_randomFloat(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomFloat}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomFloat}}`)
 
 	Expect(err).To(BeNil())
 
@@ -301,7 +301,7 @@ func Test_ApplyTemplate_randomFloat(t *testing.T) {
 func Test_ApplyTemplate_randomFloatRange(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomFloatRange 7.0 8.0}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomFloatRange 7.0 8.0}}`)
 
 	Expect(err).To(BeNil())
 
@@ -311,7 +311,7 @@ func Test_ApplyTemplate_randomFloatRange(t *testing.T) {
 func Test_ApplyTemplate_randomEmail(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomEmai}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomEmai}}`)
 
 	Expect(err).To(BeNil())
 	Expect(template).To(Not(Equal(ContainSubstring(`{{randomEmail}}`))))
@@ -320,7 +320,7 @@ func Test_ApplyTemplate_randomEmail(t *testing.T) {
 func Test_ApplyTemplate_randomIPv4(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomIPv4}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomIPv4}}`)
 
 	Expect(err).To(BeNil())
 
@@ -330,7 +330,7 @@ func Test_ApplyTemplate_randomIPv4(t *testing.T) {
 func Test_ApplyTemplate_randomIPv6(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomIPv6}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomIPv6}}`)
 
 	Expect(err).To(BeNil())
 
@@ -340,7 +340,7 @@ func Test_ApplyTemplate_randomIPv6(t *testing.T) {
 func Test_ApplyTemplate_randomUuid(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomUuid}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{randomUuid}}`)
 
 	Expect(err).To(BeNil())
 
@@ -350,9 +350,16 @@ func Test_ApplyTemplate_randomUuid(t *testing.T) {
 func Test_ApplyTemplate_Request_Body(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := templating.NewTemplator().ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{ Request.Body jsonPath "$.test" }}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{ Request.Body jsonPath "$.test" }}`)
 
 	Expect(err).To(BeNil())
 
 	Expect(template).To(Not(Equal(ContainSubstring(`{{Request.Body jsonPath \"$.test\"}}`))))
+}
+
+func ApplyTemplate(requestDetails *models.RequestDetails, state map[string]string, responseBody string) (string, error) {
+	templator := templating.NewTemplator()
+	template, _ := templator.ParseTemplate(responseBody)
+
+	return templator.RenderTemplate(template, requestDetails, state)
 }


### PR DESCRIPTION
This is recommended by Raymond handlebar library https://github.com/aymerick/raymond#correct-usage to avoid parsing template on every request. 

Benchmark results before and after:
Before
```
BenchmarkProcessRequest/Templated_simulation-8            300000             98836 ns/op
```
After
```
BenchmarkProcessRequest/Templated_simulation-8           3000000             11367 ns/op
```