### PR TITLE
docs: update copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 project = u'Hoverfly'
-copyright = u'2017, SpectoLabs'
+copyright = u'2021, SpectoLabs'
 author = u'SpectoLabs'
 
 


### PR DESCRIPTION
Update year from 2017 to 2021.

Outdated copyright makes it look like the project is abandoned.
