### PR TITLE
Code changes for matcher chaining

### DIFF
--- a/core/handlers/v2/simulation_views_v5.go
+++ b/core/handlers/v2/simulation_views_v5.go
@@ -40,6 +40,7 @@ type MatcherViewV5 struct {
 	Matcher string                 `json:"matcher"`
 	Value   interface{}            `json:"value"`
 	Config  map[string]interface{} `json:"config,omitempty"`
+	DoMatch *MatcherViewV5         `json:"doMatch,omitempty"`
 }
 
 type GlobalVariableViewV5 struct {

--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -193,22 +193,6 @@ var fieldMatcherTests = []fieldMatcherTest{
 		toMatch: `<document><details>{"name":"Test", "id":"12345"}</details></document>`,
 		equals:  BeTrue(),
 	},
-	{
-		// exactmatch, containsexactly, jsonmatch, xmlmatch match exact details
-		name: "IgnoreDoMatchIncaseOfExactMatcher",
-		matchers: []models.RequestFieldMatchers{
-			{
-				Matcher: "exact",
-				Value:   "test",
-				DoMatch: &models.RequestFieldMatchers{
-					Matcher: "glob",
-					Value:   "*es*",
-				},
-			},
-		},
-		toMatch: "test",
-		equals:  BeTrue(),
-	},
 }
 
 func Test_FieldMatcher(t *testing.T) {

--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -155,6 +155,60 @@ var fieldMatcherTests = []fieldMatcherTest{
 		toMatch: `<document></document>`,
 		equals:  BeTrue(),
 	},
+	{
+		name: "MatcherChaining1",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: "xpath",
+				Value:   "/document/id",
+				DoMatch: &models.RequestFieldMatchers{
+					Matcher: "exact",
+					Value:   "12345",
+				},
+			},
+		},
+		toMatch: "<document><id>12345</id><name>Test</name></document>",
+		equals:  BeTrue(),
+	},
+	{
+		name: "MatcherChaining2",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: "xpath",
+				Value:   "/document/details",
+				DoMatch: &models.RequestFieldMatchers{
+					Matcher: "jsonpath",
+					Value:   "$.name",
+					DoMatch: &models.RequestFieldMatchers{
+						Matcher: "glob",
+						Value:   "*es*",
+						DoMatch: &models.RequestFieldMatchers{
+							Matcher: "exact",
+							Value:   "Test",
+						},
+					},
+				},
+			},
+		},
+		toMatch: `<document><details>{"name":"Test", "id":"12345"}</details></document>`,
+		equals:  BeTrue(),
+	},
+	{
+		// exactmatch, containsexactly, jsonmatch, xmlmatch match exact details
+		name: "IgnoreDoMatchIncaseOfExactMatcher",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: "exact",
+				Value:   "test",
+				DoMatch: &models.RequestFieldMatchers{
+					Matcher: "glob",
+					Value:   "*es*",
+				},
+			},
+		},
+		toMatch: "test",
+		equals:  BeTrue(),
+	},
 }
 
 func Test_FieldMatcher(t *testing.T) {

--- a/core/matching/matchers/matcher_value_generator.go
+++ b/core/matching/matchers/matcher_value_generator.go
@@ -1,0 +1,78 @@
+package matchers
+
+import (
+	"encoding/json"
+	"reflect"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+func IdentityValueGenerator(match interface{}, toMatch string) string {
+
+	return toMatch
+}
+
+func JsonPathMatcherValueGenerator(match interface{}, toMatch string) string {
+
+	matchString := prepareJsonPathQuery(match.(string))
+
+	jsonPath := jsonpath.New("")
+
+	err := jsonPath.Parse(matchString)
+	if err != nil {
+		log.Errorf("Failed to parse json path query %s: %s", matchString, err.Error())
+		return ""
+	}
+
+	var data interface{}
+	if err := json.Unmarshal([]byte(toMatch), &data); err != nil {
+		log.Errorf("Failed to unmarshal body to JSON: %s", err.Error())
+		return ""
+	}
+
+	results, err := jsonPath.FindResults(data)
+	if err != nil {
+		log.Errorf("err to execute json path match: %s", err.Error())
+		return ""
+	}
+
+	return getResult(results)
+}
+
+func getResult(results [][]reflect.Value) string {
+	var allResultsInterface []interface{}
+	for _, result := range results {
+		for _, singleResult := range result {
+			allResultsInterface = append(allResultsInterface, singleResult.Interface())
+		}
+	}
+	if len(allResultsInterface) == 1 {
+		if _, ok := allResultsInterface[0].(string); ok {
+			return allResultsInterface[0].(string)
+		}
+		bytes, err := json.Marshal(allResultsInterface[0])
+		if err != nil {
+			log.Errorf("err to marshal %s", err.Error())
+			return ""
+		}
+		return string(bytes)
+	}
+
+	bytes, err := json.Marshal(allResultsInterface)
+	if err != nil {
+		log.Errorf("err to marshal %s", err.Error())
+		return ""
+	}
+	return string(bytes)
+}
+
+func XPathMatchValueGenerator(match interface{}, toMatch string) string {
+
+	results, err := XpathExecution(match.(string), toMatch)
+	if err != nil {
+		log.Errorf("Failed to generate xpath value: %s", err.Error())
+		return ""
+	}
+	return results.String()
+}

--- a/core/matching/matchers/matcher_value_generator_test.go
+++ b/core/matching/matchers/matcher_value_generator_test.go
@@ -1,0 +1,55 @@
+package matchers_test
+
+import (
+	"testing"
+
+	"github.com/SpectoLabs/hoverfly/core/matching/matchers"
+	. "github.com/onsi/gomega"
+)
+
+func Test_IdentityValueGenerator_ReturnsActualValue(t *testing.T) {
+	RegisterTestingT(t)
+
+	value := matchers.IdentityValueGenerator("*es*", "Test")
+	Expect(value).Should(Equal(value))
+}
+
+func Test_JsonPathValueGenerator_ReturnsStringValue(t *testing.T) {
+	RegisterTestingT(t)
+	value := matchers.JsonPathMatcherValueGenerator("$.field", `{"field": 1234}`)
+	Expect(value).Should(Equal("1234"))
+}
+
+func Test_JsonPathValueGenerator_ReturnsArrayValue(t *testing.T) {
+	RegisterTestingT(t)
+	value := matchers.JsonPathMatcherValueGenerator("$.field", `{"field":["test1","test2","test3","test4"]}`)
+	Expect(value).Should(Equal(`["test1","test2","test3","test4"]`))
+}
+
+func Test_JsonPathValueGenerator_ReturnsArrayObject(t *testing.T) {
+	RegisterTestingT(t)
+
+	value := matchers.JsonPathMatcherValueGenerator("$.field[1:3]", `{"field":[{"field1":"value1"}, {"field2":"value2"}, {"field3":"value3"}, {"field4":"value4"}]}`)
+	Expect(value).Should(Equal(`[{"field2":"value2"},{"field3":"value3"}]`))
+}
+
+func Test_JsonPathValueGenerator_ReturnsObject(t *testing.T) {
+	RegisterTestingT(t)
+
+	value := matchers.JsonPathMatcherValueGenerator("$.field", `{"field":{"key1":"value1"}}`)
+	Expect(value).Should(Equal(`{"key1":"value1"}`))
+}
+
+func Test_XPathValueGenerator_ReturnsValue(t *testing.T) {
+	RegisterTestingT(t)
+
+	value := matchers.XPathMatchValueGenerator("/document/name", "<document><id>1234</id><name>Test</name></document>")
+	Expect(value).Should(Equal(value))
+}
+
+func Test_XPathValueGenerator_ReturnsEmbeddedJson(t *testing.T) {
+	RegisterTestingT(t)
+
+	value := matchers.XPathMatchValueGenerator("/document/details", `<document><details>{"id":1234,"name":"test"}</details></document>`)
+	Expect(value).Should(Equal(`{"id":1234,"name":"test"}`))
+}

--- a/core/matching/matchers/matchers.go
+++ b/core/matching/matchers/matchers.go
@@ -4,23 +4,67 @@ type MatcherFunc func(data interface{}, toMatch string) bool
 
 type MatcherFuncWithConfig func(data interface{}, toMatch string, config map[string]interface{}) bool
 
-var Matchers = map[string]MatcherFunc{
-	// Default matcher
-	"": ExactMatch,
+/*
+	 this is called only if matcher returns true and there is chaining to feed value
+		this is set as nil for matchers where we are doing complete details match and there is no need of chaining
+*/
+type MatcherValueGenerator func(data interface{}, toMatch string) string
 
-	Exact:           ExactMatch,
-	Glob:            GlobMatch,
-	Json:            JsonMatch,
-	JsonPath:        JsonPathMatch,
-	JsonPartial:     JsonPartialMatch,
-	Regex:           RegexMatch,
-	Xml:             XmlMatch,
-	Xpath:           XpathMatch,
-	XmlTemplated:    XmlTemplatedMatch,
-	ContainsExactly: ContainsExactlyMatch,
-	Array:           ContainsExactlyMatch,
+var Matchers = map[string]MatcherDetails{
+	// Default matcher
+	"": {
+		MatcherFunction: ExactMatch,
+	},
+	Exact: {
+		MatcherFunction: ExactMatch,
+	},
+	Glob: {
+		MatcherFunction:     GlobMatch,
+		MatchValueGenerator: IdentityValueGenerator,
+	},
+	Json: {
+		MatcherFunction: JsonMatch,
+	},
+	JsonPath: {
+		MatcherFunction:     JsonPathMatch,
+		MatchValueGenerator: JsonPathMatcherValueGenerator,
+	},
+	JsonPartial: {
+		MatcherFunction:     JsonPartialMatch,
+		MatchValueGenerator: IdentityValueGenerator,
+	},
+	Regex: {
+		MatcherFunction:     RegexMatch,
+		MatchValueGenerator: IdentityValueGenerator,
+	},
+	Xml: {
+		MatcherFunction: XmlMatch,
+	},
+	Xpath: {
+		MatcherFunction:     XpathMatch,
+		MatchValueGenerator: XPathMatchValueGenerator,
+	},
+	XmlTemplated: {
+		MatcherFunction:     XmlTemplatedMatch,
+		MatchValueGenerator: IdentityValueGenerator,
+	},
+	ContainsExactly: {
+		MatcherFunction: ContainsExactlyMatch,
+	},
+	Array: {
+		MatcherFunction:     ContainsExactlyMatch,
+		MatchValueGenerator: IdentityValueGenerator,
+	},
 }
 
-var MatchersWithConfig = map[string]MatcherFuncWithConfig{
-	Array: ArrayMatch,
+type MatcherDetails struct {
+	MatcherFunction     interface{}
+	MatchValueGenerator MatcherValueGenerator
+}
+
+var MatchersWithConfig = map[string]MatcherDetails{
+	Array: {
+		MatcherFunction:     ArrayMatch,
+		MatchValueGenerator: IdentityValueGenerator,
+	},
 }

--- a/core/matching/matchers/matchers.go
+++ b/core/matching/matchers/matchers.go
@@ -13,17 +13,20 @@ type MatcherValueGenerator func(data interface{}, toMatch string) string
 var Matchers = map[string]MatcherDetails{
 	// Default matcher
 	"": {
-		MatcherFunction: ExactMatch,
+		MatcherFunction:     ExactMatch,
+		MatchValueGenerator: IdentityValueGenerator,
 	},
 	Exact: {
-		MatcherFunction: ExactMatch,
+		MatcherFunction:     ExactMatch,
+		MatchValueGenerator: IdentityValueGenerator,
 	},
 	Glob: {
 		MatcherFunction:     GlobMatch,
 		MatchValueGenerator: IdentityValueGenerator,
 	},
 	Json: {
-		MatcherFunction: JsonMatch,
+		MatcherFunction:     JsonMatch,
+		MatchValueGenerator: IdentityValueGenerator,
 	},
 	JsonPath: {
 		MatcherFunction:     JsonPathMatch,
@@ -38,7 +41,8 @@ var Matchers = map[string]MatcherDetails{
 		MatchValueGenerator: IdentityValueGenerator,
 	},
 	Xml: {
-		MatcherFunction: XmlMatch,
+		MatcherFunction:     XmlMatch,
+		MatchValueGenerator: IdentityValueGenerator,
 	},
 	Xpath: {
 		MatcherFunction:     XpathMatch,
@@ -49,7 +53,8 @@ var Matchers = map[string]MatcherDetails{
 		MatchValueGenerator: IdentityValueGenerator,
 	},
 	ContainsExactly: {
-		MatcherFunction: ContainsExactlyMatch,
+		MatcherFunction:     ContainsExactlyMatch,
+		MatchValueGenerator: IdentityValueGenerator,
 	},
 	Array: {
 		MatcherFunction:     ContainsExactlyMatch,

--- a/core/models/request_matcher.go
+++ b/core/models/request_matcher.go
@@ -12,6 +12,7 @@ type RequestFieldMatchers struct {
 	Matcher string
 	Value   interface{}
 	Config  map[string]interface{}
+	DoMatch *RequestFieldMatchers
 }
 
 func NewRequestFieldMatchersFromView(matchers []v2.MatcherViewV5) []RequestFieldMatchers {
@@ -20,13 +21,30 @@ func NewRequestFieldMatchersFromView(matchers []v2.MatcherViewV5) []RequestField
 	}
 	convertedMatchers := []RequestFieldMatchers{}
 	for _, matcher := range matchers {
+		doMatch := getDoMatchRequestFromMatcherView(matcher.DoMatch)
 		convertedMatchers = append(convertedMatchers, RequestFieldMatchers{
 			Matcher: matcher.Matcher,
 			Value:   matcher.Value,
 			Config:  matcher.Config,
+			DoMatch: doMatch,
 		})
 	}
 	return convertedMatchers
+}
+
+func getDoMatchRequestFromMatcherView(matcher *v2.MatcherViewV5) *RequestFieldMatchers {
+
+	if matcher == nil {
+		return nil
+	}
+	matcherValue := *matcher
+	return &RequestFieldMatchers{
+		Matcher: matcherValue.Matcher,
+		Value:   matcherValue.Value,
+		Config:  matcherValue.Config,
+		DoMatch: getDoMatchRequestFromMatcherView(matcherValue.DoMatch),
+	}
+
 }
 
 func NewRequestFieldMatchersFromMapView(mapMatchers map[string][]v2.MatcherViewV5) map[string][]RequestFieldMatchers {
@@ -56,10 +74,26 @@ func NewQueryRequestFieldMatchersFromMapView(mapMatchers *v2.QueryMatcherViewV5)
 }
 
 func (this RequestFieldMatchers) BuildView() v2.MatcherViewV5 {
+	doMatch := getViewFromRequestFieldMatcher(this.DoMatch)
 	return v2.MatcherViewV5{
 		Matcher: this.Matcher,
 		Value:   this.Value,
 		Config:  this.Config,
+		DoMatch: doMatch,
+	}
+}
+
+func getViewFromRequestFieldMatcher(matcher *RequestFieldMatchers) *v2.MatcherViewV5 {
+
+	if matcher == nil {
+		return nil
+	}
+	matcherValue := *matcher
+	return &v2.MatcherViewV5{
+		Matcher: matcherValue.Matcher,
+		Value:   matcherValue.Value,
+		Config:  matcherValue.Config,
+		DoMatch: getViewFromRequestFieldMatcher(matcherValue.DoMatch),
 	}
 }
 

--- a/docs/pages/keyconcepts/templating/templating.rst
+++ b/docs/pages/keyconcepts/templating/templating.rst
@@ -177,11 +177,19 @@ Example date time formats
     - ``epoch``: UNIX timestamp in milliseconds
 
 
+Conditional Templating, Looping and More
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Hoverfly uses the https://github.com/aymerick/raymond library for templating, which is based on http://handlebarsjs.com/
+
+To learn about more advanced templating functionality, such as looping and conditionals, read the documentation for these projects.
+
 Global Literals and Variables
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 We can define global literals and variables which can be used in any of responses. 
 
 Literals
+~~~~~~~~
 
 - Format to define literals under data is as follow. 
 
@@ -210,6 +218,7 @@ Literals
 
 
 Variables
+~~~~~~~~~
 
 - Format to define variables under data is as follow. 
 
@@ -256,6 +265,7 @@ Variables
     }
 
 Getting data for defined Literals and Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Defined literals and variables can be accessed in any of responses using below way via templating.
 
@@ -264,11 +274,3 @@ Defined literals and variables can be accessed in any of responses using below w
 +-----------+-------------------------------------+
 | Variables | {{Vars.<variable name>}}            |
 +-----------+-------------------------------------+
-
-
-Conditional Templating, Looping and More
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Hoverfly uses the https://github.com/aymerick/raymond library for templating, which is based on http://handlebarsjs.com/
-
-To learn about more advanced templating functionality, such as looping and conditionals, read the documentation for these projects.

--- a/docs/pages/reference/hoverfly/request_matchers.rst
+++ b/docs/pages/reference/hoverfly/request_matchers.rst
@@ -589,12 +589,12 @@ Matcher Chaining
 
 - It can be combine any of matchers.
 
-
 For an example, with matcher chaining, one can use JSONPath to get a JSON node, and use other matcher to compare its value as mentioned below. 
 
 Example
 """""""
 .. code:: json
+    
     "matcher":<any matcher>,
     "value":?,
     "doMatch": {

--- a/docs/pages/reference/hoverfly/request_matchers.rst
+++ b/docs/pages/reference/hoverfly/request_matchers.rst
@@ -579,3 +579,38 @@ Example
             "order:latest",
             "profile:vd"
     ]
+
+Matcher Chaining
+----------------
+
+- Matcher chaining helps to chain multiple matchers. MatchedValue of parent matcher is feed into child matcher and further matching is done.
+  
+- It typically removes the stress of composing and testing complex expressions and make matchers more readable.
+
+- It can be combine any of matchers.
+
+
+For an example, with matcher chaining, one can use JSONPath to get a JSON node, and use other matcher to compare its value as mentioned below. 
+
+Example
+"""""""
+.. code:: json
+    "matcher":<any matcher>,
+    "value":?,
+    "doMatch": {
+        "matcher": <any matcher>
+        "value":?
+    }
+
+    {
+        body : [
+            {
+                "matcher": "jsonpath",
+                "value": "$.user.id",
+                "doMatch": {
+                    matcher: "exact",
+                    value: "1"
+                }
+            }
+        ]
+


### PR DESCRIPTION
Resolves #761. Different way of implementation but following same approach as followed in PR #1035 

PR contains changes for implementing matcher chaining. Any matcher can be combined with any of the other matchers. Output/matched value of one matcher is feed into other matcher mentioned in do match. If this PR looks fine then I will add documentation. 

`{
body: [
{
matcher: "jsonpath"
value: “$.user.id"
domatch: {
matcher: “exact”,
value: “1"
}
]
}

"body": [
{
"matcher": "xpath",
"value": "/root/id",
"domatch": {
"matcher": "exact",
"value": "123"
}
}
]
`