### PR TITLE
Code changes for matcher chaining for any matchers

### DIFF
--- a/core/handlers/v2/simulation_views_v5.go
+++ b/core/handlers/v2/simulation_views_v5.go
@@ -40,6 +40,7 @@ type MatcherViewV5 struct {
 	Matcher string                 `json:"matcher"`
 	Value   interface{}            `json:"value"`
 	Config  map[string]interface{} `json:"config,omitempty"`
+	DoMatch *MatcherViewV5         `json:"domatch,omitempty"`
 }
 
 type GlobalVariableViewV5 struct {

--- a/core/matching/field_matcher.go
+++ b/core/matching/field_matcher.go
@@ -31,13 +31,24 @@ func FieldMatcher(fields []models.RequestFieldMatchers, toMatch string) *FieldMa
 }
 
 func isMatching(field models.RequestFieldMatchers, toMatch string) bool {
-	isMatched := false
-	if len(field.Config) > 0 {
-		isMatched = matchers.MatchersWithConfig[strings.ToLower(field.Matcher)](field.Value, toMatch, field.Config)
-	} else {
-		isMatched = matchers.Matchers[strings.ToLower(field.Matcher)](field.Value, toMatch)
+
+	matcher := field
+	actual := toMatch
+	result := false
+	for {
+		matchedValue, isMatched := matchers.Matchers[strings.ToLower(matcher.Matcher)](matcher.Value, actual, matcher.Config)
+		if !isMatched {
+			return false
+		}
+		if matcher.DoMatch == nil {
+			result = isMatched
+			break
+		}
+		matcher = *matcher.DoMatch
+		actual = matchedValue
 	}
-	return isMatched
+
+	return result
 }
 
 type FieldMatch struct {

--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -130,29 +130,41 @@ var fieldMatcherTests = []fieldMatcherTest{
 		equals:  BeFalse(),
 	},
 	{
-		name: "FieldMatcher_WithMultipleMatchers_ScoresDouble",
+		name: "MatcherChaining1",
 		matchers: []models.RequestFieldMatchers{
 			{
-				Matcher: matchers.Exact,
-				Value:   "test",
-			},
-			{
-				Matcher: matchers.Exact,
-				Value:   "test",
+				Matcher: "xpath",
+				Value:   "/document/id",
+				DoMatch: &models.RequestFieldMatchers{
+					Matcher: "exact",
+					Value:   "12345",
+				},
 			},
 		},
-		toMatch:     "test",
-		scoreEquals: Equal(4),
+		toMatch: "<document><id>12345</id><name>Test</name></document>",
+		equals:  BeTrue(),
 	},
 	{
-		name: "MatcherNameShouldBeCaseInsensitive",
+		name: "MatcherChaining2",
 		matchers: []models.RequestFieldMatchers{
 			{
-				Matcher: "XML",
-				Value:   `<document></document>`,
+				Matcher: "xpath",
+				Value:   "/document/details",
+				DoMatch: &models.RequestFieldMatchers{
+					Matcher: "jsonpath",
+					Value:   "$.name",
+					DoMatch: &models.RequestFieldMatchers{
+						Matcher: "glob",
+						Value:   "*es*",
+						DoMatch: &models.RequestFieldMatchers{
+							Matcher: "exact",
+							Value:   "Test",
+						},
+					},
+				},
 			},
 		},
-		toMatch: `<document></document>`,
+		toMatch: `<document><details>{"name":"Test", "id":"12345"}</details></document>`,
 		equals:  BeTrue(),
 	},
 }

--- a/core/matching/matchers/array_match.go
+++ b/core/matching/matchers/array_match.go
@@ -14,19 +14,23 @@ const (
 
 var Array = "array"
 
-func ArrayMatch(match interface{}, toMatch string, config map[string]interface{}) bool {
+func ArrayMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchStringArr, ok := util.GetStringArray(match)
 	if !ok {
-		return false
+		return "", false
 	}
 	toMatchArr := strings.Split(toMatch, ";")
 	ignoreUnknown := util.GetBoolOrDefault(config, IGNORE_UNKNOWN, false)
 	ignoreOrder := util.GetBoolOrDefault(config, IGNORE_ORDER, false)
 	ignoreOccurrences := util.GetBoolOrDefault(config, IGNORE_OCCURRENCES, false)
 
-	return (ignoreUnknown || hasAllKnown(matchStringArr, toMatchArr)) &&
+	isMatched := (ignoreUnknown || hasAllKnown(matchStringArr, toMatchArr)) &&
 		(ignoreOccurrences || hasSameNoOfOccurrences(matchStringArr, toMatchArr)) &&
 		(ignoreOrder || isInSameOrder(matchStringArr, toMatchArr))
+	if isMatched {
+		return toMatch, isMatched
+	}
+	return "", false
 }
 
 func hasSameNoOfOccurrences(matchGroup, toMatch []string) bool {

--- a/core/matching/matchers/array_match_test.go
+++ b/core/matching/matchers/array_match_test.go
@@ -11,7 +11,8 @@ func Test_ArrayMatch_ReturnsFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
 	configMap := make(map[string]interface{})
-	Expect(matchers.ArrayMatch("hello", "yes", configMap)).To(BeFalse())
+	_, isMatched := matchers.ArrayMatch("hello", "yes", configMap)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_ArrayMatch_ReturnsTrueWithIdenticalArray(t *testing.T) {
@@ -19,7 +20,9 @@ func Test_ArrayMatch_ReturnsTrueWithIdenticalArray(t *testing.T) {
 
 	configMap := getConfiguration(false, false, false)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q2;q3", configMap)).To(BeTrue())
+	matchedValue, isMatched := matchers.ArrayMatch(arr[:], "q1;q2;q3", configMap)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(matchedValue))
 }
 
 func Test_ArrayMatch_ReturnsTrueWithAllKnownsInArrayAndNotIgnoringUnkowns(t *testing.T) {
@@ -27,14 +30,17 @@ func Test_ArrayMatch_ReturnsTrueWithAllKnownsInArrayAndNotIgnoringUnkowns(t *tes
 
 	configMap := getConfiguration(false, true, true)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q2;q1;q3", configMap)).To(BeTrue())
+	matchedValue, isMatched := matchers.ArrayMatch(arr[:], "q1;q3;q2;q1;q3", configMap)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("q1;q3;q2;q1;q3"))
 }
 func Test_ArrayMatch_ReturnsFalseWithUnkownsInArrayAndNotIgnoringUnkowns(t *testing.T) {
 	RegisterTestingT(t)
 
 	configMap := getConfiguration(false, true, true)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q4;q3;q2", configMap)).To(BeFalse())
+	_, isMatched := matchers.ArrayMatch(arr[:], "q1;q4;q3;q2", configMap)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_ArrayMatch_ReturnsTrueWithInSameOrderAndNotIgnoringOrder(t *testing.T) {
@@ -42,7 +48,9 @@ func Test_ArrayMatch_ReturnsTrueWithInSameOrderAndNotIgnoringOrder(t *testing.T)
 
 	configMap := getConfiguration(true, true, false)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q2;q3;q2;q4", configMap)).To(BeTrue())
+	matchedValue, isMatched := matchers.ArrayMatch(arr[:], "q1;q2;q3;q2;q4", configMap)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("q1;q2;q3;q2;q4"))
 }
 
 func Test_ArrayMatch_ReturnsFalseWithOutOfOrderAndNotIgnoringOrder(t *testing.T) {
@@ -50,7 +58,8 @@ func Test_ArrayMatch_ReturnsFalseWithOutOfOrderAndNotIgnoringOrder(t *testing.T)
 
 	configMap := getConfiguration(true, true, false)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q3;q2;q4", configMap)).To(BeFalse())
+	_, isMatched := matchers.ArrayMatch(arr[:], "q1;q3;q3;q2;q4", configMap)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_ArrayMatch_ReturnsTrueWithSameOccurrencesAndNotIgnoringOccurrences(t *testing.T) {
@@ -58,7 +67,9 @@ func Test_ArrayMatch_ReturnsTrueWithSameOccurrencesAndNotIgnoringOccurrences(t *
 
 	configMap := getConfiguration(true, false, true)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q0;q2;q4", configMap)).To(BeTrue())
+	matchedValue, isMatched := matchers.ArrayMatch(arr[:], "q1;q3;q0;q2;q4", configMap)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("q1;q3;q0;q2;q4"))
 }
 
 func Test_ArrayMatch_ReturnsFalseWithDifferentNoOfOccurrencesAndNotIgnoringOccurrences(t *testing.T) {
@@ -66,7 +77,8 @@ func Test_ArrayMatch_ReturnsFalseWithDifferentNoOfOccurrencesAndNotIgnoringOccur
 
 	configMap := getConfiguration(true, false, true)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q3;q2;q4", configMap)).To(BeFalse())
+	_, isMatched := matchers.ArrayMatch(arr[:], "q1;q3;q3;q2;q4", configMap)
+	Expect(isMatched).To(BeFalse())
 }
 
 func getConfiguration(ignoreUnknown, ignoreOccurrences, ignoreOrder bool) map[string]interface{} {

--- a/core/matching/matchers/contains_exactly_match.go
+++ b/core/matching/matchers/contains_exactly_match.go
@@ -2,6 +2,6 @@ package matchers
 
 var ContainsExactly = "containsexactly"
 
-func ContainsExactlyMatch(match interface{}, toMatch string) bool {
+func ContainsExactlyMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	return ArrayMatch(match, toMatch, nil)
 }

--- a/core/matching/matchers/contains_exactly_match_test.go
+++ b/core/matching/matchers/contains_exactly_match_test.go
@@ -10,33 +10,40 @@ import (
 func Test_ContainsExactlyMatch_MatchesFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.ContainsExactlyMatch("hello", "yes")).To(BeFalse())
+	_, isMatched := matchers.ContainsExactlyMatch("hello", "yes", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_ContainsExactlyMatch_MatchesTrueWithIdenticalArray(t *testing.T) {
 	RegisterTestingT(t)
 
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ContainsExactlyMatch(arr[:], "q1;q2;q3")).To(BeTrue())
+	matchedValue, isMatched := matchers.ContainsExactlyMatch(arr[:], "q1;q2;q3", nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("q1;q2;q3"))
 }
 
 func Test_ContainsExactlyMatch_MatchesTrueWithIdenticalArrayWithMatcherAsArrayOfInterface(t *testing.T) {
 	RegisterTestingT(t)
 
 	arr := [3]interface{}{"q1", "q2", "q3"}
-	Expect(matchers.ContainsExactlyMatch(arr[:], "q1;q2;q3")).To(BeTrue())
+	matchedValue, isMatched := matchers.ContainsExactlyMatch(arr[:], "q1;q2;q3", nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("q1;q2;q3"))
 }
 
 func Test_ContainsExactlyMatch_MatchesFalseWithSameArrayInDifferentOrder(t *testing.T) {
 	RegisterTestingT(t)
 
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ContainsExactlyMatch(arr[:], "q1;q3;q2")).To(BeFalse())
+	_, isMatched := matchers.ContainsExactlyMatch(arr[:], "q1;q3;q2", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_ContainsExactlyMatch_MatchesFalseWithDifferentArray(t *testing.T) {
 	RegisterTestingT(t)
 
 	arr := [4]string{"q1", "q2", "q3", "q4"}
-	Expect(matchers.ContainsExactlyMatch(arr[:], "q5;q6")).To(BeFalse())
+	_, isMatched := matchers.ContainsExactlyMatch(arr[:], "q5;q6", nil)
+	Expect(isMatched).To(BeFalse())
 }

--- a/core/matching/matchers/exact_match.go
+++ b/core/matching/matchers/exact_match.go
@@ -2,11 +2,14 @@ package matchers
 
 var Exact = "exact"
 
-func ExactMatch(match interface{}, toMatch string) bool {
+func ExactMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
-	return matchString == toMatch
+	if matchString == toMatch {
+		return toMatch, true
+	}
+	return "", false
 }

--- a/core/matching/matchers/exact_match_test.go
+++ b/core/matching/matchers/exact_match_test.go
@@ -10,34 +10,40 @@ import (
 func Test_ExactMatch_MatchesFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.ExactMatch(1, "yes")).To(BeFalse())
+	_, isMatched := matchers.ExactMatch(1, "yes", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_ExactMatch_MatchesTrueWithExactMatch(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.ExactMatch("yes", "yes")).To(BeTrue())
+	matchedValue, isMatched := matchers.ExactMatch("yes", "yes", nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("yes"))
 }
 
 func Test_ExactMatch_MatchesFalseWithIncorrectExactMatch(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.ExactMatch("yes", "no")).To(BeFalse())
+	_, isMatched := matchers.ExactMatch("yes", "no", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_ExactMatch_MatchesTrueWithJSON(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.ExactMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"json":true,"minified":true}}`)).To(BeTrue())
+	_, isMatched := matchers.ExactMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"json":true,"minified":true}}`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_ExactMatch_MatchesTrueWithUnminifiedJSON(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.ExactMatch(`{"test":{"json":true,"minified":true}}`, `{
+	_, isMatchedValue := matchers.ExactMatch(`{"test":{"json":true,"minified":true}}`, `{
 		"test": {
 			"json": true,
 			"minified": true
 		}
-	}`)).To(BeFalse())
+	}`, nil)
+	Expect(isMatchedValue).To(BeFalse())
 }

--- a/core/matching/matchers/glob_match.go
+++ b/core/matching/matchers/glob_match.go
@@ -4,11 +4,14 @@ import "github.com/ryanuber/go-glob"
 
 var Glob = "glob"
 
-func GlobMatch(match interface{}, toMatch string) bool {
+func GlobMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
-	return glob.Glob(matchString, toMatch)
+	if matched := glob.Glob(matchString, toMatch); matched {
+		return toMatch, true
+	}
+	return "", false
 }

--- a/core/matching/matchers/glob_match_test.go
+++ b/core/matching/matchers/glob_match_test.go
@@ -10,61 +10,81 @@ import (
 func Test_GlobMatch_MatchesFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch(1, "yes")).To(BeFalse())
+	_, isMatched := matchers.GlobMatch(1, "yes", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_GlobMatch_MatchesTrueWithGlobMatch(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("t*st", `test`)).To(BeTrue())
+	matchedValue, isMatched := matchers.GlobMatch("t*st", `test`, nil)
+	expectTrueWithTestString(isMatched, matchedValue)
 }
 
 func Test_GlobMatch_MatchesTrueWithGlobMatch_MatchesZeroExtraCharactersAtEnd(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("test*", `test`)).To(BeTrue())
+	matchedValue, isMatched := matchers.GlobMatch("test*", `test`, nil)
+	expectTrueWithTestString(isMatched, matchedValue)
 }
 
 func Test_GlobMatch_MatchesTrueWithGlobMatch_MatchesZeroExtraCharactersAtStart(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("*test", `test`)).To(BeTrue())
+	matchedValue, isMatched := matchers.GlobMatch("*test", `test`, nil)
+	expectTrueWithTestString(isMatched, matchedValue)
 }
 
 func Test_GlobMatch_MatchesTrueWithGlobMatch_MatchesZeroExtraCharactersAtStartAndEnd(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("*test*", `test`)).To(BeTrue())
+	matchedValue, isMatched := matchers.GlobMatch("*test*", `test`, nil)
+	expectTrueWithTestString(isMatched, matchedValue)
 }
 
 func Test_GlobMatch_MatchesTrueWithGlobMatch_MatchesUpperCase(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("*est", `Test`)).To(BeTrue())
+	matchedValue, isMatched := matchers.GlobMatch("*est", `Test`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("Test"))
 }
 
 func Test_GlobMatch_MatchesTrueWithGlobMatch_MatchesLowerCase(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("*est", `test`)).To(BeTrue())
+	matchedValue, isMatched := matchers.GlobMatch("*est", `test`, nil)
+	expectTrueWithTestString(isMatched, matchedValue)
 }
 
 func Test_GlobMatch_MatchesTrueWithGlobMatch_MatchesAstrik(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("*est", `*est`)).To(BeTrue())
-	Expect(matchers.GlobMatch("t*est", `t*est`)).To(BeTrue())
-	Expect(matchers.GlobMatch("test*", `test*`)).To(BeTrue())
+	_, isMatched1 := matchers.GlobMatch("*est", `*est`, nil)
+	Expect(isMatched1).To(BeTrue())
+
+	_, isMatched2 := matchers.GlobMatch("t*est", `t*est`, nil)
+	Expect(isMatched2).To(BeTrue())
+
+	_, isMatched3 := matchers.GlobMatch("test*", `test*`, nil)
+	Expect(isMatched3).To(BeTrue())
 }
 
 func Test_GlobMatch_MatchesFalseWithGlobMatch_UpperCase(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("*esT", `test`)).To(BeFalse())
