### PR TITLE
upgrade exactMatcher docs

### DIFF
--- a/docs/pages/reference/api/api.rst
+++ b/docs/pages/reference/api/api.rst
@@ -635,9 +635,10 @@ Gets the requests and responses stored in the cache.
                 "key": "2fc8afceec1b6bcf99ff1f547c1f5b11",
                 "matchingPair": {
                     "request": {
-                        "path": {
-                            "exactMatch": "hoverfly.io"
-                        }
+                        "path": [{
+                            "matcher": "exact",
+                            "value": "hoverfly.io"
+                        }]
                     },
                     "response": {
                         "status": 200,
@@ -650,7 +651,8 @@ Gets the requests and responses stored in the cache.
                         }
                     }
                 },
-                "headerMatch": false
+                "headerMatch": false,
+                "closestMiss": null
             }
         ]
     }
@@ -770,9 +772,10 @@ Filter and search entries stored in the journal.
 ::
     {
         "request": {
-            "destination": {
-              "exactMatch": "hoverfly.io"
-            }
+            "destination": [{
+              "matcher": "exact",
+              "value": "hoverfly.io"
+            }]
         }
     }
 


### PR DESCRIPTION
Latest version seems not to support `exactMatch` key anymore in favor of separate `matcher` and `value`:

```bash
$ curl -XPOST http://localhost:8888/api/v2/journal --data '{"request": {"destination": {"exactMatch": "hoverfly.io"}}}'
{"error":"Malformed JSON"}✔
```

Plus, there is `closestMiss` key missing in cache response.