### PR TITLE
fix pac file content-type

### DIFF
--- a/core/handlers/handlers.go
+++ b/core/handlers/handlers.go
@@ -38,11 +38,19 @@ func ReadFromRequest(request *http.Request, v interface{}) error {
 	return nil
 }
 
-func WriteResponse(response http.ResponseWriter, bytes []byte) {
-	response.Header().Set("Content-Type", detectContentType(bytes))
+func writeResponse(response http.ResponseWriter, bytes []byte, contentType string) {
+	response.Header().Set("Content-Type", contentType)
 	writeCorsHeadersIfEnabled(response)
 
 	response.Write(bytes)
+}
+
+func WriteResponse(response http.ResponseWriter, bytes []byte) {
+	writeResponse(response, bytes, detectContentType(bytes))
+}
+
+func WriteResponseWithContentType(response http.ResponseWriter, bytes []byte, contentType string) {
+	writeResponse(response, bytes, contentType)
 }
 
 func WriteErrorResponse(response http.ResponseWriter, message string, code int) {

--- a/core/handlers/v2/hoverfly_pac_handler.go
+++ b/core/handlers/v2/hoverfly_pac_handler.go
@@ -43,8 +43,8 @@ func (this *HoverflyPACHandler) Get(w http.ResponseWriter, req *http.Request, ne
 	if pacFile == nil {
 		handlers.WriteErrorResponse(w, "Not found", 404)
 	}
-	handlers.WriteResponse(w, pacFile)
-	w.Header().Set("Content-Type", "application/x-ns-proxy-autoconfig")
+
+	handlers.WriteResponseWithContentType(w, pacFile, "application/x-ns-proxy-autoconfig")
 }
 
 func (this *HoverflyPACHandler) Put(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {


### PR DESCRIPTION
response with pac file was supposed to have `application/x-ns-proxy-autoconfig` content-type, but it always was `text/plain`.