### PR TITLE
Set response content length safely

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,7 +40,7 @@
     ".",
     "ext/auth"
   ]
-  revision = "7f7f48f6cfc35287b46ad3ef95aafbf1c247f7e3"
+  revision = "04eaec60149482b840c282245794775076c34e62"
 
 [[projects]]
   branch = "master"

--- a/core/import.go
+++ b/core/import.go
@@ -159,8 +159,7 @@ func (hf *Hoverfly) importRequestResponsePairViews(pairViews []v2.RequestMatcher
 
 			if len(pairView.Response.Headers["Content-Length"]) > 0 {
 				contentLength, err := strconv.Atoi(pairView.Response.Headers["Content-Length"][0])
-				response := models.NewResponseDetailsFromResponse(pairView.Response)
-				if err == nil && contentLength != len(response.Body) {
+				if err == nil && contentLength != len(pair.Response.Body) {
 					importResult.AddContentLengthMismatchWarning(i)
 				}
 			}

--- a/core/modes/modes.go
+++ b/core/modes/modes.go
@@ -98,8 +98,7 @@ func ReconstructResponse(request *http.Request, pair models.RequestResponsePair)
 	response := &http.Response{}
 	response.Request = request
 
-	// ContentLength is unknown (-1), HTTP package knows what to do
-	response.ContentLength = -1
+	response.ContentLength = int64(len(pair.Response.Body))
 	response.Body = ioutil.NopCloser(strings.NewReader(pair.Response.Body))
 	response.StatusCode = pair.Response.Status
 
@@ -110,6 +109,10 @@ func ReconstructResponse(request *http.Request, pair models.RequestResponsePair)
 	}
 
 	response.Header = headers
+
+	if response.ContentLength > 0 && response.Header.Get("Content-Length") == "" && response.Header.Get("Transfer-Encoding") == "" {
+		response.Header.Set("Content-Length", fmt.Sprintf("%v", response.ContentLength))
+	}
 
 	return response
 }

--- a/core/proxy.go
+++ b/core/proxy.go
@@ -83,17 +83,6 @@ func NewProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 			})
 	}
 
-	// Set content length only if both Content-Length and Transfer-Encoding are absent
-	proxy.OnResponse().DoFunc(func(r *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
-		if r.Body != nil && r.Header.Get("Content-Length") == "" && r.Header.Get("Transfer-Encoding") == "" {
-			responseBytes, _ := ioutil.ReadAll(r.Body)
-			r.Header.Set("Content-Length", fmt.Sprintf("%v", len(responseBytes)))
-			r.Body = ioutil.NopCloser(bytes.NewReader(responseBytes))
-			r.ContentLength = int64(len(responseBytes))
-		}
-		return r
-	})
-
 	// intercepts response
 	proxy.OnResponse(matchesFilter(hoverfly.Cfg.Destination)).DoFunc(
 		func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {

--- a/functional-tests/core/ft_simulate_mode_test.go
+++ b/functional-tests/core/ft_simulate_mode_test.go
@@ -2,6 +2,7 @@ package hoverfly_test
 
 import (
 	"io/ioutil"
+	"os"
 
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -468,5 +469,20 @@ Which if hit would have given the following response:
 		body, err = ioutil.ReadAll(resp.Body)
 		Expect(err).To(BeNil())
 		Expect(string(body)).To(Equal("response 2b"))
+	})
+
+	It("Should simulate a base64 encoded body with correct content length", func() {
+		pwd, _ := os.Getwd()
+		expectedFile := "/testdata/1x1.png"
+		expectedImage, _ := ioutil.ReadFile(pwd + expectedFile)
+		hoverfly.ImportSimulation(testdata.Base64EncodedBody)
+
+		slingRequest := sling.New().Get("http://test-server.com/image.png")
+		response := hoverfly.Proxy(slingRequest)
+
+		body, err := ioutil.ReadAll(response.Body)
+		Expect(err).To(BeNil())
+		Expect(body).To(Equal(expectedImage))
+		Expect(response.Header.Get("Content-Length")).To(Equal("67"))
 	})
 })

--- a/functional-tests/testdata/base64_encoded_body.go
+++ b/functional-tests/testdata/base64_encoded_body.go
@@ -1,0 +1,44 @@
+package testdata
+
+var Base64EncodedBody = `{
+	"data": {
+		"pairs": [
+			{
+				"request": {
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "test-server.com"
+						}
+					],
+					"path": [
+						{
+							"matcher": "exact",
+							"value": "/image.png"
+						}
+					],
+					"method": [
+						{
+							"matcher": "exact",
+							"value": "GET"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGP6DwABBQECz6AuzQAAAABJRU5ErkJggg==",
+					"encodedBody": true,
+					"templated": false
+				}
+			}
+		],
+		"globalActions": {
+			"delays": []
+		}
+	},
+	"meta": {
+		"schemaVersion": "v5",
+		"hoverflyVersion": "v1.0.0-rc.2",
+		"timeExported": "2019-02-28T14:48:28Z"
+	}
+}`

--- a/vendor/github.com/SpectoLabs/goproxy/https.go
+++ b/vendor/github.com/SpectoLabs/goproxy/https.go
@@ -2,7 +2,6 @@ package goproxy
 
 import (
 	"bufio"
-	"bytes"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -158,14 +157,6 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				defer resp.Body.Close()
 			}
 			resp = proxy.filterResponse(resp, ctx)
-
-			// According to here: https://github.com/golang/go/issues/923
-			// There should not be an issue writing out body with an unknown ContentLength, but it's not the case for ConnectHTTPMitm
-			if resp.ContentLength == -1 {
-				responseBytes, _ := ioutil.ReadAll(resp.Body)
-				resp.Body = ioutil.NopCloser(bytes.NewReader(responseBytes))
-				resp.ContentLength = int64(len(responseBytes))
-			}
 			if err := resp.Write(proxyClient); err != nil {
 				httpError(proxyClient, ctx, err)
 				return


### PR DESCRIPTION
This PR provides a safer way to set response content length without reading the body from the stream at all.