### PR TITLE
remove useless Req/Resp headers

### DIFF
--- a/core/proxy.go
+++ b/core/proxy.go
@@ -127,8 +127,6 @@ func NewWebserverProxy(hoverfly *Hoverfly) *goproxy.ProxyHttpServer {
 			}
 		}
 
-		w.Header().Set("Req", r.RequestURI)
-		w.Header().Set("Resp", resp.Header.Get("Content-Length"))
 		w.WriteHeader(resp.StatusCode)
 		w.Write([]byte(body))
 


### PR DESCRIPTION
refer to [gitter message](https://gitter.im/SpectoLabs/hoverfly?at=5eb46ba25cd4fe50a3f748b7).

# why you made it

If we run hoverfly as a webserver mode, hoverfly adds nonstandard Req/Resp headers like debugging output. Also, some tests will be failed if the application under test can only accept expected request headers.

For these reasons, we want to remove Req/Resp headers.

* We checked git blame. These lines were added at the first commit of the webserver feature. ([commit ca010575e3b71dcbaab3a8f750ab9d1c01592145)](https://github.com/SpectoLabs/hoverfly/commit/ca010575e3b71dcbaab3a8f750ab9d1c01592145)

# how to test it

We ran `make test`, and there are no failures.
[make_test_output.txt](https://github.com/SpectoLabs/hoverfly/files/4606026/make_test_output.txt)
