### PR TITLE
disable switching from simulate to modify mode while being a webserver

### DIFF
--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -49,6 +49,10 @@ func (this *Hoverfly) SetMode(mode string) error {
 	})
 }
 
+func (this *Hoverfly) canSwitchWebserverMode(modeView v2.ModeView) bool {
+	return modeView.Mode != modes.Capture && modeView.Mode != modes.Modify
+}
+
 func (this *Hoverfly) SetModeWithArguments(modeView v2.ModeView) error {
 
 	availableModes := map[string]bool{
@@ -67,9 +71,9 @@ func (this *Hoverfly) SetModeWithArguments(modeView v2.ModeView) error {
 		return fmt.Errorf("Not a valid mode")
 	}
 
-	if this.Cfg.Webserver && modeView.Mode == modes.Capture {
-		log.Error("Cannot change the mode of Hoverfly to capture when running as a webserver")
-		return fmt.Errorf("Cannot change the mode of Hoverfly to capture when running as a webserver")
+	if this.Cfg.Webserver && !this.canSwitchWebserverMode(modeView) {
+		log.Errorf("Cannot change the mode of Hoverfly to %s when running as a webserver", modeView.Mode)
+		return fmt.Errorf("Cannot change the mode of Hoverfly to %s when running as a webserver", modeView.Mode)
 	}
 
 	for _, header := range modeView.Arguments.Headers {

--- a/docs/pages/keyconcepts/modes/modify.rst
+++ b/docs/pages/keyconcepts/modes/modify.rst
@@ -3,6 +3,10 @@
 Modify mode
 ===========
 
+.. note::
+
+    Hoverfly cannot be set to Modify mode when running as a webserver (see :ref:`webserver`).
+
 Modify mode is similar to :ref:`capture_mode`, except it **does not save the requests and responses**.
 In Modify mode, Hoverfly will pass each request to a :ref:`middleware` executable before forwarding
 it to the destination. Responses will also be passed to middleware before being returned to the client.

--- a/docs/pages/keyconcepts/webserver.rst
+++ b/docs/pages/keyconcepts/webserver.rst
@@ -9,7 +9,7 @@ Sometimes you may not be able to configure your client to use a proxy, or you ma
 
 .. note::
 
-    When running as a webserver, Hoverfly cannot capture traffic (see :ref:`capture_mode`) - it can only be used to simulate and synthesize APIs (see :ref:`simulate_mode`, :ref:`modify_mode` and :ref:`synthesize_mode`). For this reason, when you use Hoverfly as a webserver, you should have Hoverfly simulations ready to be loaded.
+    When running as a webserver, Hoverfly cannot capture traffic (see :ref:`capture_mode`) - it can only be used to simulate and synthesize APIs (see :ref:`simulate_mode` and :ref:`synthesize_mode`). For this reason, when you use Hoverfly as a webserver, you should have Hoverfly simulations ready to be loaded.
 
 When running as a webserver, Hoverfly strips the domain from the endpoint URL. For example, if you made requests to the following URL while capturing traffic with Hoverfly running as a proxy:
 

--- a/functional-tests/hoverctl/hoverfly_modes_test.go
+++ b/functional-tests/hoverctl/hoverfly_modes_test.go
@@ -266,14 +266,6 @@ var _ = Describe("When I use hoverfly-cli", func() {
 				Expect(output).To(ContainSubstring("Hoverfly is currently set to synthesize mode"))
 			})
 
-			It("when hoverfly is in modify mode", func() {
-				hoverfly.SetMode("modify")
-
-				output := functional_tests.Run(hoverctlBinary, "mode")
-
-				Expect(output).To(ContainSubstring("Hoverfly is currently set to modify mode"))
-			})
-
 		})
 
 		Context("I can set hoverfly's mode", func() {
@@ -314,12 +306,12 @@ var _ = Describe("When I use hoverfly-cli", func() {
 			It("to modify mode", func() {
 				output := functional_tests.Run(hoverctlBinary, "mode", "modify")
 
-				Expect(output).To(ContainSubstring("Hoverfly has been set to modify mode"))
+				Expect(output).To(ContainSubstring("Cannot change the mode of Hoverfly to modify when running as a webserver"))
 
 				output = functional_tests.Run(hoverctlBinary, "mode")
 
-				Expect(output).To(ContainSubstring("Hoverfly is currently set to modify mode"))
-				Expect(hoverfly.GetMode().Mode).To(Equal(modify))
+				Expect(output).To(ContainSubstring("Hoverfly is currently set to simulate mode"))
+				Expect(hoverfly.GetMode().Mode).To(Equal(simulate))
 			})
 		})
 	})


### PR DESCRIPTION
Closes #873 

Restricting to enter modify mode from simulate while being a webserver.