### PR TITLE
ISSUE-1014: Add docker multi-arch support 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,8 @@ jobs:
       - run:
           name: Build and push master Docker image
           command: |
-            docker build -t spectolabs/hoverfly:master .
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker buildx build --platform=linux/arm64,linux/amd64 --no-cache --tag spectolabs/hoverfly:master --push .
+            docker login --username $DOCKER_USER --password $DOCKER_PASS
             docker push spectolabs/hoverfly:master
       - run:
           name: Install gox
@@ -99,9 +99,9 @@ jobs:
       - run:
           name: Build and push master Docker image
           command: |
-            docker build -t spectolabs/hoverfly:$CIRCLE_TAG .
+            docker buildx build --platform=linux/arm64,linux/amd64 --no-cache --tag spectolabs/hoverfly:$CIRCLE_TAG --push .
             docker tag spectolabs/hoverfly:$CIRCLE_TAG spectolabs/hoverfly:latest
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker login --username $DOCKER_USER --password $DOCKER_PASS
             docker push spectolabs/hoverfly:$CIRCLE_TAG
             docker push spectolabs/hoverfly:latest
       - run:


### PR DESCRIPTION
Add docker multi-arch support and add arm64 as target architecture

In addition to ticket 123, multi-arch support has also been added to the Docker image.

We use Hoverfly for our integration test where we spin up a Docker container from Hoverfly. To also support the colleagues with M1 we need a Docker image with arm64 architecture.

I tested the feature and execute the docker builds build command and uploaded the result to my personal docker hub repository. Please check this to verify that the implementation works: https://hub.docker.com/r/ezienecker/hoverfly/tags