+	_, isMatched := matchers.GlobMatch("*esT", `test`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_GlobMatch_MatchesFalseWithIncorrectGlobMatch(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.GlobMatch("t*st", `tset`)).To(BeFalse())
+	_, isMatched := matchers.GlobMatch("t*st", `tset`, nil)
+	Expect(isMatched).To(BeFalse())
+}
+
+func expectTrueWithTestString(isMatched bool, matchedValue string) {
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("test"))
 }

--- a/core/matching/matchers/json_match.go
+++ b/core/matching/matchers/json_match.go
@@ -7,26 +7,29 @@ import (
 
 var Json = "json"
 
-func JsonMatch(match interface{}, toMatch string) bool {
+func JsonMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
 	if matchString == toMatch {
-		return true
+		return toMatch, true
 	}
 	var matchingObject interface{}
 	err := json.Unmarshal([]byte(matchString), &matchingObject)
 	if err != nil {
-		return false
+		return "", false
 	}
 
 	var toMatchObject interface{}
 	err = json.Unmarshal([]byte(toMatch), &toMatchObject)
 	if err != nil {
-		return false
+		return "", false
 	}
 
-	return reflect.DeepEqual(matchingObject, toMatchObject)
+	if isMatched := reflect.DeepEqual(matchingObject, toMatchObject); isMatched {
+		return toMatch, true
+	}
+	return "", false
 }

--- a/core/matching/matchers/json_match_test.go
+++ b/core/matching/matchers/json_match_test.go
@@ -10,104 +10,131 @@ import (
 func Test_JsonMatch_MatchesFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(1, "yes")).To(BeFalse())
+	_, isMatched := matchers.JsonMatch(1, "yes", nil)
+	Expect(isMatched).To(BeFalse())
 }
 func Test_JsonMatch_MatchesTrueWithJSON(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"json":true,"minified":true}}`)).To(BeTrue())
+	matchedValue, isMatch := matchers.JsonMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"json":true,"minified":true}}`, nil)
+	Expect(isMatch).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`{"test":{"json":true,"minified":true}}`))
 }
 
 func Test_JsonMatch_MatchesTrueWithJSON_InADifferentOrder(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`{"test":{"minified":true, "json":true}}`, `{"test":{"json":true,"minified":true}}`)).To(BeTrue())
