### PR TITLE
Realised handling templating on headers response

### DIFF
--- a/core/hoverfly_funcs_test.go
+++ b/core/hoverfly_funcs_test.go
@@ -321,6 +321,11 @@ func Test_Hoverfly_GetResponse_WillCacheTemplateIfNotInCache(t *testing.T) {
 			Status: 200,
 			Body:   "{{ randomUuid }}",
 			Templated: true,
+			Headers: map[string][]string{
+				"X-Image-Id": {
+					"{{ randomInteger }}",
+				},
+			},
 		},
 	})
 
@@ -336,6 +341,7 @@ func Test_Hoverfly_GetResponse_WillCacheTemplateIfNotInCache(t *testing.T) {
 	Expect(found).To(BeTrue())
 
 	Expect(cachedRequestResponsePair.(*models.CachedResponse).MatchingPair.Response.Body).To(Equal("{{ randomUuid }}"))
+	Expect(cachedRequestResponsePair.(*models.CachedResponse).MatchingPair.Response.Headers["X-Image-Id"][0]).To(Equal("{{ randomInteger }}"))
 	Expect(cachedRequestResponsePair.(*models.CachedResponse).ResponseTemplate).NotTo(BeNil())
 }
 

--- a/core/hoverfly_funcs_test.go
+++ b/core/hoverfly_funcs_test.go
@@ -321,11 +321,6 @@ func Test_Hoverfly_GetResponse_WillCacheTemplateIfNotInCache(t *testing.T) {
 			Status: 200,
 			Body:   "{{ randomUuid }}",
 			Templated: true,
-			Headers: map[string][]string{
-				"X-Image-Id": {
-					"{{ randomInteger }}",
-				},
-			},
 		},
 	})
 
@@ -341,7 +336,6 @@ func Test_Hoverfly_GetResponse_WillCacheTemplateIfNotInCache(t *testing.T) {
 	Expect(found).To(BeTrue())
 
 	Expect(cachedRequestResponsePair.(*models.CachedResponse).MatchingPair.Response.Body).To(Equal("{{ randomUuid }}"))
-	Expect(cachedRequestResponsePair.(*models.CachedResponse).MatchingPair.Response.Headers["X-Image-Id"][0]).To(Equal("{{ randomInteger }}"))
 	Expect(cachedRequestResponsePair.(*models.CachedResponse).ResponseTemplate).NotTo(BeNil())
 }
 

--- a/core/models/cached_response.go
+++ b/core/models/cached_response.go
@@ -9,4 +9,5 @@ type CachedResponse struct {
 	MatchingPair *RequestMatcherResponsePair
 	ClosestMiss  *ClosestMiss
 	ResponseTemplate *raymond.Template
+	ResponseHeadersTemplates map[string][]*raymond.Template
 }

--- a/functional-tests/core/ft_templated_response_test.go
+++ b/functional-tests/core/ft_templated_response_test.go
@@ -166,6 +166,21 @@ var _ = Describe("When I run Hoverfly", func() {
 			Expect(parsedInt > 0).To(BeTrue())
 		})
 
+		It("randomInteger in header", func() {
+			hoverfly.ImportSimulation(testdata.TemplatingHelpers)
+
+			resp := hoverfly.Proxy(sling.New().Get("http://test-server.com/randomIntegerHeader"))
+			Expect(resp.StatusCode).To(Equal(200))
+
+			imageId := resp.Header.Get("X-Image-Id")
+			Expect(imageId).NotTo(BeEmpty())
+
+			parsedImageId, err := strconv.ParseInt(imageId, 10, 0)
+			Expect(err).To(BeNil())
+
+			Expect(parsedImageId > 0).To(BeTrue())
+		})
+
 		It("randomIntegerRange", func() {
 			hoverfly.ImportSimulation(testdata.TemplatingHelpers)
 

--- a/functional-tests/testdata/templating_helpers.go
+++ b/functional-tests/testdata/templating_helpers.go
@@ -88,6 +88,25 @@ var TemplatingHelpers = `{
 					"path": [
 						{
 							"matcher": "exact",
+							"value": "/randomIntegerHeader"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "",
+					"encodedBody": false,
+					"headers": {
+						"X-Image-Id": ["{{ randomInteger }}"]
+					},
+					"templated": true
+				}
+			},
+			{
+				"request": {
+					"path": [
+						{
+							"matcher": "exact",
 							"value": "/randomFloat"
 						}
 					]


### PR DESCRIPTION
I made handling templates in response headers.
I update `core/hoverfly_funcs_test.go#Test_Hoverfly_GetResponse_WillCacheTemplateIfNotInCache` test: add header `X-Image-Id` with template `{{ randomInteger }}`.

How I test it:
1. Make local docker image: `docker build -t kulaginds/hoverfly`.
2. Run docker image: `docker run -ti --rm -p 8888:8888 -p 8500:8500 kulaginds/hoverfly:latest`
3. Put [test.json](https://gist.github.com/kulaginds/893d7d8fff142d9a218f1b4a3438e35c) to hoverfly.
4. Execute `curl -vvv -x localhost:8500 http://google.com/hello`.
Expected random integer in header `X-Image-Id`, actual `3551771716390149526`.