### PR TITLE
Datetime templating func

### DIFF
--- a/core/templating/template_helpers.go
+++ b/core/templating/template_helpers.go
@@ -15,23 +15,25 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const defaultDateTimeFormat = "2006-01-02T15:04:05Z07:00"
+
 type templateHelpers struct {
 	now func() time.Time
 }
 
 func (t templateHelpers) iso8601DateTime() string {
-	return t.now().UTC().Format("2006-01-02T15:04:05Z07:00")
+	return t.now().UTC().Format(defaultDateTimeFormat)
 }
 
 func (t templateHelpers) iso8601DateTimePlusDays(days string) string {
 	atoi, _ := strconv.Atoi(days)
-	return t.now().AddDate(0, 0, atoi).UTC().Format("2006-01-02T15:04:05Z07:00")
+	return t.now().AddDate(0, 0, atoi).UTC().Format(defaultDateTimeFormat)
 }
 
 func (t templateHelpers) currentDateTime(format string) string {
 	formatted := t.now().UTC().Format(format)
 	if formatted == format {
-		return t.now().UTC().Format("2006-01-02T15:04:05Z07:00")
+		return t.now().UTC().Format(defaultDateTimeFormat)
 	}
 	return formatted
 }
@@ -44,7 +46,7 @@ func (t templateHelpers) currentDateTimeAdd(addTime string, format string) strin
 	}
 	formatted := now.UTC().Format(format)
 	if formatted == format {
-		return now.UTC().Format("2006-01-02T15:04:05Z07:00")
+		return now.UTC().Format(defaultDateTimeFormat)
 	}
 	return formatted
 }
@@ -57,8 +59,36 @@ func (t templateHelpers) currentDateTimeSubtract(subtractTime string, format str
 	}
 	formatted := now.UTC().Format(format)
 	if formatted == format {
-		return now.UTC().Format("2006-01-02T15:04:05Z07:00")
+		return now.UTC().Format(defaultDateTimeFormat)
 	}
+	return formatted
+}
+
+func (t templateHelpers) nowHelper(offset string, format string) string {
+	now := t.now()
+	if offset != "" {
+		duration, err := ParseDuration(offset)
+		if err == nil {
+			now = now.Add(duration)
+		}
+	}
+	
+	var formatted string
+	if format == "" {
+		formatted = now.UTC().Format(defaultDateTimeFormat)
+	} else if format == "unix" {
+		formatted = strconv.FormatInt(now.Unix(), 10)
+	} else if format == "epoch" {
+		formatted = strconv.FormatInt(now.UnixNano() / 1000000, 10)
+	} else {
+		formatted = now.UTC().Format(format)	
+	}
+
+	// when format is invalid
+	if formatted == format {
+		return now.UTC().Format(defaultDateTimeFormat)
+	}
+	
 	return formatted
 }
 

--- a/core/templating/template_helpers_test.go
+++ b/core/templating/template_helpers_test.go
@@ -116,12 +116,74 @@ func Test_currentDateTimeSubtract_failure(t *testing.T) {
 	Expect(unit.currentDateTimeSubtract("cat", "cat")).To(Equal("2018-01-01T00:00:00Z"))
 }
 
+func Test_now_withEmptyOffsetAndEmptyFormat(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := templateHelpers{now:testNow}
+
+	Expect(unit.nowHelper("", "")).To(Equal("2018-01-01T00:00:00Z"))
+}
+
+func Test_now_withEmptyOffsetAndUnixFormat(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := templateHelpers{now:testNow}
+
+	Expect(unit.nowHelper("", "unix")).To(Equal("1514764800"))
+}
+
+func Test_now_withEmptyOffsetAndUnixMillisFormat(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := templateHelpers{now:testNow}
+
+	Expect(unit.nowHelper("", "epoch")).To(Equal("1514764800000"))
+}
+
+func Test_now_withEmptyOffsetAndCustomFormat(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := templateHelpers{now:testNow}
+
+	Expect(unit.nowHelper("", "Mon Jan 2 15:04:05 MST 2006")).To(Equal("Mon Jan 1 00:00:00 UTC 2018"))
+}
+
+func Test_now_withPositiveOffsetAndEmptyFormat(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := templateHelpers{now:testNow}
+
+	Expect(unit.nowHelper("1d", "")).To(Equal("2018-01-02T00:00:00Z"))
+}
+
+func Test_now_withNegativeOffsetAndEmptyFormat(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := templateHelpers{now:testNow}
+
+	Expect(unit.nowHelper("-1d", "")).To(Equal("2017-12-31T00:00:00Z"))
+}
+
+func Test_now_withInvalidOffset(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := templateHelpers{now:testNow}
+
+	Expect(unit.nowHelper("cat", "")).To(Equal("2018-01-01T00:00:00Z"))
+}
+
+func Test_now_withInvalidFormat(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := templateHelpers{now:testNow}
+
+	Expect(unit.nowHelper("", "dog")).To(Equal("2018-01-01T00:00:00Z"))
+}
+
 func Test_replace(t *testing.T) {
 	RegisterTestingT(t)
 
-	unit := templateHelpers{
-		now: testNow,
-	}
+	unit := templateHelpers{}
 
 	Expect(unit.replace("oink, oink, oink", "oink", "moo")).To(Equal("moo, moo, moo"))
 }

