### PR TITLE
Fix slow import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ functional-tests/core/bin/hoverctl
 test.db
 /vendor/vendor.json
 config.yaml
+/testdata/large_file.json

--- a/core/benchmark_test.go
+++ b/core/benchmark_test.go
@@ -1,6 +1,7 @@
 package hoverfly
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
@@ -10,6 +11,39 @@ import (
 	"testing"
 	"time"
 )
+
+
+func BenchmarkPutSimulationAPI(b *testing.B) {
+	RegisterTestingT(b)
+
+	hoverfly := NewHoverflyWithConfiguration(&Configuration{
+		ProxyPort: "8500",
+		AdminPort: "8888",
+		Mode:      "simulate",
+	})
+
+	data, _ := ioutil.ReadFile("../testdata/large_file.json")
+
+	adminApi := AdminApi{}
+
+	go adminApi.StartAdminInterface(hoverfly)
+	time.Sleep(time.Second)
+
+	var resp *http.Response
+	var err error
+
+	b.Run("Import large simulation file", func(b *testing.B) {
+
+		for n := 0; n < b.N; n++ {
+			request, _ := http.NewRequest(http.MethodPut, "http://localhost:8888/api/v2/simulation", bytes.NewReader(data))
+			resp, err = http.DefaultClient.Do(request)
+		}
+	})
+
+	Expect(err).To(BeNil())
+	Expect(resp.StatusCode).To(Equal(200))
+
+}
 
 func BenchmarkProcessRequest(b *testing.B) {
 

--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -104,9 +104,10 @@ var (
 	logsFormat = flag.String("logs", "plaintext", "Specify format for logs, options are \"plaintext\" and \"json\"")
 	logsSize   = flag.Int("logs-size", 1000, "Set the amount of logs to be stored in memory")
 
-	journalSize = flag.Int("journal-size", 1000, "Set the size of request/response journal")
-	cacheSize 	= flag.Int("cache-size", 1000, "Set the size of request/response cache")
-	cors     = flag.Bool("cors", false, "Enable CORS support")
+	journalSize 	= flag.Int("journal-size", 1000, "Set the size of request/response journal")
+	cacheSize 		= flag.Int("cache-size", 1000, "Set the size of request/response cache")
+	cors     		= flag.Bool("cors", false, "Enable CORS support")
+	skipImportCheck	= flag.Bool("skip-import-check", false, "Skip duplicate request check when importing simulations")
 
 	clientAuthenticationDestination = flag.String("client-authentication-destination", "", "Regular expression of destination with client authentication")
 	clientAuthenticationClientCert  = flag.String("client-authentication-client-cert", "", "Path to the client certification file used for authentication")
@@ -300,6 +301,8 @@ func main() {
 		cfg.CORS = *cs.DefaultCORSConfigs()
 		log.Info("CORS has been enabled")
 	}
+
+	cfg.SkipImportCheck = *skipImportCheck
 
 	cfg.ClientAuthenticationDestination = *clientAuthenticationDestination
 	cfg.ClientAuthenticationClientCert = *clientAuthenticationClientCert

--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -104,10 +104,10 @@ var (
 	logsFormat = flag.String("logs", "plaintext", "Specify format for logs, options are \"plaintext\" and \"json\"")
 	logsSize   = flag.Int("logs-size", 1000, "Set the amount of logs to be stored in memory")
 
-	journalSize 	= flag.Int("journal-size", 1000, "Set the size of request/response journal")
-	cacheSize 		= flag.Int("cache-size", 1000, "Set the size of request/response cache")
-	cors     		= flag.Bool("cors", false, "Enable CORS support")
-	skipImportCheck	= flag.Bool("skip-import-check", false, "Skip duplicate request check when importing simulations")
+	journalSize   = flag.Int("journal-size", 1000, "Set the size of request/response journal")
+	cacheSize     = flag.Int("cache-size", 1000, "Set the size of request/response cache")
+	cors          = flag.Bool("cors", false, "Enable CORS support")
+	noImportCheck = flag.Bool("no-import-check", false, "Skip duplicate request check when importing simulations")
 
 	clientAuthenticationDestination = flag.String("client-authentication-destination", "", "Regular expression of destination with client authentication")
 	clientAuthenticationClientCert  = flag.String("client-authentication-client-cert", "", "Path to the client certification file used for authentication")
@@ -302,7 +302,10 @@ func main() {
 		log.Info("CORS has been enabled")
 	}
 
-	cfg.SkipImportCheck = *skipImportCheck
+	if *noImportCheck {
+		cfg.NoImportCheck = *noImportCheck
+		log.Info("Import check has been disabled")
+	}
 
 	cfg.ClientAuthenticationDestination = *clientAuthenticationDestination
 	cfg.ClientAuthenticationClientCert = *clientAuthenticationClientCert

--- a/core/import.go
+++ b/core/import.go
@@ -144,7 +144,7 @@ func (hf *Hoverfly) importRequestResponsePairViews(pairViews []v2.RequestMatcher
 			pair := models.NewRequestMatcherResponsePairFromView(&pairView)
 
 			var isPairAdded bool
-			if hf.Cfg.SkipImportCheck {
+			if hf.Cfg.NoImportCheck {
 				hf.Simulation.AddPairWithoutCheck(pair)
 				isPairAdded = true
 			} else {

--- a/core/import.go
+++ b/core/import.go
@@ -143,8 +143,15 @@ func (hf *Hoverfly) importRequestResponsePairViews(pairViews []v2.RequestMatcher
 
 			pair := models.NewRequestMatcherResponsePairFromView(&pairView)
 
-			isAdded := hf.Simulation.AddPair(pair)
-			if isAdded {
+			var isPairAdded bool
+			if hf.Cfg.SkipImportCheck {
+				hf.Simulation.AddPairWithoutCheck(pair)
+				isPairAdded = true
+			} else {
+				isPairAdded = hf.Simulation.AddPair(pair)
+			}
+
+			if isPairAdded {
 				for k, v := range pair.RequestMatcher.RequiresState {
 					initialStates[k] = v
 				}

--- a/core/models/simulation.go
+++ b/core/models/simulation.go
@@ -42,6 +42,12 @@ func (this *Simulation) AddPair(pair *RequestMatcherResponsePair) bool {
 	return !duplicate
 }
 
+func (this *Simulation) AddPairWithoutCheck(pair *RequestMatcherResponsePair) {
+	this.RWMutex.Lock()
+	this.matchingPairs = append(this.matchingPairs, *pair)
+	this.RWMutex.Unlock()
+}
+
 func (this *Simulation) AddPairInSequence(pair *RequestMatcherResponsePair, state *state.State) {
 	var duplicate bool
 

--- a/core/settings.go
+++ b/core/settings.go
@@ -44,7 +44,7 @@ type Configuration struct {
 	PlainHttpTunneling bool
 	CORS cors.Configs
 
-	SkipImportCheck bool
+	NoImportCheck bool
 
 	ClientAuthenticationDestination string
 	ClientAuthenticationClientCert  string
@@ -192,9 +192,9 @@ func InitSettings() *Configuration {
 	}
 
 	if os.Getenv(HoverflySkipImportCheckEV) == "true" {
-		appConfig.SkipImportCheck = true
+		appConfig.NoImportCheck = true
 	} else {
-		appConfig.SkipImportCheck = false
+		appConfig.NoImportCheck = false
 	}
 
 	appConfig.Mode = "simulate"

--- a/core/settings.go
+++ b/core/settings.go
@@ -44,6 +44,8 @@ type Configuration struct {
 	PlainHttpTunneling bool
 	CORS cors.Configs
 
+	SkipImportCheck bool
+
 	ClientAuthenticationDestination string
 	ClientAuthenticationClientCert  string
 	ClientAuthenticationClientKey   string
@@ -93,6 +95,7 @@ const DefaultJWTExpirationDelta = 1 * 24 * 60 * 60
 
 // Environment variables
 const (
+	// TODO Should use naming convention for environment variables
 	HoverflyAuthEnabledEV     = "HoverflyAuthEnabled"
 	HoverflySecretEV          = "HoverflySecret"
 	HoverflyTokenExpirationEV = "HoverflyTokenExpiration"
@@ -111,6 +114,7 @@ const (
 	HoverflyImportRecordsEV = "HoverflyImport"
 
 	HoverflyUpstreamProxyPortEV = "UpstreamProxy"
+	HoverflySkipImportCheckEV = "SKIP_IMPORT_CHECK"
 )
 
 // InitSettings gets and returns initial configuration from env
@@ -185,6 +189,12 @@ func InitSettings() *Configuration {
 		appConfig.TLSVerification = false
 	} else {
 		appConfig.TLSVerification = true
+	}
+
+	if os.Getenv(HoverflySkipImportCheckEV) == "true" {
+		appConfig.SkipImportCheck = true
+	} else {
+		appConfig.SkipImportCheck = false
 	}
 
 	appConfig.Mode = "simulate"

--- a/core/settings_test.go
+++ b/core/settings_test.go
@@ -163,5 +163,5 @@ func TestSettingsSkipDuplicatePairCheckEnv(t *testing.T) {
 	os.Setenv("SKIP_IMPORT_CHECK", "true")
 	cfg := InitSettings()
 
-	Expect(cfg.SkipImportCheck).To(BeTrue())
+	Expect(cfg.NoImportCheck).To(BeTrue())
 }

--- a/core/settings_test.go
+++ b/core/settings_test.go
@@ -154,3 +154,14 @@ func Test_InitSettings_SetsCORSToDisabled(t *testing.T) {
 
 	Expect(settings.CORS.Enabled).To(BeFalse())
 }
+
+func TestSettingsSkipDuplicatePairCheckEnv(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer os.Setenv("SKIP_IMPORT_CHECK", "")
+
+	os.Setenv("SKIP_IMPORT_CHECK", "true")
+	cfg := InitSettings()
+
+	Expect(cfg.SkipImportCheck).To(BeTrue())
+}

--- a/functional-tests/core/ft_import_test.go
+++ b/functional-tests/core/ft_import_test.go
@@ -1,0 +1,46 @@
+package hoverfly_test
+
+import (
+	"encoding/json"
+	v2 "github.com/SpectoLabs/hoverfly/core/handlers/v2"
+	"github.com/SpectoLabs/hoverfly/functional-tests"
+	"github.com/SpectoLabs/hoverfly/functional-tests/testdata"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+)
+
+var _ = Describe("When I run Hoverfly", func() {
+
+	var (
+		hoverfly *functional_tests.Hoverfly
+	)
+
+	BeforeEach(func() {
+		hoverfly = functional_tests.NewHoverfly()
+	})
+
+	AfterEach(func() {
+		hoverfly.Stop()
+	})
+
+	Context("with skip import check", func() {
+
+		BeforeEach(func() {
+			hoverfly.Start("-skip-import-check=true")
+		})
+
+		It("should skip duplicate pair check", func() {
+
+			hoverfly.ImportSimulation(testdata.DuplicatePairs)
+
+			recordsJson, err := ioutil.ReadAll(hoverfly.GetSimulation())
+			Expect(err).To(BeNil())
+
+			payload := v2.SimulationViewV5{}
+
+			Expect(json.Unmarshal(recordsJson, &payload)).To(Succeed())
+			Expect(payload.RequestResponsePairs).To(HaveLen(2))
+		})
+	})
+})

--- a/functional-tests/core/ft_import_test.go
+++ b/functional-tests/core/ft_import_test.go
@@ -24,10 +24,10 @@ var _ = Describe("When I run Hoverfly", func() {
 		hoverfly.Stop()
 	})
 
-	Context("with skip import check", func() {
+	Context("with -no-import-check", func() {
 
 		BeforeEach(func() {
-			hoverfly.Start("-skip-import-check=true")
+			hoverfly.Start("-no-import-check")
 		})
 
 		It("should skip duplicate pair check", func() {

--- a/functional-tests/hoverctl/start_test.go
+++ b/functional-tests/hoverctl/start_test.go
@@ -207,6 +207,15 @@ var _ = Describe("hoverctl `start`", func() {
 			output = functional_tests.Run(hoverctlBinary, "logs", "--json")
 			Expect(output).To(ContainSubstring("CORS has been enabled"))
 		})
+
+		It("should start an instance of hoverfly with import check disabled", func() {
+			output := functional_tests.Run(hoverctlBinary, "start", "--no-import-check")
+
+			Expect(output).To(ContainSubstring("Hoverfly is now running"))
+
+			output = functional_tests.Run(hoverctlBinary, "logs", "--json")
+			Expect(output).To(ContainSubstring("Import check has been disabled"))
+		})
 	})
 
 	Context("with a target", func() {

--- a/functional-tests/testdata/duplicate_pairs.go
+++ b/functional-tests/testdata/duplicate_pairs.go
@@ -1,0 +1,56 @@
+package testdata
+
+var DuplicatePairs = `{
+	"data": {
+		"pairs": [
+			{
+				"request": {
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "destination.com"
+						},
+						{
+							"matcher": "glob",
+							"value": "*.com"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "multiple matches",
+					"encodedBody": false,
+					"templated": false
+				}
+			},
+			{
+				"request": {
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "destination.com"
+						},
+						{
+							"matcher": "glob",
+							"value": "*.com"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "multiple matches 2",
+					"encodedBody": false,
+					"templated": false
+				}
+			}
+		],
+		"globalActions": {
+			"delays": []
+		}
+	},
+	"meta": {
+		"schemaVersion": "v5",
+		"hoverflyVersion": "v0.17.0",
+		"timeExported": "2018-05-03T15:27:30+01:00"
+	}
+}`

--- a/hoverctl/cmd/start.go
+++ b/hoverctl/cmd/start.go
@@ -73,6 +73,7 @@ hoverctl configuration file.
 		target.UpstreamProxyUrl, _ = cmd.Flags().GetString("upstream-proxy")
 		target.HttpsOnly, _ = cmd.Flags().GetBool("https-only")
 		target.CORS, _ = cmd.Flags().GetBool("cors")
+		target.NoImportCheck, _ = cmd.Flags().GetBool("no-import-check")
 
 		target.Simulations, _ = cmd.Flags().GetStringSlice("import")
 
@@ -153,6 +154,7 @@ func init() {
 	startCmd.Flags().Bool("https-only", false, "Disable insecure HTTP traffic in Hoverfly")
 	startCmd.Flags().String("listen-on-host", "", "Bind hoverfly listener to a host")
 	startCmd.Flags().Bool("cors", false, "Enable CORS support")
+	startCmd.Flags().Bool("no-import-check", false, "Skip duplicate request check when importing simulations")
 
 	startCmd.Flags().String("client-authentication-destination", "", "Regular expression for hosts need client authentication")
 	startCmd.Flags().String("client-authentication-client-cert", "", "Path to client certificate file used for authentication")

--- a/hoverctl/configuration/target.go
+++ b/hoverctl/configuration/target.go
@@ -26,7 +26,8 @@ type Target struct {
 	UpstreamProxyUrl string `yaml:",omitempty"`
 	PACFile          string `yaml:",omitempty"`
 	HttpsOnly        bool   `yaml:",omitempty"`
-	CORS       	 	bool   `yaml:",omitempty"`
+	CORS             bool   `yaml:",omitempty"`
+	NoImportCheck    bool   `yaml:",omitempty"`
 
 	ClientAuthenticationDestination string `yaml:",omitempty"`
 	ClientAuthenticationClientCert  string `yaml:",omitempty"`
@@ -140,6 +141,10 @@ func (this Target) BuildFlags() Flags {
 
 	if this.ClientAuthenticationCACert != "" {
 		flags = append(flags, "-client-authentication-ca-cert="+this.ClientAuthenticationCACert)
+	}
+
+	if this.NoImportCheck {
+		flags = append(flags, "-no-import-check")
 	}
 
 	if len(this.Simulations) > 0 {

--- a/hoverctl/configuration/target_test.go
+++ b/hoverctl/configuration/target_test.go
@@ -248,3 +248,24 @@ func Test_Target_BuildFlags_SetImportFlags(t *testing.T) {
 	Expect(unit.BuildFlags()[0]).To(Equal("-import=foo.json"))
 	Expect(unit.BuildFlags()[1]).To(Equal("-import=bar.json"))
 }
+
+func Test_Target_BuildFlags_AddSkipImportCheckFlagWhenTrue(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := Target{
+		NoImportCheck: true,
+	}
+
+	Expect(unit.BuildFlags()).To(HaveLen(1))
+	Expect(unit.BuildFlags()[0]).To(Equal("-no-import-check"))
+}
+
+func Test_Target_BuildFlags_DoesNotAddSkipImportCheckFlagWhenFalse(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := Target{
+		NoImportCheck: false,
+	}
+
+	Expect(unit.BuildFlags()).To(HaveLen(0))
+}


### PR DESCRIPTION
With this PR, you can disable duplicate pair check on import, by starting hoverfly with: 
```
hoverfly -no-import-check
```

or 
```
hoverctl start --no-import-check
```