+	matchedValue, isMatch := matchers.JsonMatch(`{"test":{"minified":true, "json":true}}`, `{"test":{"json":true,"minified":true}}`, nil)
+	Expect(isMatch).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`{"test":{"json":true,"minified":true}}`))
 }
 
 func Test_JsonMatch_MatchesTrueWithUnminifiedJSON(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`{"test":{"json":true,"minified":true}}`, `{
+	matchedValue, isMatched := matchers.JsonMatch(`{"test":{"json":true,"minified":true}}`, `{
 		"test": {
 			"json": true,
 			"minified": true
 		}
-	}`)).To(BeTrue())
+	}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`{
+		"test": {
+			"json": true,
+			"minified": true
+		}
+	}`))
 }
 
 func Test_JsonMatch_MatchesFalseWithInvalidJSONAsMatcher(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`"test":"json":true,"minified"`, `{
+	_, isMatched := matchers.JsonMatch(`"test":"json":true,"minified"`, `{
 		"test": {
 			"json": true,
 			"minified": true
 		}
-	}`)).To(BeFalse())
+	}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonMatch_MatchesFalseWithInvalidJSON(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`{"test":{"json":true,"minified":true}}`, `{
+	_, isMatched := matchers.JsonMatch(`{"test":{"json":true,"minified":true}}`, `{
 		"test": {
 			"json": true,
 			"minified": 
 		}
-	}`)).To(BeFalse())
+	}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonMatch_MatchesTrueWithTwoEmptyString(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(``, ``)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonMatch(``, ``, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(``))
 }
 
 func Test_JsonMatch_MatchesFalseAgainstEmptyString(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`{
+	_, isMatched := matchers.JsonMatch(`{
 		"test": {
 			"json": true,
 			"minified": 
 		}
-	}`, ``)).To(BeFalse())
+	}`, ``, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonMatch_MatchesFalseWithEmptyString(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(``, `{
+	_, isMatched := matchers.JsonMatch(``, `{
 		"test": {
 			"json": true,
 			"minified": 
 		}
-	}`)).To(BeFalse())
+	}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 // Should not ignore JSON array order by default
 func Test_JsonMatch_MatchesFalseWithJSONRootAsArray_InADifferentOrder(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`[{"minified": true}, {"json": true}]`, `[{"json":true},{"minified":true}]`)).To(BeFalse())
+	_, isMatched := matchers.JsonMatch(`[{"minified": true}, {"json": true}]`, `[{"json":true},{"minified":true}]`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonMatch_MatchesTrueWithUnminifiedJSONRootAsArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`[{"minified": true}, {"json": true}]`, `[
+	matchedValue, isMatched := matchers.JsonMatch(`[{"minified": true}, {"json": true}]`, `[
 		{
 			"minified": true
 		}, {
 			"json": true
 		}
-	]`)).To(BeTrue())
+	]`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`[
+		{
+			"minified": true
+		}, {
+			"json": true
+		}
+	]`))
 }
