### PR TITLE
#855 Use copyState map as the parameter in StateMatcher function

### DIFF
--- a/core/matching/matching_strategy_runner.go
+++ b/core/matching/matching_strategy_runner.go
@@ -37,7 +37,7 @@ func MatchingStrategyRunner(req models.RequestDetails, webserver bool, simulatio
 
 		strategy.Matching(QueryMatching(requestMatcher, req.Query), "queries")
 
-		strategy.Matching(StateMatcher(state, requestMatcher.RequiresState), "state")
+		strategy.Matching(StateMatcher(copyState, requestMatcher.RequiresState), "state")
 
 		if result := strategy.PostMatching(req, requestMatcher, matchingPair, copyState); result != nil {
 			return result

--- a/core/matching/state_matcher.go
+++ b/core/matching/state_matcher.go
@@ -1,10 +1,6 @@
 package matching
 
-import (
-	"github.com/SpectoLabs/hoverfly/core/state"
-)
-
-func StateMatcher(currentState *state.State, requiredState map[string]string) *FieldMatch {
+func StateMatcher(copyState map[string]string, requiredState map[string]string) *FieldMatch {
 
 	score := 0
 	matched := true
@@ -17,11 +13,10 @@ func StateMatcher(currentState *state.State, requiredState map[string]string) *F
 	}
 
 	for key, value := range requiredState {
-		currentStateValue, ok := currentState.GetState(key)
-		if !ok {
+		if _, ok := copyState[key]; !ok {
 			matched = false
 		}
-		if currentStateValue != value {
+		if copyState[key] != value {
 			matched = false
 		} else {
 			score++

--- a/core/matching/state_matcher_test.go
+++ b/core/matching/state_matcher_test.go
@@ -3,7 +3,6 @@ package matching
 import (
 	"testing"
 
-	"github.com/SpectoLabs/hoverfly/core/state"
 	. "github.com/onsi/gomega"
 )
 
@@ -28,7 +27,7 @@ func Test_StateMatcher_ShouldMatchIfCurrentStateIsNilAndRequiredStateIsEmpty(t *
 func Test_StateMatcher_ShouldMatchIfCurrentStateIEmptyAndRequiredStateIsNil(t *testing.T) {
 	RegisterTestingT(t)
 
-	match := StateMatcher(&state.State{State: make(map[string]string)}, nil)
+	match := StateMatcher(make(map[string]string), nil)
 
 	Expect(match.Matched).To(BeTrue())
 	Expect(match.Score).To(Equal(0))
@@ -37,7 +36,7 @@ func Test_StateMatcher_ShouldMatchIfCurrentStateIEmptyAndRequiredStateIsNil(t *t
 func Test_StateMatcher_ShouldNotMatchIfRequiredStateLengthIsGreaterThanActualStateLength(t *testing.T) {
 	RegisterTestingT(t)
 
-	match := StateMatcher(&state.State{State: make(map[string]string)}, map[string]string{"foo": "bar"})
+	match := StateMatcher(make(map[string]string), map[string]string{"foo": "bar"})
 
 	Expect(match.Matched).To(BeFalse())
 	Expect(match.Score).To(Equal(0))
@@ -47,7 +46,7 @@ func Test_StateMatcher_ShouldNotMatchIfLengthsAreTheSameButKeysAreDifferent(t *t
 	RegisterTestingT(t)
 
 	match := StateMatcher(
-		&state.State{State: map[string]string{"foo": "bar", "cheese": "ham"}},
+		map[string]string{"foo": "bar", "cheese": "ham"},
 		map[string]string{"adasd": "bar", "sadsad": "ham"})
 
 	Expect(match.Matched).To(BeFalse())
@@ -58,7 +57,7 @@ func Test_StateMatcher_ShouldNotMatchIfKeysAreTheSameButValuesAreDifferent(t *te
 	RegisterTestingT(t)
 
 	match := StateMatcher(
-		&state.State{State: map[string]string{"foo": "bar", "cheese": "ham"}},
+		map[string]string{"foo": "bar", "cheese": "ham"},
 		map[string]string{"foo": "adsad", "cheese": "ham"})
 
 	Expect(match.Matched).To(BeFalse())
@@ -69,7 +68,7 @@ func Test_StateMatcher_ShouldMatchIsKeysAndValuesAreTheSame(t *testing.T) {
 	RegisterTestingT(t)
 
 	match := StateMatcher(
-		&state.State{State: map[string]string{"foo": "bar", "cheese": "ham"}},
+		map[string]string{"foo": "bar", "cheese": "ham"},
 		map[string]string{"foo": "bar", "cheese": "ham"})
 
 	Expect(match.Matched).To(BeTrue())


### PR DESCRIPTION
Use copyState map as the parameter in StateMatcher function to avoid race condition