--- a/core/templating/templating.go
+++ b/core/templating/templating.go
@@ -40,6 +40,7 @@ func NewTemplator() *Templator {
 		raymond.RegisterHelper("currentDateTime", t.currentDateTime)
 		raymond.RegisterHelper("currentDateTimeAdd", t.currentDateTimeAdd)
 		raymond.RegisterHelper("currentDateTimeSubtract", t.currentDateTimeSubtract)
+		raymond.RegisterHelper("now", t.nowHelper)
 		raymond.RegisterHelper("randomString", t.randomString)
 		raymond.RegisterHelper("randomStringLength", t.randomStringLength)
 		raymond.RegisterHelper("randomBoolean", t.randomBoolean)

--- a/core/templating/templating_test.go
+++ b/core/templating/templating_test.go
@@ -237,6 +237,17 @@ func Test_ApplyTemplate_currentDateTimeSubtract(t *testing.T) {
 	Expect(template).To(Not(Equal(ContainSubstring(`{{currentDateTimeSubtract "5m" "2006-01-02T15:04:05Z07:00"}}`))))
 }
 
+
+func Test_ApplyTemplate_now(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{now "" "unix"}}`)
+
+	Expect(err).To(BeNil())
+
+	Expect(template).To(Not(Equal(ContainSubstring(`{{now "" "unix"}}`))))
+}
+
 func Test_ApplyTemplate_randomString(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/docs/pages/keyconcepts/templating/templating.rst
+++ b/docs/pages/keyconcepts/templating/templating.rst
@@ -47,18 +47,11 @@ Additional data can come from helper methods. These are the ones Hoverfly curren
 +-----------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------+
 | Description                                               | Example                                                   |  Result                                 |
 +===========================================================+===========================================================+=========================================+
-| The current UTC date time, formatted in iso8601           | {{ iso8601DateTime }}                                     |  2006-01-02T15:04:05Z                   |
-+-----------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------+
-| The current UTC date time, formatted in iso8601,          |                                                           |                                         |
-| with days added                                           | {{ iso8601DateTimePlusDays Request.QueryParam.plusDays }} |  2006-02-02T15:04:05Z                   |
-+-----------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------+
-| The current UTC date time, in the format specified        | {{ currentDateTime "2006-Jan-02" }}                       |  2018-Jul-05                            |
-+-----------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------+
-| The current UTC date time, in the format specified,       |                                                           |                                         |
-| with duration added                                       | {{ currentDateTimeAdd "1d" "2006-Jan-02" }}               |  2018-Jul-06                            |
-+-----------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------+
-| The current UTC date time, in the format specified,       |                                                           |                                         |
-| with duration subtracted                                  | {{ currentDateTimeSubtract "1d" "2006-Jan-02" }}          |  2018-Jul-04                            |
+| The current date time with offset duration, in the format |                                                           |                                         |
+| specified. For example:                                   |                                                           |                                         |
+| - The current date time plus 1 day in unix timestamp      | {{ now "1d" "unix" }}                                     |  1136300645                             |
+| - The current date time in ISO 8601 format                | {{ now "" "" }}                                           |  2006-01-02T15:04:05Z                   |
+| - The current date time minus 1 day in custom format      | {{ now "-1d" "2006-Jan-02" }}                             |  2006-Jan-01                            |
 +-----------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------+
 | A random string                                           | {{ randomString }}                                        |  hGfclKjnmwcCds                         |
 +-----------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------+
@@ -86,9 +79,19 @@ Additional data can come from helper methods. These are the ones Hoverfly curren
 | value in the target string                                | (where Request.Body has the value of "to be or not to be" |  to mock or not to mock                 |
 +-----------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------+
 
+.. note::
+
+    The following helper methods will be deprecated, please use ``now`` helper for date time:
+        - ``iso8601DateTime``
+        - ``iso8601DateTimePlusDays``
+        - ``currentDateTime``
+        - ``currentDateTimeAdd``
+        - ``currentDateTimeSubtract``
+
+
 Durations
 ~~~~~~~~~
-When using template helper methods such as ``currentDateTimeAdd`` and ``currentDateTimeSubtract``, durations must be formatted following the following syntax for durations. 
+When using template helper method ``now``, durations must be formatted using the following syntax.
 
 +-----------+-------------+
 | Shorthand | Type        |
@@ -110,6 +113,8 @@ When using template helper methods such as ``currentDateTimeAdd`` and ``currentD
 | y         | Year        |
 +-----------+-------------+
 
+Prefix duration with ``-`` to subtract the duration from the current date time.
+
 Example Durations
 ~~~~~~~~~~~~~~~~~
 
@@ -123,8 +128,8 @@ Example Durations
 
 Date time formats
 ~~~~~~~~~~~~~~~~~
-When using template helper methods such as ``currentDateTime``, ``currentDateTimeAdd`` and ``currentDateTimeSubtract``, date time formats must follow
-the Golang syntax. More can be found out here https://golang.org/pkg/time/#Parse
+When using template helper method ``now``, date time formats must follow the Golang syntax.
+More can be found out here https://golang.org/pkg/time/#Parse
 
 Example date time formats
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -136,6 +141,13 @@ Example date time formats
 +-------------------------------+
 | Jan _2 15:04:05               |
 +-------------------------------+
+
+.. note::
+
+    If you leave the format string empty, the default format to be used is ISO 8601 (2006-01-02T15:04:05Z07:00).
+    You can also get UNIX timestamp by setting format to:
+    - ``unix``: UNIX timestamp in seconds
+    - ``epoch``: UNIX timestamp in milliseconds
 
 
 Conditional Templating, Looping and More


### PR DESCRIPTION
Proposing a new date time template helper: 
```
{{ now <offset> <format> }}
```

offset is a signed duration string
format can be golang datetime format or `unix` and `epoch` for UNIX timestamp

This helper will supersede the existing date time helper methods like `currentDateTimeAdd`, `iso8601DateTimePlusDays` etcs.