### PR TITLE
allow to specify Access-Control-Allow-Origin for dev

### DIFF
--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -64,22 +64,23 @@ const boltBackend = "boltdb"
 const inmemoryBackend = "memory"
 
 var (
-	version      = flag.Bool("version", false, "Get the version of hoverfly")
-	verbose      = flag.Bool("v", false, "Should every proxy request be logged to stdout")
-	logLevelFlag = flag.String("log-level", "info", "Set log level (panic, fatal, error, warn, info or debug)")
-	capture      = flag.Bool("capture", false, "Start Hoverfly in capture mode - transparently intercepts and saves requests/response")
-	synthesize   = flag.Bool("synthesize", false, "Start Hoverfly in synthesize mode (middleware is required)")
-	modify       = flag.Bool("modify", false, "Start Hoverfly in modify mode - applies middleware (required) to both outgoing and incoming HTTP traffic")
-	spy          = flag.Bool("spy", false, "Start Hoverfly in spy mode, similar to simulate but calls real server when cache miss")
-	diff         = flag.Bool("diff", false, "Start Hoverfly in diff mode - calls real server and compares the actual response with the expected simulation config if present")
-	middleware   = flag.String("middleware", "", "Set middleware by passing the name of the binary and the path of the middleware script separated by space. (i.e. '-middleware \"python script.py\"')")
-	proxyPort    = flag.String("pp", "", "Proxy port - run proxy on another port (i.e. '-pp 9999' to run proxy on port 9999)")
-	adminPort    = flag.String("ap", "", "Admin port - run admin interface on another port (i.e. '-ap 1234' to run admin UI on port 1234)")
-	listenOnHost = flag.String("listen-on-host", "", "Specify which network interface to bind to, eg. 0.0.0.0 will bind to all interfaces. By default hoverfly will only bind ports to loopback interface")
-	metrics      = flag.Bool("metrics", false, "Enable metrics logging to stdout")
-	dev          = flag.Bool("dev", false, "Enable CORS headers to allow Hoverfly Admin UI development")
-	destination  = flag.String("destination", ".", "Control which URLs Hoverfly should intercept and process, it can be string or regex")
-	webserver    = flag.Bool("webserver", false, "Start Hoverfly in webserver mode (simulate mode)")
+	version       = flag.Bool("version", false, "Get the version of hoverfly")
+	verbose       = flag.Bool("v", false, "Should every proxy request be logged to stdout")
+	logLevelFlag  = flag.String("log-level", "info", "Set log level (panic, fatal, error, warn, info or debug)")
+	capture       = flag.Bool("capture", false, "Start Hoverfly in capture mode - transparently intercepts and saves requests/response")
+	synthesize    = flag.Bool("synthesize", false, "Start Hoverfly in synthesize mode (middleware is required)")
+	modify        = flag.Bool("modify", false, "Start Hoverfly in modify mode - applies middleware (required) to both outgoing and incoming HTTP traffic")
+	spy           = flag.Bool("spy", false, "Start Hoverfly in spy mode, similar to simulate but calls real server when cache miss")
+	diff          = flag.Bool("diff", false, "Start Hoverfly in diff mode - calls real server and compares the actual response with the expected simulation config if present")
+	middleware    = flag.String("middleware", "", "Set middleware by passing the name of the binary and the path of the middleware script separated by space. (i.e. '-middleware \"python script.py\"')")
+	proxyPort     = flag.String("pp", "", "Proxy port - run proxy on another port (i.e. '-pp 9999' to run proxy on port 9999)")
+	adminPort     = flag.String("ap", "", "Admin port - run admin interface on another port (i.e. '-ap 1234' to run admin UI on port 1234)")
+	listenOnHost  = flag.String("listen-on-host", "", "Specify which network interface to bind to, eg. 0.0.0.0 will bind to all interfaces. By default hoverfly will only bind ports to loopback interface")
+	metrics       = flag.Bool("metrics", false, "Enable metrics logging to stdout")
+	dev           = flag.Bool("dev", false, "Enable CORS headers to allow Hoverfly Admin UI development")
+	devCorsOrigin = flag.String("dev-cors-origin", "http://localhost:4200", "Custom CORS origin for dev mode")
+	destination   = flag.String("destination", ".", "Control which URLs Hoverfly should intercept and process, it can be string or regex")
+	webserver     = flag.Bool("webserver", false, "Start Hoverfly in webserver mode (simulate mode)")
 
 	addNew          = flag.Bool("add", false, "Add new user '-add -username hfadmin -password hfpass'")
 	addUser         = flag.String("username", "", "Username for new user")
@@ -310,6 +311,9 @@ func main() {
 
 	if *dev {
 		handlers.EnableCors = true
+		handlers.CorsOrigin = *devCorsOrigin
+
+		log.WithField("allowOrigin", *devCorsOrigin).Warn("Dev mode is enabled")
 	}
 
 	if *generateCA {

--- a/core/handlers/handlers.go
+++ b/core/handlers/handlers.go
@@ -12,7 +12,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var EnableCors bool
+var (
+	EnableCors bool
+	CorsOrigin string
+)
 
 type ErrorView struct {
 	Error string `json:"error"`
@@ -62,7 +65,7 @@ func WriteErrorResponse(response http.ResponseWriter, message string, code int) 
 
 func writeCorsHeadersIfEnabled(response http.ResponseWriter) {
 	if EnableCors {
-		response.Header().Set("Access-Control-Allow-Origin", "http://localhost:4200")
+		response.Header().Set("Access-Control-Allow-Origin", CorsOrigin)
 		response.Header().Set("Access-Control-Allow-Methods", "GET, PUT, POST, OPTIONS, DELETE")
 		response.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization")
 		response.Header().Set("Access-Control-Allow-Credentials", "true")

--- a/docs/pages/reference/hoverfly/hoverfly.output
+++ b/docs/pages/reference/hoverfly/hoverfly.output
@@ -37,6 +37,8 @@ Usage of hoverfly:
         Control which URLs Hoverfly should intercept and process, it can be string or regex (default ".")
   -dev
         Enable CORS headers to allow Hoverfly Admin UI development
+  -dev-cors-origin string
+        Custom CORS origin for dev mode (default "http://localhost:4200")
   -diff
         Start Hoverfly in diff mode - calls real server and compares the actual response with the expected simulation config if present
   -disable-cache

--- a/functional-tests/core/ft_hoverfly_dev_test.go
+++ b/functional-tests/core/ft_hoverfly_dev_test.go
@@ -19,7 +19,6 @@ var _ = Describe("hoverfly -dev", func() {
 
 		BeforeEach(func() {
 			hoverfly = functional_tests.NewHoverfly()
-			hoverfly.Start("-dev")
 		})
 
 		AfterEach(func() {
@@ -27,11 +26,24 @@ var _ = Describe("hoverfly -dev", func() {
 		})
 
 		It("should add CORS headers to API responses", func() {
+			hoverfly.Start("-dev")
 			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/hoverfly")
 			res := functional_tests.DoRequest(req)
 			Expect(res.StatusCode).To(Equal(http.StatusOK))
 
 			Expect(res.Header.Get("Access-Control-Allow-Origin")).To(Equal("http://localhost:4200"))
+			Expect(res.Header.Get("Access-Control-Allow-Methods")).To(Equal("GET, PUT, POST, OPTIONS, DELETE"))
+			Expect(res.Header.Get("Access-Control-Allow-Headers")).To(Equal("Origin, X-Requested-With, Content-Type, Accept, Authorization"))
+			Expect(res.Header.Get("Access-Control-Allow-Credentials")).To(Equal("true"))
+		})
+
+		It("should add CORS headers with custom allowed origin to API responses", func() {
+			hoverfly.Start("-dev", "-dev-cors-origin=http://localhost:3000")
+			req := sling.New().Get("http://localhost:" + hoverfly.GetAdminPort() + "/api/v2/hoverfly")
+			res := functional_tests.DoRequest(req)
+			Expect(res.StatusCode).To(Equal(http.StatusOK))
+
+			Expect(res.Header.Get("Access-Control-Allow-Origin")).To(Equal("http://localhost:3000"))
 			Expect(res.Header.Get("Access-Control-Allow-Methods")).To(Equal("GET, PUT, POST, OPTIONS, DELETE"))
 			Expect(res.Header.Get("Access-Control-Allow-Headers")).To(Equal("Origin, X-Requested-With, Content-Type, Accept, Authorization"))
 			Expect(res.Header.Get("Access-Control-Allow-Credentials")).To(Equal("true"))


### PR DESCRIPTION
We use hoverfly for developing a UI and it's inconvenient not to be able to change the Access-Control-Allow-Origin which is hardcoded for now.