### PR TITLE
fix unicode read and json dump error

### DIFF
--- a/functional-tests/core/testdata/binary_middleware.py
+++ b/functional-tests/core/testdata/binary_middleware.py
@@ -17,8 +17,8 @@ def main():
 
     payload_dict = json.loads(payload)
 
-    bytes = open(os.getcwd() + "/testdata/1x1.png").read()
-    responseBody = base64.b64encode(bytes) # We need to base 64 encode binary data
+    bytes = open(os.getcwd() + "/testdata/1x1.png", "rb").read()
+    responseBody = base64.b64encode(bytes).decode('utf-8') # We need to base 64 encode binary data
     contentLength = len(bytes) # Content length should be what we expect the unencoded binary data to be
 
     payload_dict['request']['body'] = "CHANGED_REQUEST_BODY"


### PR DESCRIPTION
I've lately updated my fedora to the latest (31) version and hoverfly started failing middleware binary tests:

```shell
• Failure [0.089 seconds]
Running Hoverfly in various modes
/home/nsafonov/go/src/github.com/SpectoLabs/hoverfly/functional-tests/core/ft_modes_test.go:17
  Using middleware with binary data
  /home/nsafonov/go/src/github.com/SpectoLabs/hoverfly/functional-tests/core/ft_modes_test.go:155
    Should render an image correctly after base64 encoding it using middleware [It]
    /home/nsafonov/go/src/github.com/SpectoLabs/hoverfly/functional-tests/core/ft_modes_test.go:167

    Expected
        <[]uint8 | len:858, cap:1536>: Hoverfly Error!
        
        There was an error when executing middleware
        
        Got error: Middleware failed
        Command: python /tmp/hoverfly/hoverfly_988159876
        exit status 1
        
        STDIN:
        {"response":{"status":0,"body":"","encodedBody":false},"request":{"path":"/","method":"GET","destination":"www.foo.com","scheme":"http","query":"","body":"","headers":{"Accept-Encoding":["gzip"],"User-Agent":["Go-http-client/1.1"]}}}
        
        STDERR:
        Traceback (most recent call last):
          File "/tmp/hoverfly/hoverfly_988159876", line 35, in <module>
            main()
          File "/tmp/hoverfly/hoverfly_988159876", line 20, in main
            bytes = open(os.getcwd() + "/testdata/1x1.png").read()
          File "/usr/lib64/python3.7/codecs.py", line 322, in decode
            (result, consumed) = self._buffer_decode(data, self.errors, final)
        UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
        
    to equal
        <[]uint8 | len:67, cap:579>: �PNG
        
IHD:~�U 
        IDATx�c�Ϡ.�IEND�B`�

    /home/nsafonov/go/src/github.com/SpectoLabs/hoverfly/functional-tests/core/ft_modes_test.go:171
```

After I switch the open mode to `rb`:

```shell
• Failure [0.086 seconds]
Running Hoverfly in various modes
/home/nsafonov/go/src/github.com/SpectoLabs/hoverfly/functional-tests/core/ft_modes_test.go:17
  Using middleware with binary data
  /home/nsafonov/go/src/github.com/SpectoLabs/hoverfly/functional-tests/core/ft_modes_test.go:155
    Should render an image correctly after base64 encoding it using middleware [It]
    /home/nsafonov/go/src/github.com/SpectoLabs/hoverfly/functional-tests/core/ft_modes_test.go:167

    Expected
        <[]uint8 | len:1121, cap:1536>: Hoverfly Error!
        
        There was an error when executing middleware
        
        Got error: Middleware failed
        Command: python /tmp/hoverfly/hoverfly_741897576
        exit status 1
        
        STDIN:
        {"response":{"status":0,"body":"","encodedBody":false},"request":{"path":"/","method":"GET","destination":"www.foo.com","scheme":"http","query":"","body":"","headers":{"Accept-Encoding":["gzip"],"User-Agent":["Go-http-client/1.1"]}}}
        
        STDERR:
        Traceback (most recent call last):
          File "/tmp/hoverfly/hoverfly_741897576", line 35, in <module>
            main()
          File "/tmp/hoverfly/hoverfly_741897576", line 32, in main
            print(json.dumps(payload_dict))
          File "/usr/lib64/python3.7/json/__init__.py", line 231, in dumps
            return _default_encoder.encode(obj)
          File "/usr/lib64/python3.7/json/encoder.py", line 199, in encode
            chunks = self.iterencode(o, _one_shot=True)
          File "/usr/lib64/python3.7/json/encoder.py", line 257, in iterencode
            return _iterencode(o, 0)
          File "/usr/lib64/python3.7/json/encoder.py", line 179, in default
            raise TypeError(f'Object of type {o.__class__.__name__} '
        TypeError: Object of type bytes is not JSON serializable
        
    to equal
        <[]uint8 | len:67, cap:579>: �PNG
        
IHD:~�U 
        IDATx�c�Ϡ.�IEND�B`�

    /home/nsafonov/go/src/github.com/SpectoLabs/hoverfly/functional-tests/core/ft_modes_test.go:171
```

Then `decode` to make it a string.

My python version is Python 3.7.6 (default, Jan 30 2020, 09:44:41) .