-
 
 func Test_JsonMatch_MatchesTrueWithJSONRootAsArray_WithDataInDifferentOrder(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonMatch(`[{"minified":true, "json":true}]`, `[{"json":true,"minified":true}]`)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonMatch(`[{"minified":true, "json":true}]`, `[{"json":true,"minified":true}]`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`[{"json":true,"minified":true}]`))
 }
-

--- a/core/matching/matchers/json_partial_match.go
+++ b/core/matching/matchers/json_partial_match.go
@@ -6,18 +6,18 @@ import (
 
 var JsonPartial = "jsonpartial"
 
-func JsonPartialMatch(match interface{}, toMatch string) bool {
+func JsonPartialMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	var expected interface{}
 	var toMatchType interface{}
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
 	err0 := json.Unmarshal([]byte(toMatch), &toMatchType)
 	err1 := json.Unmarshal([]byte(matchString), &expected)
 	if err0 != nil || err1 != nil {
-		return false
+		return "", false
 	}
 
 	actual, ok := toMatchType.(map[string]interface{})
@@ -32,16 +32,16 @@ func JsonPartialMatch(match interface{}, toMatch string) bool {
 	for _, node := range allNodes {
 		if expectedMap, ok := expected.(map[string]interface{}); ok {
 			if mapContainsMap(expectedMap, node) {
-				return true
+				return toMatch, true
 			}
 		} else if expectedArray, ok := expected.([]interface{}); ok {
 			if arrayContainsArray(expectedArray, node) {
-				return true
+				return toMatch, true
 			}
 		}
 	}
 
-	return false
+	return "", false
 }
 
 func mapContainsMap(match, toMatch interface{}) bool {

--- a/core/matching/matchers/json_partial_match_test.go
+++ b/core/matching/matchers/json_partial_match_test.go
@@ -10,7 +10,7 @@ import (
 func Test_JsonPartialMatch_MatchesTrueWithEqualsJSON(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`
+	_, isMatched := matchers.JsonPartialMatch(`
 	{
         "name": "Object 2",
         "set": false,
@@ -25,55 +25,67 @@ func Test_JsonPartialMatch_MatchesTrueWithEqualsJSON(t *testing.T) {
         "set": false,
         "age": 400
     }]
-}`)).To(BeTrue())
+}`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPartialMatch_MatchesTrueWithNotOrderedJSON(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`{"test":{"minified":true,"json":true}}`, `{"test":{"json":true,"minified":true}}`)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonPartialMatch(`{"test":{"minified":true,"json":true}}`, `{"test":{"json":true,"minified":true}}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`{"test":{"json":true,"minified":true}}`))
 }
 
 func Test_JsonPartialMatch_MatchesTrueWithAbsentNode(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`{"test":{"minified":true}}`, `{"test":{"json":true,"minified":true}}`)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonPartialMatch(`{"test":{"minified":true}}`, `{"test":{"json":true,"minified":true}}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`{"test":{"json":true,"minified":true}}`))
 }
 
 func Test_JsonPartialMatch_MatchesTrueWithAbsentObject(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`{"test":{"minified":true}}`, `{"test":{"json":true,"minified":true,"someObject":{"fieldA":"valueA"}}}`)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonPartialMatch(`{"test":{"minified":true}}`, `{"test":{"json":true,"minified":true,"someObject":{"fieldA":"valueA"}}}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`{"test":{"json":true,"minified":true,"someObject":{"fieldA":"valueA"}}}`))
 }
 
 func Test_JsonPartialMatch_MatchesFalseWithAbsentNode(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"minified":true}}`)).To(BeFalse())
+	_, isMatched := matchers.JsonPartialMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"minified":true}}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonPartialMatch_MatchesFalseWithAbsentObject(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`{"test":{"json":true,"minified":true,"someObject":{"fieldA":"valueA"}}}`, `{"test":{"minified":true}}`)).To(BeFalse())
+	_, isMatched := matchers.JsonPartialMatch(`{"test":{"json":true,"minified":true,"someObject":{"fieldA":"valueA"}}}`, `{"test":{"minified":true}}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonPartialMatch_MatchesTrueEmptyJson(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`{}`, `{}`)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonPartialMatch(`{}`, `{}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`{}`))
 }
 
 func Test_JsonPartialMatch_MatchesFalseInvalidJson(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"json":true,"minified":}}`)).To(BeFalse())
+	_, isMatched := matchers.JsonPartialMatch(`{"test":{"json":true,"minified":true}}`, `{"test":{"json":true,"minified":}}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonPartialMatch_MatchesTrueDeep(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(
+	_, isMatched := matchers.JsonPartialMatch(
 		`{
   "fieldA": "valueA"
 }`,
@@ -84,13 +96,14 @@ func Test_JsonPartialMatch_MatchesTrueDeep(t *testing.T) {
 		"someObject": {
 			"fieldA": "valueA"
 		}
-}}`)).To(BeTrue())
+}}`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPartialMatch_MatchesTrueDeepArrayInside(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(
+	_, isMatched := matchers.JsonPartialMatch(
 		`{
   "NAME": "79684881033",
   "REDIRECT_NUMBER": "79684881033"
@@ -124,13 +137,14 @@ func Test_JsonPartialMatch_MatchesTrueDeepArrayInside(t *testing.T) {
       ]
     ]
   }
-}`)).To(BeTrue())
+}`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPartialMatch_MatchesTrueDeepComplexWithArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(
+	_, isMatched := matchers.JsonPartialMatch(
 		`{
     "redirect_type": 1,
     "followme_struct": [
@@ -177,13 +191,14 @@ func Test_JsonPartialMatch_MatchesTrueDeepComplexWithArray(t *testing.T) {
       ]
     ]
   }
-}`)).To(BeTrue())
+}`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPartialMatch_MatchesFalseDeepComplexWithArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(
+	_, isMatched := matchers.JsonPartialMatch(
 		`{
     "redirect_type": 1,
     "followme_struct": [
@@ -230,13 +245,14 @@ func Test_JsonPartialMatch_MatchesFalseDeepComplexWithArray(t *testing.T) {
       ]
     ]
   }
-}`)).To(BeFalse())
+}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonPartialMatch_MatchesTrueAgainstJSONRootAsArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`
+	_, isMatched := matchers.JsonPartialMatch(`
 	{
         "name": "Object 2",
         "set": false,
@@ -251,13 +267,14 @@ func Test_JsonPartialMatch_MatchesTrueAgainstJSONRootAsArray(t *testing.T) {
 			"set": false,
 			"age": 400
 		}]
-	}]`)).To(BeTrue())
+	}]`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`
+	_, isMatched := matchers.JsonPartialMatch(`
 	[{
         "name": "Object 1",
         "set": true
@@ -276,13 +293,14 @@ func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsArray(t *testing.T) {
 			"set": false,
 			"age": 400
 		}]
-	}`)).To(BeTrue())
+	}`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsPartialArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`
+	_, isMatched := matchers.JsonPartialMatch(`
 	[{
         "name": "Object 1",
         "set": true
@@ -297,13 +315,14 @@ func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsPartialArray(t *testing.T) {
 			"set": false,
 			"age": 400
 		}]
-	}`)).To(BeTrue())
+	}`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsPartialArrayWithPartialObject(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`
+	_, isMatched := matchers.JsonPartialMatch(`
 	[{
         "name": "Object 2",
         "set": false
@@ -318,13 +337,14 @@ func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsPartialArrayWithPartialObjec
 			"set": false,
 			"age": 400
 		}]
-	}`)).To(BeTrue())
+	}`, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPartialMatch_MatchesFalseWithJSONRootAsArrayWithDifferentElement(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`
+	_, isMatched := matchers.JsonPartialMatch(`
 	[{
         "name": "Object 3",
         "set": true
@@ -339,13 +359,14 @@ func Test_JsonPartialMatch_MatchesFalseWithJSONRootAsArrayWithDifferentElement(t
 			"set": false,
 			"age": 400
 		}]
-	}`)).To(BeFalse())
+	}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsArrayAgainstJSONRootAsArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`
+	_, isMatched := matchers.JsonPartialMatch(`
 	[{
         "name": "Object 1",
         "set": true
@@ -358,14 +379,14 @@ func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsArrayAgainstJSONRootAsArray(
 		"name": "Object 2",
 		"set": false,
 		"age": 400
-	}]`)).To(BeTrue())
+	}]`, nil)
+	Expect(isMatched).To(BeTrue())
 }
-
 
 func Test_JsonPartialMatch_MatchesFalseWithJSONRootAsArrayAgainstJSONRootAsArrayWithDifferentElement(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPartialMatch(`
