### PR TITLE
adding alpine based image with CA certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.11.4 AS build-env
+WORKDIR /usr/local/go/src/github.com/SpectoLabs/hoverfly
+COPY . /usr/local/go/src/github.com/SpectoLabs/hoverfly    
+RUN cd core/cmd/hoverfly && CGO_ENABLED=0 GOOS=linux go install -ldflags "-s -w"
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY --from=build-env /usr/local/go/bin/hoverfly /bin/hoverfly
+ENTRYPOINT ["/bin/hoverfly", "-listen-on-host=0.0.0.0"]
+CMD [""]
+
+EXPOSE 8500 8888


### PR DESCRIPTION
Hi guys, I am using Hoverfly after a long break, good job maintaining and expanding it!. The dockerfile in core/ is missing CA certs so can't fetch simulations from for example github gist when running in a container. As I see, it was switched from alpine image because you need to add some additional build settings `CGO_ENABLED=0 GOOS=linux go install`. The issue is visible in the logs below:

```
➜  hoverfly git:(master) ✗ docker logs eloquent_napier
INFO[2019-02-14T18:31:44Z] Listen on specific interface                  host=0.0.0.0
INFO[2019-02-14T18:31:44Z] Using memory backend                        
INFO[2019-02-14T18:31:44Z] URL                                           importFrom="https://gist.githubusercontent.com/rusenask/e66bafde97b640ddcc4072ee601f2ccd/raw/fb60ccaf06ce1ef4f4c2b945989a71c9228a1a76/hoverfly-simulation.json" isURL=true
FATA[2019-02-14T18:31:44Z] Failed to import given resource               error="Failed to fetch given URL, error Get https://gist.githubusercontent.com/rusenask/e66bafde97b640ddcc4072ee601f2ccd/raw/fb60ccaf06ce1ef4f4c2b945989a71c9228a1a76/hoverfly-simulation.json: x509: certificate signed by unknown authority" import="https://gist.githubusercontent.com/rusenask/e66bafde97b640ddcc4072ee601f2ccd/raw/fb60ccaf06ce1ef4f4c2b945989a71c9228a1a76/hoverfly-simulation.json"
```
I am not in a position to do any build pipeline changes but I would suggest switching to a multi-stage build to avoid any dependencies that might come from using CircleCI and expecting that the binaries are there. 

For now I think it's good at least to have a Dockerfile in the root project dir for anyone who wants to build it without deciphering the Makefile :) 