### PR TITLE
omit os.Getwd call in main.go

### DIFF
--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -180,15 +180,9 @@ func init() {
 func main() {
 	hoverfly := hv.NewHoverfly()
 
-	dir, err := os.Getwd()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
 	flag.Var(&importFlags, "import", "Import from file or from URL (i.e. '-import my_service.json' or '-import http://mypage.com/service_x.json'")
 	flag.Var(&destinationFlags, "dest", "Specify which hosts to process (i.e. '-dest fooservice.org -dest barservice.org -dest catservice.org') - other hosts will be ignored will passthrough'")
-	flag.StringVar(&responseBodyFilesPath, "response-body-files-path", dir, "When a response contains a relative bodyFile, it will be resolved against this path")
+	flag.StringVar(&responseBodyFilesPath, "response-body-files-path", "", "When a response contains a relative bodyFile, it will be resolved against this path (default is CWD)")
 
 	flag.Parse()
 


### PR DESCRIPTION
Continuing with cwd :smile: A way to omit `os.Getwd` call. Downsides:
1. No information in help about current working dir
2. No early error handling

Should we keep it as it is now or merge this PR?