### PR TITLE
Release Hoverfly for Linux/ARM64

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -8,7 +8,7 @@ HF_BUILD_DIR=${DIR}/core/cmd/hoverfly
 HCTL_BUILD_DIR=${DIR}/hoverctl
 LICENSE=${DIR}/LICENSE
 GOX="${GOPATH}/bin/gox"
-declare -a OSARCH_LIST=("darwin/amd64" "windows/amd64" "windows/386" "linux/amd64" "linux/386")
+declare -a OSARCH_LIST=("darwin/amd64" "windows/amd64" "windows/386" "linux/amd64" "linux/386" "linux/arm64")
 
 for OSARCH in "${OSARCH_LIST[@]}"; do
   SUFFIX=$(echo ${OSARCH//darwin/OSX} | tr / _ )


### PR DESCRIPTION
Closes #949 

Added "linux/arm64" to the OSARCH_LIST in the build-release.sh file.

Signed-off-by: odidev <odidev@puresoftware.com>
