### PR TITLE
feature - introduce generic array matcher with options

### DIFF
--- a/core/matching/field_matcher.go
+++ b/core/matching/field_matcher.go
@@ -1,9 +1,10 @@
 package matching
 
 import (
+	"strings"
+
 	"github.com/SpectoLabs/hoverfly/core/matching/matchers"
 	"github.com/SpectoLabs/hoverfly/core/models"
-	"strings"
 )
 
 func FieldMatcher(fields []models.RequestFieldMatchers, toMatch string) *FieldMatch {
@@ -15,7 +16,7 @@ func FieldMatcher(fields []models.RequestFieldMatchers, toMatch string) *FieldMa
 	}
 
 	for _, field := range fields {
-		if matchers.Matchers[strings.ToLower(field.Matcher)](field.Value, toMatch) {
+		if isMatching(field, toMatch) {
 			if field.Matcher == matchers.Exact || field.Matcher == matchers.ContainsExactly {
 				fieldMatch.Score = fieldMatch.Score + 2
 			} else {
@@ -27,6 +28,16 @@ func FieldMatcher(fields []models.RequestFieldMatchers, toMatch string) *FieldMa
 	}
 
 	return fieldMatch
+}
+
+func isMatching(field models.RequestFieldMatchers, toMatch string) bool {
+	isMatched := false
+	if len(field.Config) > 0 {
+		isMatched = matchers.MatchersWithConfig[strings.ToLower(field.Matcher)](field.Value, toMatch, field.Config)
+	} else {
+		isMatched = matchers.Matchers[strings.ToLower(field.Matcher)](field.Value, toMatch)
+	}
+	return isMatched
 }
 
 type FieldMatch struct {

--- a/core/matching/matchers/array_match.go
+++ b/core/matching/matchers/array_match.go
@@ -1,0 +1,77 @@
+package matchers
+
+import (
+	"strings"
+
+	"github.com/SpectoLabs/hoverfly/core/util"
+)
+
+const (
+	IGNORE_UNKNOWN     = "ignoreunknown"
+	IGNORE_ORDER       = "ignoreorder"
+	IGNORE_OCCURRENCES = "ignoreoccurrences"
+)
+
+var Array = "array"
+
+func ArrayMatch(match interface{}, toMatch string, config map[string]interface{}) bool {
+	matchStringArr, ok := util.GetStringArray(match)
+	if !ok {
+		return false
+	}
+	toMatchArr := strings.Split(toMatch, ";")
+	ignoreUnknown := util.GetBoolOrDefault(config, IGNORE_UNKNOWN, false)
+	ignoreOrder := util.GetBoolOrDefault(config, IGNORE_ORDER, false)
+	ignoreOccurrences := util.GetBoolOrDefault(config, IGNORE_OCCURRENCES, false)
+
+	return (ignoreUnknown || hasAllKnown(matchStringArr, toMatchArr)) &&
+		(ignoreOccurrences || hasSameNoOfOccurrences(matchStringArr, toMatchArr)) &&
+		(ignoreOrder || isInSameOrder(matchStringArr, toMatchArr))
+}
+
+func hasSameNoOfOccurrences(matchGroup, toMatch []string) bool {
+
+	matchGroupSet := make(map[string]int)
+	for _, value := range matchGroup {
+		matchGroupSet[value] = matchGroupSet[value] + 1
+	}
+	toMatchSet := make(map[string]int)
+	for _, value := range toMatch {
+		toMatchSet[value] = toMatchSet[value] + 1
+	}
+
+	for key, value := range matchGroupSet {
+		if toMatchSet[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func hasAllKnown(matchGroup, toMatch []string) bool {
+
+	matchGroupSet := make(map[string]bool)
+	for _, value := range matchGroup {
+		matchGroupSet[value] = true
+	}
+
+	for _, value := range toMatch {
+		if _, found := matchGroupSet[value]; !found {
+			return false
+		}
+	}
+	return true
+}
+
+func isInSameOrder(matchGroup, toMatch []string) bool {
+
+	index := 0
+	for _, value := range toMatch {
+		if index < len(matchGroup) && value == matchGroup[index] {
+			index++
+		} else if index == len(matchGroup) {
+			break
+		}
+	}
+	return index == len(matchGroup)
+}

--- a/core/matching/matchers/array_match_test.go
+++ b/core/matching/matchers/array_match_test.go
@@ -1,0 +1,79 @@
+package matchers_test
+
+import (
+	"testing"
+
+	"github.com/SpectoLabs/hoverfly/core/matching/matchers"
+	. "github.com/onsi/gomega"
+)
+
+func Test_ArrayMatch_ReturnsFalseWithIncorrectDataType(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := make(map[string]interface{})
+	Expect(matchers.ArrayMatch("hello", "yes", configMap)).To(BeFalse())
+}
+
+func Test_ArrayMatch_ReturnsTrueWithIdenticalArray(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := getConfiguration(false, false, false)
+	arr := [3]string{"q1", "q2", "q3"}
+	Expect(matchers.ArrayMatch(arr[:], "q1;q2;q3", configMap)).To(BeTrue())
+}
+
+func Test_ArrayMatch_ReturnsTrueWithAllKnownsInArrayAndNotIgnoringUnkowns(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := getConfiguration(false, true, true)
+	arr := [3]string{"q1", "q2", "q3"}
+	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q2;q1;q3", configMap)).To(BeTrue())
+}
+func Test_ArrayMatch_ReturnsFalseWithUnkownsInArrayAndNotIgnoringUnkowns(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := getConfiguration(false, true, true)
+	arr := [3]string{"q1", "q2", "q3"}
+	Expect(matchers.ArrayMatch(arr[:], "q1;q4;q3;q2", configMap)).To(BeFalse())
+}
+
+func Test_ArrayMatch_ReturnsTrueWithInSameOrderAndNotIgnoringOrder(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := getConfiguration(true, true, false)
+	arr := [3]string{"q1", "q2", "q3"}
+	Expect(matchers.ArrayMatch(arr[:], "q1;q2;q3;q2;q4", configMap)).To(BeTrue())
+}
+
+func Test_ArrayMatch_ReturnsFalseWithOutOfOrderAndNotIgnoringOrder(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := getConfiguration(true, true, false)
+	arr := [3]string{"q1", "q2", "q3"}
+	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q3;q2;q4", configMap)).To(BeFalse())
+}
+
+func Test_ArrayMatch_ReturnsTrueWithSameOccurrencesAndNotIgnoringOccurrences(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := getConfiguration(true, false, true)
+	arr := [3]string{"q1", "q2", "q3"}
+	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q0;q2;q4", configMap)).To(BeTrue())
+}
+
+func Test_ArrayMatch_ReturnsFalseWithDifferentNoOfOccurrencesAndNotIgnoringOccurrences(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := getConfiguration(true, false, true)
+	arr := [3]string{"q1", "q2", "q3"}
+	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q3;q2;q4", configMap)).To(BeFalse())
+}
+
+func getConfiguration(ignoreUnknown, ignoreOccurrences, ignoreOrder bool) map[string]interface{} {
+
+	configMap := make(map[string]interface{})
+	configMap[matchers.IGNORE_UNKNOWN] = ignoreUnknown
+	configMap[matchers.IGNORE_ORDER] = ignoreOrder
+	configMap[matchers.IGNORE_OCCURRENCES] = ignoreOccurrences
+	return configMap
+}

--- a/core/matching/matchers/contains_exactly_match.go
+++ b/core/matching/matchers/contains_exactly_match.go
@@ -1,7 +1,6 @@
 package matchers
 
 import (
-	"reflect"
 	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -10,19 +9,9 @@ import (
 var ContainsExactly = "containsexactly"
 
 func ContainsExactlyMatch(match interface{}, toMatch string) bool {
-	val := reflect.ValueOf(match)
-	if val.Kind() != reflect.Slice {
+	matchStringArr, ok := util.GetStringArray(match)
+	if !ok {
 		return false
-	}
-	var matchStringArr []string
-	for i := 0; i < val.Len(); i++ {
-		currentValue := val.Index(i)
-		if currentValue.Kind() == reflect.Interface {
-			matchStringArr = append(matchStringArr, currentValue.Elem().String())
-		} else {
-			matchStringArr = append(matchStringArr, currentValue.String())
-		}
-
 	}
 	toMatchArr := strings.Split(toMatch, ";")
 	return util.Identical(matchStringArr, toMatchArr)

--- a/core/matching/matchers/contains_match.go
+++ b/core/matching/matchers/contains_match.go
@@ -1,7 +1,6 @@
 package matchers
 
 import (
-	"reflect"
 	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -10,19 +9,9 @@ import (
 var Contains = "contains"
 
 func ContainsMatch(match interface{}, toMatch string) bool {
-	val := reflect.ValueOf(match)
-	if val.Kind() != reflect.Slice {
+	matchStringArr, ok := util.GetStringArray(match)
+	if !ok {
 		return false
-	}
-	var matchStringArr []string
-	for i := 0; i < val.Len(); i++ {
-		currentValue := val.Index(i)
-		if currentValue.Kind() == reflect.Interface {
-			matchStringArr = append(matchStringArr, currentValue.Elem().String())
-		} else {
-			matchStringArr = append(matchStringArr, currentValue.String())
-		}
-
 	}
 	toMatchArr := strings.Split(toMatch, ";")
 	return util.Contains(matchStringArr, toMatchArr)

--- a/core/matching/matchers/contains_only_match.go
+++ b/core/matching/matchers/contains_only_match.go
@@ -1,7 +1,6 @@
 package matchers
 
 import (
-	"reflect"
 	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/util"
@@ -10,19 +9,9 @@ import (
 var ContainsOnly = "containsonly"
 
 func ContainsOnlyMatch(match interface{}, toMatch string) bool {
-	val := reflect.ValueOf(match)
-	if val.Kind() != reflect.Slice {
+	matchStringArr, ok := util.GetStringArray(match)
+	if !ok {
 		return false
-	}
-	var matchStringArr []string
-	for i := 0; i < val.Len(); i++ {
-		currentValue := val.Index(i)
-		if currentValue.Kind() == reflect.Interface {
-			matchStringArr = append(matchStringArr, currentValue.Elem().String())
-		} else {
-			matchStringArr = append(matchStringArr, currentValue.String())
-		}
-
 	}
 	toMatchArr := strings.Split(toMatch, ";")
 	return util.ContainsOnly(matchStringArr, toMatchArr)

--- a/core/matching/matchers/matchers.go
+++ b/core/matching/matchers/matchers.go
@@ -2,6 +2,8 @@ package matchers
 
 type MatcherFunc func(data interface{}, toMatch string) bool
 
+type MatcherFuncWithConfig func(data interface{}, toMatch string, config map[string]interface{}) bool
+
 var Matchers = map[string]MatcherFunc{
 	// Default matcher
 	"": ExactMatch,
@@ -18,4 +20,9 @@ var Matchers = map[string]MatcherFunc{
 	ContainsExactly: ContainsExactlyMatch,
 	ContainsOnly:    ContainsOnlyMatch,
 	Contains:        ContainsMatch,
+	Array:           ContainsExactlyMatch,
+}
+
+var MatchersWithConfig = map[string]MatcherFuncWithConfig{
+	Array: ArrayMatch,
 }

--- a/core/models/request_matcher.go
+++ b/core/models/request_matcher.go
@@ -1,15 +1,17 @@
 package models
 
 import (
-	"github.com/SpectoLabs/hoverfly/core/handlers/v2"
+	"net/url"
+
+	v2 "github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	"github.com/SpectoLabs/hoverfly/core/matching/matchers"
 	"github.com/SpectoLabs/hoverfly/core/util"
-	"net/url"
 )
 
 type RequestFieldMatchers struct {
 	Matcher string
 	Value   interface{}
+	Config  map[string]interface{}
 }
 
 func NewRequestFieldMatchersFromView(matchers []v2.MatcherViewV5) []RequestFieldMatchers {
@@ -21,6 +23,7 @@ func NewRequestFieldMatchersFromView(matchers []v2.MatcherViewV5) []RequestField
 		convertedMatchers = append(convertedMatchers, RequestFieldMatchers{
 			Matcher: matcher.Matcher,
 			Value:   matcher.Value,
+			Config:  matcher.Config,
 		})
 	}
 	return convertedMatchers
@@ -56,6 +59,7 @@ func (this RequestFieldMatchers) BuildView() v2.MatcherViewV5 {
 	return v2.MatcherViewV5{
 		Matcher: this.Matcher,
 		Value:   this.Value,
+		Config:  this.Config,
 	}
 }
 

--- a/core/util/util.go
+++ b/core/util/util.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -301,4 +302,30 @@ func ContainsOnly(first, second []string) bool {
 		}
 	}
 	return true
+}
+
+func GetStringArray(data interface{}) ([]string, bool) {
+	val := reflect.ValueOf(data)
+	if val.Kind() != reflect.Slice {
+		return nil, false
+	}
+	var dataArr []string
+	for i := 0; i < val.Len(); i++ {
+		currentValue := val.Index(i)
+		if currentValue.Kind() == reflect.Interface {
+			dataArr = append(dataArr, currentValue.Elem().String())
+		} else {
+			dataArr = append(dataArr, currentValue.String())
+		}
+
+	}
+	return dataArr, true
+}
+
+func GetBoolOrDefault(data map[string]interface{}, key string, defaultValue bool) bool {
+	genericValue, found := data[key]
+	if !found {
+		return defaultValue
+	}
+	return genericValue.(bool)
 }

--- a/docs/pages/reference/hoverfly/request_matchers.rst
+++ b/docs/pages/reference/hoverfly/request_matchers.rst
@@ -645,3 +645,32 @@ Example
 
 |
 |
+Generic Array matcher
+-----------------------
+
+Matches the matcher group with value passed in request array based on the configuration passed.
+
+ignoreorder - ignore order in which values that are passed.
+ignoreunknowns - ignore unknowns in the values that are passed
+
+Example
+"""""""
+
+.. code:: json
+   
+   "matcher": "contains"
+   "value": "[?]"
+   "configuration": "{}"
+{
+    "matcher": "array",
+    "config": {
+        "ignoreunknown": <true/false>,
+        "ignoreorder": <true/false>,
+        "ignoreoccurrences": <true/false>
+    }
+    "value": [
+        "access:vod",
+        "order:latest",
+        "profile:vd"
+    ]
+}


### PR DESCRIPTION
Matches the matcher group with value passed in request array based on the configuration passed.

ignoreorder - ignore order in which values are passed
ignoreunknowns - ignore unknowns in the values passed
ignoreoccurrences - ignore comparision of no of occurrences in matcher group and values passed

``` 
   
   "matcher": "contains"
   "value": "[?]"
   "configuration": "{}"
{
    "matcher": "array",
    "config": {
        "ignoreunknown": <true/false>,
        "ignoreorder": <true/false>,
        "ignoreoccurrences": <true/false>
    }
    "value": [
        "access:vod",
        "order:latest",
        "profile:vd"
    ]
}
