### PR TITLE
Handle array of string and empty interfaces for match

### DIFF
--- a/core/matching/matchers/contains_exactly_match.go
+++ b/core/matching/matchers/contains_exactly_match.go
@@ -1,6 +1,7 @@
 package matchers
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -9,9 +10,19 @@ import (
 var ContainsExactly = "containsexactly"
 
 func ContainsExactlyMatch(match interface{}, toMatch string) bool {
-	matchStringArr, ok := match.([]string)
-	if !ok {
+	val := reflect.ValueOf(match)
+	if val.Kind() != reflect.Slice {
 		return false
+	}
+	var matchStringArr []string
+	for i := 0; i < val.Len(); i++ {
+		currentValue := val.Index(i)
+		if currentValue.Kind() == reflect.Interface {
+			matchStringArr = append(matchStringArr, currentValue.Elem().String())
+		} else {
+			matchStringArr = append(matchStringArr, currentValue.String())
+		}
+
 	}
 	toMatchArr := strings.Split(toMatch, ";")
 	return util.Identical(matchStringArr, toMatchArr)

--- a/core/matching/matchers/contains_exactly_match_test.go
+++ b/core/matching/matchers/contains_exactly_match_test.go
@@ -20,6 +20,13 @@ func Test_ContainsExactlyMatch_MatchesTrueWithIdenticalArray(t *testing.T) {
 	Expect(matchers.ContainsExactlyMatch(arr[:], "q1;q2;q3")).To(BeTrue())
 }
 
+func Test_ContainsExactlyMatch_MatchesTrueWithIdenticalArrayWithMatcherAsArrayOfInterface(t *testing.T) {
+	RegisterTestingT(t)
+
+	arr := [3]interface{}{"q1", "q2", "q3"}
+	Expect(matchers.ContainsExactlyMatch(arr[:], "q1;q2;q3")).To(BeTrue())
+}
+
 func Test_ContainsExactlyMatch_MatchesFalseWithSameArrayInDifferentOrder(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/matching/matchers/contains_match.go
+++ b/core/matching/matchers/contains_match.go
@@ -1,6 +1,7 @@
 package matchers
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -9,9 +10,19 @@ import (
 var Contains = "contains"
 
 func ContainsMatch(match interface{}, toMatch string) bool {
-	matchStringArr, ok := match.([]string)
-	if !ok {
+	val := reflect.ValueOf(match)
+	if val.Kind() != reflect.Slice {
 		return false
+	}
+	var matchStringArr []string
+	for i := 0; i < val.Len(); i++ {
+		currentValue := val.Index(i)
+		if currentValue.Kind() == reflect.Interface {
+			matchStringArr = append(matchStringArr, currentValue.Elem().String())
+		} else {
+			matchStringArr = append(matchStringArr, currentValue.String())
+		}
+
 	}
 	toMatchArr := strings.Split(toMatch, ";")
 	return util.Contains(matchStringArr, toMatchArr)

--- a/core/matching/matchers/contains_match_test.go
+++ b/core/matching/matchers/contains_match_test.go
@@ -20,6 +20,13 @@ func Test_ContainsMatch_MatchesTrueWithArrayContainingAllValues(t *testing.T) {
 	Expect(matchers.ContainsMatch(arr[:], "q1;q2")).To(BeTrue())
 }
 
+func Test_ContainsMatch_MatchesTrueWithArrayContainingAllValuesWithMatcherAsArrayOfInterface(t *testing.T) {
+	RegisterTestingT(t)
+
+	arr := [3]interface{}{"q1", "q2", "q3"}
+	Expect(matchers.ContainsMatch(arr[:], "q1;q2")).To(BeTrue())
+}
+
 func Test_ContainsMatch_MatchesTrueWithArrayContainingSomeValues(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/core/matching/matchers/contains_only_match.go
+++ b/core/matching/matchers/contains_only_match.go
@@ -1,6 +1,7 @@
 package matchers
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -9,9 +10,19 @@ import (
 var ContainsOnly = "containsonly"
 
 func ContainsOnlyMatch(match interface{}, toMatch string) bool {
-	matchStringArr, ok := match.([]string)
-	if !ok {
+	val := reflect.ValueOf(match)
+	if val.Kind() != reflect.Slice {
 		return false
+	}
+	var matchStringArr []string
+	for i := 0; i < val.Len(); i++ {
+		currentValue := val.Index(i)
+		if currentValue.Kind() == reflect.Interface {
+			matchStringArr = append(matchStringArr, currentValue.Elem().String())
+		} else {
+			matchStringArr = append(matchStringArr, currentValue.String())
+		}
+
 	}
 	toMatchArr := strings.Split(toMatch, ";")
 	return util.ContainsOnly(matchStringArr, toMatchArr)

--- a/core/matching/matchers/contains_only_match_test.go
+++ b/core/matching/matchers/contains_only_match_test.go
@@ -20,6 +20,13 @@ func Test_ContainsOnlyMatch_MatchesTrueWithIdenticalArray(t *testing.T) {
 	Expect(matchers.ContainsOnlyMatch(arr[:], "q1;q2;q3")).To(BeTrue())
 }
 
+func Test_ContainsOnlyMatch_MatchesTrueWithIdenticalArrayWithMatcherAsArrayOfInterface(t *testing.T) {
+	RegisterTestingT(t)
+
+	arr := [3]interface{}{"q1", "q2", "q3"}
+	Expect(matchers.ContainsOnlyMatch(arr[:], "q1;q2;q3")).To(BeTrue())
+}
+
 func Test_ContainsOnlyMatch_MatchesTrueWithSameArrayInDifferentOrder(t *testing.T) {
 	RegisterTestingT(t)
 


### PR DESCRIPTION
@tommysitu  I found one issue wherein on capturing the requests, we are saving an array of strings as values for matcher containsexactly as we are picking these values from query params, and on updating simulation via API call, an array of empty interfaces(generics) is being passed due to which code is breaking. Could you please take a look and approve this PR?