+	_, isMatched := matchers.JsonPartialMatch(`
 	[{
         "name": "Object 3",
         "set": false
@@ -378,5 +399,6 @@ func Test_JsonPartialMatch_MatchesFalseWithJSONRootAsArrayAgainstJSONRootAsArray
 		"name": "Object 2",
 		"set": false,
 		"age": 400
-	}]`)).To(BeFalse())
+	}]`, nil)
+	Expect(isMatched).To(BeFalse())
 }

--- a/core/matching/matchers/json_path_match.go
+++ b/core/matching/matchers/json_path_match.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/util/jsonpath"
@@ -11,19 +12,19 @@ import (
 
 var JsonPath = "jsonpath"
 
-func JsonPathMatch(match interface{}, toMatch string) bool {
+func JsonPathMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
 	matchString = prepareJsonPathQuery(matchString)
-	returnedString, err := JsonPathExecution(matchString, toMatch)
+	returnedString, err := jsonPathExecutionReturningJsonString(matchString, toMatch)
 	if err != nil || returnedString == matchString {
-		return false
+		return "", false
 	}
 
-	return true
+	return returnedString, true
 }
 
 func JsonPathExecution(matchString, toMatch string) (string, error) {
@@ -50,6 +51,57 @@ func JsonPathExecution(matchString, toMatch string) (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+func jsonPathExecutionReturningJsonString(matchString, toMatch string) (string, error) {
+	jsonPath := jsonpath.New("")
+
+	err := jsonPath.Parse(matchString)
+	if err != nil {
+		log.Errorf("Failed to parse json path query %s: %s", matchString, err.Error())
+		return "", err
+	}
+
+	var data interface{}
+	if err := json.Unmarshal([]byte(toMatch), &data); err != nil {
+		log.Errorf("Failed to unmarshal body to JSON: %s", err.Error())
+		return "", err
+	}
+
+	results, err := jsonPath.FindResults(data)
+	if err != nil {
+		log.Errorf("err to execute json path match: %s", err.Error())
+		return "", err
+	}
+
+	return getResult(results)
+}
+
+func getResult(results [][]reflect.Value) (string, error) {
+	var allResultsInterface []interface{}
+	for _, result := range results {
+		for _, singleResult := range result {
+			allResultsInterface = append(allResultsInterface, singleResult.Interface())
+		}
+	}
+	if len(allResultsInterface) == 1 {
+		if _, ok := allResultsInterface[0].(string); ok {
+			return allResultsInterface[0].(string), nil
+		}
+		bytes, err := json.Marshal(allResultsInterface[0])
+		if err != nil {
+			log.Errorf("err to marshal %s", err.Error())
+			return "", err
+		}
+		return string(bytes), nil
+	}
+
+	bytes, err := json.Marshal(allResultsInterface)
+	if err != nil {
+		log.Errorf("err to marshal %s", err.Error())
+		return "", err
+	}
+	return string(bytes), nil
 }
 
 func prepareJsonPathQuery(query string) string {

--- a/core/matching/matchers/json_path_match_test.go
+++ b/core/matching/matchers/json_path_match_test.go
@@ -10,54 +10,91 @@ import (
 func Test_JsonPathMatch_MatchesFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch(1, "yes")).To(BeFalse())
+	_, isMatched := matchers.JsonPathMatch(1, "yes", nil)
+	Expect(isMatched).To(BeFalse())
 }
 func Test_JsonPathMatch_MatchesFalseWithInvalidJsonPath(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch("test", `{"test": "field"}`)).To(BeFalse())
+	_, isMatched := matchers.JsonPathMatch("test", `{"test": "field"}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonPathMatch_MatchesTrueWithJsonMatch_GetSingleElement(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch("$.test", `{"test": "field"}`)).To(BeTrue())
+	matchedContext, isMatched := matchers.JsonPathMatch("$.test", `{"test": "field"}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedContext).Should(Equal("field"))
 }
 
 func Test_JsonPathMatch_MatchesFalseWithIncorrectJsonMatch_GetSingleElement(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch("$.notAField", `{"test": "field"}`)).To(BeFalse())
+	_, isMatched := matchers.JsonPathMatch("$.notAField", `{"test": "field"}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonPathMatch_MatchesTrueWithJsonMatch_GetElementFromArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch("$.test[1]", `{"test": [{}, {}]}`)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonPathMatch("$.test[1]", `{"test": [{}, {}]}`, nil)
+	Expect(matchedValue).Should(Equal("{}"))
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_JsonPathMatch_MatchesFalseWithIncorrectJsonMatch_GetElementFromArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch("$.test[2]", `{"test": [{}, {}]}`)).To(BeFalse())
+	_, isMatched := matchers.JsonPathMatch("$.test[2]", `{"test": [{}, {}]}`, nil)
+	Expect(isMatched).To(BeFalse())
+}
+
+func Test_JsonPathMatch_MatchesTrueWithJsonMatch_GetArrayElement(t *testing.T) {
+	RegisterTestingT(t)
+
+	matchedValue, isMatched := matchers.JsonPathMatch("$.test", `{"test": ["hello", "world"]}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("[\"hello\",\"world\"]"))
 }
 
 func Test_JsonPathMatch_MatchesTrueWithJsonMatch_WithExpression(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch("$.test[?(@.field == \"test\")]", `{"test": [{"field": "test"}]}`)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonPathMatch("$.test[?(@.field == \"test\")]", `{"test": [{"field": "test"}]}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("{\"field\":\"test\"}"))
 }
 
 func Test_JsonPathMatch_MatchesFalseWithIncorrectJsonMatch_WithExpression(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch("$.test[*]?(@.field == \"test\")", `{"test": [{"field": "not-test"}]}`)).To(BeFalse())
