### PR TITLE
WIP: Export body files / body / all

### DIFF
--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -1,7 +1,6 @@
 package hoverfly
 
 import (
-	"errors"
 	"fmt"
 	v2 "github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	"github.com/aymerick/raymond"
@@ -10,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	herrors "github.com/SpectoLabs/hoverfly/core/errors"
+	"github.com/SpectoLabs/hoverfly/core/errors"
 	"github.com/SpectoLabs/hoverfly/core/matching"
 	"github.com/SpectoLabs/hoverfly/core/matching/matchers"
 	"github.com/SpectoLabs/hoverfly/core/models"
@@ -46,7 +45,7 @@ func (hf *Hoverfly) DoRequest(request *http.Request) (*http.Response, error) {
 }
 
 // GetResponse returns stored response from cache
-func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.ResponseDetails, *herrors.HoverflyError) {
+func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.ResponseDetails, *errors.HoverflyError) {
 
 	var response models.ResponseDetails
 	var cachedResponse *models.CachedResponse
@@ -55,7 +54,7 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 
 	// Get the cached response and return if there is a miss
 	if cacheErr == nil && cachedResponse.MatchingPair == nil {
-		return nil, herrors.MatchingFailedError(cachedResponse.ClosestMiss)
+		return nil, errors.MatchingFailedError(cachedResponse.ClosestMiss)
 		// If it's cached, use that response
 	} else if cacheErr == nil {
 		response = cachedResponse.MatchingPair.Response
@@ -81,7 +80,7 @@ func (hf *Hoverfly) GetResponse(requestDetails models.RequestDetails) (*models.R
 				"method":      requestDetails.Method,
 			}).Warn("Failed to find matching request from simulation")
 
-			return nil, herrors.MatchingFailedError(result.Error.ClosestMiss)
+			return nil, errors.MatchingFailedError(result.Error.ClosestMiss)
 		} else {
 			response = result.Pair.Response
 		}
@@ -131,10 +130,10 @@ func (hf *Hoverfly) readResponseBodyFiles(pairs []v2.RequestMatcherResponsePairV
 		if len(pair.Response.GetBody()) == 0 && len(pair.Response.GetBodyFile()) > 0 {
 			bodyFile := pair.Response.GetBodyFile()
 			if filepath.IsAbs(bodyFile) {
-				err := errors.New(fmt.Sprintf(
+				err := fmt.Errorf(
 					"data.pairs[%d].response bodyFile contains absolute path (%s). only relative is supported",
 					i, bodyFile,
-				))
+				)
 				result.SetError(err)
 				return result
 			}

--- a/hoverctl/configuration/file.go
+++ b/hoverctl/configuration/file.go
@@ -18,7 +18,7 @@ func WriteFile(filePath string, data []byte) error {
 	fileName := filepath.Base(filePath)
 	log.Debug(basePath)
 
-	err := os.MkdirAll(basePath, 0644)
+	err := os.MkdirAll(basePath, 0744)
 	if err != nil {
 		return err
 	}

--- a/hoverctl/wrapper/simulation.go
+++ b/hoverctl/wrapper/simulation.go
@@ -2,7 +2,6 @@ package wrapper
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 
 	"fmt"
@@ -31,14 +30,8 @@ func ExportSimulation(target configuration.Target, urlPattern string) ([]byte, e
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		log.Debug(err.Error())
-		return nil, errors.New("Could not export from Hoverfly")
-	}
-
 	var view v2.SimulationViewV6
-	if err := json.Unmarshal(body, &view); err != nil {
+	if err := json.NewDecoder(response.Body).Decode(&view); err != nil {
 		log.Debug(err.Error())
 		return nil, err
 	}


### PR DESCRIPTION
Since bodyFiles get loaded into `body` on import, `body` is returned filled on export along with `bodyFile`. When both fields provided a warning is printed and hoverfly will use only body.

One way to get around this behavior is to add some flag to `/api/v2/simulation` that defines how to export the simulation. I've added `bodyMode` that can configure this based on the value:

1. `body-only`: export only `body`, emptying all bodyFile fields (which is default)
2. `prefer-bodyfile`: export both fields, but set `body` to an empty string when `bodyFile` is not empty (maybe this should be the defaut?)
3. `all`: export both `body` and `bodyFile` as is (current behavior)

It's just a quick working example to show a concept. It builds but tests don't pass for now. Refactoring required. Don't merge :warning: