### PR TITLE
Fix race condition with simulatenously appending new entries to journal

### DIFF
--- a/core/journal/journal.go
+++ b/core/journal/journal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+	"sync"
 
 	sorting "sort"
 	"strings"
@@ -27,6 +28,7 @@ type JournalEntry struct {
 type Journal struct {
 	entries    []JournalEntry
 	EntryLimit int
+	mutex      sync.Mutex
 }
 
 func NewJournal() *Journal {
@@ -51,6 +53,7 @@ func (this *Journal) NewEntry(request *http.Request, response *http.Response, mo
 		Headers: response.Header,
 	}
 
+	this.mutex.Lock()
 	if len(this.entries) >= this.EntryLimit {
 		this.entries = append(this.entries[:0], this.entries[1:]...)
 	}
@@ -62,6 +65,7 @@ func (this *Journal) NewEntry(request *http.Request, response *http.Response, mo
 		TimeStarted: started,
 		Latency:     time.Since(started),
 	})
+	this.mutex.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
This fixes the issue with missing journal entries described here: 

https://github.com/SpectoLabs/hoverfly-java/issues/225

The fix might not be perfect, but where previously 5 repetitions caused the error, with this change it can't be replicated in over 100 repetitions.

NOTE: I don't know how to write Go so putting the mutex to the Journal struct might be really dumb. But I'm willing to make this sensible given comments.