+	_, isMatched := matchers.JsonPathMatch("$.test[*]?(@.field == \"test\")", `{"test": [{"field": "not-test"}]}`, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_JsonPathMatch_MatchesTrueWithJsonMatch_GetSingleElement_WhereRootIsArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.JsonPathMatch("$[0].test", `[{"test": "field"}]`)).To(BeTrue())
+	matchedValue, isMatched := matchers.JsonPathMatch("$[0].test", `[{"test": "field"}]`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("field"))
+}
+
+func Test_JsonPathMatch_MatchesTrueWithJsonMatch_GetCompleteObject_WhereElementIsObject(t *testing.T) {
+	RegisterTestingT(t)
+
+	matchedValue, isMatched := matchers.JsonPathMatch("$.test", `{"test": {"field1":"value1", "field2":"value2"}}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("{\"field1\":\"value1\",\"field2\":\"value2\"}"))
+}
+
+func Test_JsonPathMatch_MatchesTrueWithJsonMatch_GetArray_WhereElementIsArrayObject(t *testing.T) {
+	RegisterTestingT(t)
+
+	matchedValue, isMatched := matchers.JsonPathMatch("$.test[1:3]", `{"test": [{"field1":"value1"}, {"field2":"value2"}, {"field3":"value3"}, {"field4":"value4"}]}`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("[{\"field2\":\"value2\"},{\"field3\":\"value3\"}]"))
 }
 
 // TODO the following JSONPath expressions are not supported at the moment

--- a/core/matching/matchers/matchers.go
+++ b/core/matching/matchers/matchers.go
@@ -1,26 +1,19 @@
 package matchers
 
-type MatcherFunc func(data interface{}, toMatch string) bool
-
-type MatcherFuncWithConfig func(data interface{}, toMatch string, config map[string]interface{}) bool
+type MatcherFunc func(data interface{}, toMatch string, config map[string]interface{}) (string, bool)
 
 var Matchers = map[string]MatcherFunc{
-	// Default matcher
-	"": ExactMatch,
 
+	"":              ExactMatch,
 	Exact:           ExactMatch,
 	Glob:            GlobMatch,
-	Json:            JsonMatch,
-	JsonPath:        JsonPathMatch,
-	JsonPartial:     JsonPartialMatch,
 	Regex:           RegexMatch,
-	Xml:             XmlMatch,
+	JsonPath:        JsonPathMatch,
 	Xpath:           XpathMatch,
-	XmlTemplated:    XmlTemplatedMatch,
+	Array:           ArrayMatch,
 	ContainsExactly: ContainsExactlyMatch,
-	Array:           ContainsExactlyMatch,
-}
-
-var MatchersWithConfig = map[string]MatcherFuncWithConfig{
-	Array: ArrayMatch,
+	Json:            JsonMatch,
+	Xml:             XmlMatch,
+	JsonPartial:     JsonPartialMatch,
+	XmlTemplated:    XmlTemplatedMatch,
 }

--- a/core/matching/matchers/regex_match.go
+++ b/core/matching/matchers/regex_match.go
@@ -4,16 +4,19 @@ import "regexp"
 
 var Regex = "regex"
 
-func RegexMatch(match interface{}, toMatch string) bool {
+func RegexMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
 	result, err := regexp.MatchString(matchString, toMatch)
 	if err != nil {
-		return false
+		return "", false
 	}
 
-	return result
+	if result {
+		return toMatch, result
+	}
+	return "", false
 }

--- a/core/matching/matchers/regex_match_test.go
+++ b/core/matching/matchers/regex_match_test.go
@@ -10,16 +10,19 @@ import (
 func Test_RegexMatch_MatchesFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.RegexMatch(1, "yes")).To(BeFalse())
+	_, isMatched := matchers.RegexMatch(1, "yes", nil)
+	Expect(isMatched).To(BeFalse())
 }
 func Test_RegexMatch_MatchesTrueWithRegexMatch(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.RegexMatch("t[o|a|e]st", `test`)).To(BeTrue())
+	matchedValue, isMatched := matchers.RegexMatch("t[o|a|e]st", `test`, nil)
+	expectTrueWithTestString(isMatched, matchedValue)
 }
 
 func Test_RegexMatch_MatchesFalseWithIncorrectRegexMatch(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.RegexMatch("t[o|a]st", `test`)).To(BeFalse())
+	_, isMatched := matchers.RegexMatch("t[o|a]st", `test`, nil)
+	Expect(isMatched).To(BeFalse())
 }

--- a/core/matching/matchers/xml_match.go
+++ b/core/matching/matchers/xml_match.go
@@ -8,21 +8,24 @@ import (
 
 var Xml = "xml"
 
-func XmlMatch(match interface{}, toMatch string) bool {
+func XmlMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
 	minifiedMatch, err := util.MinifyXml(matchString)
 	if err != nil {
-		return false
+		return "", false
 	}
 
 	minifiedToMatch, err := util.MinifyXml(toMatch)
 	if err != nil {
-		return false
+		return "", false
 	}
 
-	return reflect.DeepEqual(minifiedMatch, minifiedToMatch)
+	if isMatched := reflect.DeepEqual(minifiedMatch, minifiedToMatch); isMatched {
+		return toMatch, true
+	}
+	return "", false
 }

--- a/core/matching/matchers/xml_match_test.go
+++ b/core/matching/matchers/xml_match_test.go
@@ -10,28 +10,34 @@ import (
 func Test_XmlMatch_MatchesFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XmlMatch(1, "yes")).To(BeFalse())
+	_, isMatched := matchers.XmlMatch(1, "yes", nil)
+	Expect(isMatched).To(BeFalse())
 }
 func Test_XmlMatch_MatchesTrueWithXML(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XmlMatch(`<xml><document><test></document>`, `<xml><document><test></document>`)).To(BeTrue())
+	matchedValue, isMatched := matchers.XmlMatch(`<xml><document><test></document>`, `<xml><document><test></document>`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`<xml><document><test></document>`))
 }
 
 func Test_XmlMatch_MatchesTrueWithUnminifiedXml(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XmlMatch(`<xml>
-		<document>
-			<test key="value">cat</test>
-		</document>`, `<xml><document><test key="value">cat</test></document>`)).To(BeTrue())
+	matchedValue, isMatched := matchers.XmlMatch(`<xml>
+	<document>
+		<test key="value">cat</test>
+	</document>`, `<xml><document><test key="value">cat</test></document>`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(`<xml><document><test key="value">cat</test></document>`))
 }
 
 func Test_XmlMatch_MatchesFalseWithNotMatchingXml(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XmlMatch(`<xml>
-		<document>
-			<test key="value">cat</test>
-		</document>`, `<xml><document><test key="different">cat</test></document>`)).To(BeFalse())
+	_, isMatched := matchers.XmlMatch(`<xml>
+	<document>
+		<test key="value">cat</test>
+	</document>`, `<xml><document><test key="different">cat</test></document>`, nil)
+	Expect(isMatched).To(BeFalse())
 }

--- a/core/matching/matchers/xml_templated_match.go
+++ b/core/matching/matchers/xml_templated_match.go
@@ -11,26 +11,29 @@ var XmlTemplated = "xmltemplated"
 var ignoreExpr = regexp.MustCompile("^\\s*{{\\s*ignore\\s*}}\\s*$")
 var regExpr = regexp.MustCompile("^\\s*{{\\s*regex:(.*)}}\\s*$")
 
-func XmlTemplatedMatch(match interface{}, toMatch string) bool {
+func XmlTemplatedMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
 	// parse xml in mock data into dom tree
 	expected := etree.NewDocument()
 	if err := expected.ReadFromString(matchString); err != nil {
-		return false
+		return "", false
 	}
 
 	// parse xml in actual request body into dom tree
 	actual := etree.NewDocument()
 	if err := actual.ReadFromString(toMatch); err != nil {
-		return false
+		return "", false
 	}
 
 	// tree matching
-	return compareTree(expected.Root(), actual.Root())
+	if isMatched := compareTree(expected.Root(), actual.Root()); isMatched {
+		return toMatch, true
+	}
+	return "", false
 }
 
 func compareTree(expected *etree.Element, actual *etree.Element) bool {

--- a/core/matching/matchers/xml_templated_match_test.go
+++ b/core/matching/matchers/xml_templated_match_test.go
@@ -1537,7 +1537,8 @@ func Test_XmlTemplatedMatch_1(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_2(t *testing.T) {
@@ -1556,7 +1557,8 @@ func Test_XmlTemplatedMatch_2(t *testing.T) {
 			bbb check</bbb>	
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_3(t *testing.T) {
@@ -1576,7 +1578,8 @@ func Test_XmlTemplatedMatch_3(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_4(t *testing.T) {
@@ -1596,7 +1599,8 @@ func Test_XmlTemplatedMatch_4(t *testing.T) {
 		</xml>								
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_5(t *testing.T) {
@@ -1616,7 +1620,8 @@ func Test_XmlTemplatedMatch_5(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_6(t *testing.T) {
@@ -1636,7 +1641,8 @@ func Test_XmlTemplatedMatch_6(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_7(t *testing.T) {
@@ -1657,7 +1663,8 @@ func Test_XmlTemplatedMatch_7(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 /*
@@ -2076,8 +2083,9 @@ func Test_XmlTemplatedMatch_23(t *testing.T) {
 			<aaa>test</aaa>							
 		</xml>
 	`
-
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	matchedValue, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(actual))
 }
 
 func Test_XmlTemplatedMatch_24(t *testing.T) {
@@ -2099,7 +2107,9 @@ func Test_XmlTemplatedMatch_24(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	matchedValue, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(actual))
 }
 
 func Test_XmlTemplatedMatch_25(t *testing.T) {
@@ -2121,7 +2131,8 @@ func Test_XmlTemplatedMatch_25(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_26(t *testing.T) {
@@ -2141,7 +2152,8 @@ func Test_XmlTemplatedMatch_26(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_27(t *testing.T) {
@@ -2159,7 +2171,8 @@ func Test_XmlTemplatedMatch_27(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_28(t *testing.T) {
@@ -2177,7 +2190,8 @@ func Test_XmlTemplatedMatch_28(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_29(t *testing.T) {
@@ -2195,7 +2209,9 @@ func Test_XmlTemplatedMatch_29(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	matchedValue, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(matchedValue))
 }
 
 func Test_XmlTemplatedMatch_30(t *testing.T) {
@@ -2213,7 +2229,9 @@ func Test_XmlTemplatedMatch_30(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	matchedValue, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(actual))
 }
 
 func Test_XmlTemplatedMatch_31(t *testing.T) {
@@ -2231,7 +2249,8 @@ func Test_XmlTemplatedMatch_31(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_32(t *testing.T) {
@@ -2249,7 +2268,8 @@ func Test_XmlTemplatedMatch_32(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_33(t *testing.T) {
@@ -2267,7 +2287,8 @@ func Test_XmlTemplatedMatch_33(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_34(t *testing.T) {
@@ -2284,8 +2305,8 @@ func Test_XmlTemplatedMatch_34(t *testing.T) {
 			<aaa>xxx</aaa>					
 		</xml>
 	`
-
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_35(t *testing.T) {
@@ -2303,7 +2324,8 @@ func Test_XmlTemplatedMatch_35(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_36(t *testing.T) {
@@ -2321,7 +2343,8 @@ func Test_XmlTemplatedMatch_36(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_37(t *testing.T) {
@@ -2338,8 +2361,8 @@ func Test_XmlTemplatedMatch_37(t *testing.T) {
 			<aaa>12345</aaa>				
 		</xml>
 	`
-
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_38(t *testing.T) {
@@ -2357,7 +2380,8 @@ func Test_XmlTemplatedMatch_38(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_39(t *testing.T) {
@@ -2375,7 +2399,8 @@ func Test_XmlTemplatedMatch_39(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_40(t *testing.T) {
@@ -2393,7 +2418,8 @@ func Test_XmlTemplatedMatch_40(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_41(t *testing.T) {
@@ -2411,7 +2437,8 @@ func Test_XmlTemplatedMatch_41(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_42(t *testing.T) {
@@ -2429,7 +2456,8 @@ func Test_XmlTemplatedMatch_42(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_43(t *testing.T) {
@@ -2446,8 +2474,8 @@ func Test_XmlTemplatedMatch_43(t *testing.T) {
 			<aaa>12345</aaa>				
 		</xml>
 	`
-
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_44(t *testing.T) {
@@ -2465,7 +2493,8 @@ func Test_XmlTemplatedMatch_44(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, matchedValue := XmlTemplatedMatch(expect, actual, nil)
+	Expect(matchedValue).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_45(t *testing.T) {
@@ -2483,7 +2512,8 @@ func Test_XmlTemplatedMatch_45(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_46(t *testing.T) {
@@ -2501,7 +2531,8 @@ func Test_XmlTemplatedMatch_46(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_47(t *testing.T) {
@@ -2519,7 +2550,8 @@ func Test_XmlTemplatedMatch_47(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeTrue())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XmlTemplatedMatch_48(t *testing.T) {
@@ -2537,7 +2569,8 @@ func Test_XmlTemplatedMatch_48(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_49(t *testing.T) {
@@ -2555,7 +2588,8 @@ func Test_XmlTemplatedMatch_49(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_50(t *testing.T) {
@@ -2573,7 +2607,8 @@ func Test_XmlTemplatedMatch_50(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_51(t *testing.T) {
@@ -2591,7 +2626,8 @@ func Test_XmlTemplatedMatch_51(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_52(t *testing.T) {
@@ -2612,7 +2648,8 @@ func Test_XmlTemplatedMatch_52(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_53(t *testing.T) {
@@ -2635,7 +2672,8 @@ func Test_XmlTemplatedMatch_53(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatched := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XmlTemplatedMatch_54(t *testing.T) {
@@ -2651,5 +2689,6 @@ func Test_XmlTemplatedMatch_54(t *testing.T) {
 		</xml>
 	`
 
-	Expect(XmlTemplatedMatch(expect, actual)).To(BeFalse())
+	_, isMatch := XmlTemplatedMatch(expect, actual, nil)
+	Expect(isMatch).To(BeFalse())
 }

--- a/core/matching/matchers/xpath_match.go
+++ b/core/matching/matchers/xpath_match.go
@@ -3,6 +3,7 @@ package matchers
 import (
 	"bytes"
 	"encoding/xml"
+
 	"github.com/ChrisTrenkamp/xsel/exec"
 	"github.com/ChrisTrenkamp/xsel/grammar"
 	"github.com/ChrisTrenkamp/xsel/parser"
@@ -12,19 +13,18 @@ import (
 
 var Xpath = "xpath"
 
-
-func XpathMatch(match interface{}, toMatch string) bool {
+func XpathMatch(match interface{}, toMatch string, config map[string]interface{}) (string, bool) {
 	matchString, ok := match.(string)
 	if !ok {
-		return false
+		return "", false
 	}
 
 	results, err := XpathExecution(matchString, toMatch)
 	if err != nil {
-		return false
+		return "", false
 	}
 
-	return results.Bool()
+	return results.String(), results.Bool()
 }
 
 func XpathExecution(matchString, toMatch string) (exec.Result, error) {
@@ -48,7 +48,6 @@ func XpathExecution(matchString, toMatch string) (exec.Result, error) {
 
 	return results, nil
 }
-
 
 type xmlns struct {
 	Namespaces map[string]string

--- a/core/matching/matchers/xpath_match_test.go
+++ b/core/matching/matchers/xpath_match_test.go
@@ -11,61 +11,74 @@ import (
 func Test_XpathMatch_MatchesFalseWithIncorrectDataType(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch(1, "yes")).To(BeFalse())
+	_, isMatched := matchers.XpathMatch(1, "yes", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XpathMatch_MatchesTrue(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/root/text", xml.Header+"<root><text>test</text></root>")).To(BeTrue())
+	matchedValue, isMatched := matchers.XpathMatch("/root/text", xml.Header+"<root><text>test</text></root>", nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(matchedValue))
 }
 
 func Test_XpathMatch_MatchesFalseWithIncorectXpathMatch(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/pop", xml.Header+"<root><text>test</text></root>")).To(BeFalse())
+	_, isMatched := matchers.XpathMatch("/pop", xml.Header+"<root><text>test</text></root>", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XpathMatch_MatchesTrue_GetAnElementFromAnArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/list/item[1]/field", xml.Header+"<list><item><field>test</field></item></list>")).To(BeTrue())
+	matchedValue, isMatched := matchers.XpathMatch("/list/item[1]/field", xml.Header+"<list><item><field>test</field></item></list>", nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("test"))
 }
 
 func Test_XpathMatch_MatchesFalse_GetAnElementFromAnArray(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/list/item[1]/pop", xml.Header+"<list><item><field>test</field></item></list>")).To(BeFalse())
+	_, isMatched := matchers.XpathMatch("/list/item[1]/pop", xml.Header+"<list><item><field>test</field></item></list>", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XpathMatch_MatchesTrue_GetAttributeFromElement(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/list/item/field[@test]", xml.Header+"<list><item><field test=\"value\">test</field></item></list>")).To(BeTrue())
+	_, isMatched := matchers.XpathMatch("/list/item/field[@test]", xml.Header+"<list><item><field test=\"value\">test</field></item></list>", nil)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_XpathMatch_MatchesFalse_GetAttributeFromElement(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/list/item/field[@pop]", xml.Header+"<list><item><field test=\"value\">test</field></item></list>")).To(BeFalse())
+	_, isMatched := matchers.XpathMatch("/list/item/field[@pop]", xml.Header+"<list><item><field test=\"value\">test</field></item></list>", nil)
+	Expect(isMatched).To(BeFalse())
 }
 
 func Test_XpathMatch_MatchesTrue_GetElementWithNoValue(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/list/item/field", xml.Header+"<list><item><field></field></item></list>")).To(BeTrue())
+	matchedValue, isMatched := matchers.XpathMatch("/list/item/field", xml.Header+"<list><item><field></field></item></list>", nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(""))
 }
 
 func Test_XpathMatch_MatchesTrue_WithoutHeader(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/list/item/field", "<list><item><field></field></item></list>")).To(BeTrue())
+	matchedValue, isMatched := matchers.XpathMatch("/list/item/field", "<list><item><field></field></item></list>", nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal(""))
 }
 
 func Test_XpathMatch_MatchesTrue_WithNameSpacePrefix(t *testing.T) {
 	RegisterTestingT(t)
 
-	Expect(matchers.XpathMatch("/soapenv:Envelope/soapenv:Header/head:MessageHeader/head:From/head:Id",
+	matchedValue, isMatched := matchers.XpathMatch("/soapenv:Envelope/soapenv:Header/head:MessageHeader/head:From/head:Id",
 		`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:head="http://www.test.com/Header_01" xmlns:v1="http://www.test.com/GetStatement/v1">
 			   <soapenv:Header>
 				  <head:MessageHeader>
@@ -75,8 +88,10 @@ func Test_XpathMatch_MatchesTrue_WithNameSpacePrefix(t *testing.T) {
 				  </head:MessageHeader>
 			   </soapenv:Header>
 			   <soapenv:Body>
-				  <v1:GetCMSAccountStatementReq>         
+				  <v1:GetCMSAccountStatementReq>
 				  </v1:GetCMSAccountStatementReq>
 			   </soapenv:Body>
-			</soapenv:Envelope>`)).To(BeTrue())
+			</soapenv:Envelope>`, nil)
+	Expect(isMatched).To(BeTrue())
+	Expect(matchedValue).Should(Equal("Test"))
 }

--- a/core/models/request_matcher.go
+++ b/core/models/request_matcher.go
@@ -12,6 +12,7 @@ type RequestFieldMatchers struct {
 	Matcher string
 	Value   interface{}
 	Config  map[string]interface{}
+	DoMatch *RequestFieldMatchers
 }
 
 func NewRequestFieldMatchersFromView(matchers []v2.MatcherViewV5) []RequestFieldMatchers {
@@ -20,13 +21,30 @@ func NewRequestFieldMatchersFromView(matchers []v2.MatcherViewV5) []RequestField
 	}
 	convertedMatchers := []RequestFieldMatchers{}
 	for _, matcher := range matchers {
+		doMatch := getDoMatchRequestFromMatcherView(matcher.DoMatch)
 		convertedMatchers = append(convertedMatchers, RequestFieldMatchers{
 			Matcher: matcher.Matcher,
 			Value:   matcher.Value,
 			Config:  matcher.Config,
+			DoMatch: doMatch,
 		})
 	}
 	return convertedMatchers
+}
+
+func getDoMatchRequestFromMatcherView(matcher *v2.MatcherViewV5) *RequestFieldMatchers {
+
+	if matcher == nil {
+		return nil
+	}
+	matcherValue := *matcher
+	return &RequestFieldMatchers{
+		Matcher: matcherValue.Matcher,
+		Value:   matcherValue.Value,
+		Config:  matcherValue.Config,
+		DoMatch: getDoMatchRequestFromMatcherView(matcherValue.DoMatch),
+	}
+
 }
 
 func NewRequestFieldMatchersFromMapView(mapMatchers map[string][]v2.MatcherViewV5) map[string][]RequestFieldMatchers {
@@ -56,10 +74,26 @@ func NewQueryRequestFieldMatchersFromMapView(mapMatchers *v2.QueryMatcherViewV5)
 }
 
 func (this RequestFieldMatchers) BuildView() v2.MatcherViewV5 {
+	doMatch := getViewFromRequestFieldMatcher(this.DoMatch)
 	return v2.MatcherViewV5{
 		Matcher: this.Matcher,
 		Value:   this.Value,
 		Config:  this.Config,
+		DoMatch: doMatch,
+	}
+}
+
+func getViewFromRequestFieldMatcher(matcher *RequestFieldMatchers) *v2.MatcherViewV5 {
+
+	if matcher == nil {
+		return nil
+	}
+	matcherValue := *matcher
+	return &v2.MatcherViewV5{
+		Matcher: matcherValue.Matcher,
+		Value:   matcherValue.Value,
+		Config:  matcherValue.Config,
+		DoMatch: getViewFromRequestFieldMatcher(matcherValue.DoMatch),
 	}
 }
 


### PR DESCRIPTION
Resolves #761

PR contains changes for implementing matcher chaining. Any matcher can be combined with any of the other matchers. Output/matched value of one matcher is feed into other matcher mentioned in do match.  If this PR looks fine then I will add documentation.

`{
  body: [
    {
      matcher: "jsonpath"
      value: “$.user.id"
      domatch: {
        matcher: “exact”,
        value: “1"
    }
  ]
}

"body": [
                        {
                            "matcher": "xpath",
                            "value": "/root/id",
                            "domatch": {
                                "matcher": "exact",
                                "value": "123"
                            }
                        }
                    ]
` 