### PR TITLE
Make array matcher to be used by matcher chaining and upgrade schema to v5.2

### DIFF
--- a/core/handlers/v2/simulation_views.go
+++ b/core/handlers/v2/simulation_views.go
@@ -8,7 +8,7 @@ import (
 
 	"strings"
 
-	"github.com/SpectoLabs/hoverfly/core/handlers/v1"
+	v1 "github.com/SpectoLabs/hoverfly/core/handlers/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -130,7 +130,7 @@ type MetaView struct {
 func NewMetaView(version string) *MetaView {
 	return &MetaView{
 		HoverflyVersion: version,
-		SchemaVersion:   "v5.1",
+		SchemaVersion:   "v5.2",
 		TimeExported:    time.Now().Format(time.RFC3339),
 	}
 }

--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -171,26 +171,23 @@ var fieldMatcherTests = []fieldMatcherTest{
 		equals:  BeTrue(),
 	},
 	{
-		name: "MatcherChaining2",
+		name: "MatcherChaining3",
 		matchers: []models.RequestFieldMatchers{
 			{
-				Matcher: "xpath",
-				Value:   "/document/details",
+				Matcher: "jsonpath",
+				Value:   "$.testArr",
 				DoMatch: &models.RequestFieldMatchers{
-					Matcher: "jsonpath",
-					Value:   "$.name",
-					DoMatch: &models.RequestFieldMatchers{
-						Matcher: "glob",
-						Value:   "*es*",
-						DoMatch: &models.RequestFieldMatchers{
-							Matcher: "exact",
-							Value:   "Test",
-						},
+					Matcher: "array",
+					Value:   []string{"q1", "q2", "q3"},
+					Config: map[string]interface{}{
+						matchers.IGNORE_OCCURRENCES: false,
+						matchers.IGNORE_ORDER:       false,
+						matchers.IGNORE_UNKNOWN:     false,
 					},
 				},
 			},
 		},
-		toMatch: `<document><details>{"name":"Test", "id":"12345"}</details></document>`,
+		toMatch: `{"testArr":["q1", "q2", "q3"]}`,
 		equals:  BeTrue(),
 	},
 }

--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -170,6 +170,29 @@ var fieldMatcherTests = []fieldMatcherTest{
 		toMatch: "<document><id>12345</id><name>Test</name></document>",
 		equals:  BeTrue(),
 	},
+        {
+		name: "MatcherChaining2",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: "xpath",
+				Value:   "/document/details",
+				DoMatch: &models.RequestFieldMatchers{
+					Matcher: "jsonpath",
+					Value:   "$.name",
+					DoMatch: &models.RequestFieldMatchers{
+						Matcher: "glob",
+						Value:   "*es*",
+						DoMatch: &models.RequestFieldMatchers{
+							Matcher: "exact",
+							Value:   "Test",
+						},
+					},
+				},
+			},
+		},
+		toMatch: `<document><details>{"name":"Test", "id":"12345"}</details></document>`,
+		equals:  BeTrue(),
+	},
 	{
 		name: "MatcherChaining3",
 		matchers: []models.RequestFieldMatchers{

--- a/core/matching/matchers/array_match.go
+++ b/core/matching/matchers/array_match.go
@@ -1,9 +1,11 @@
 package matchers
 
 import (
-	"strings"
+	"encoding/json"
+	"fmt"
 
 	"github.com/SpectoLabs/hoverfly/core/util"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -19,7 +21,10 @@ func ArrayMatch(match interface{}, toMatch string, config map[string]interface{}
 	if !ok {
 		return false
 	}
-	toMatchArr := strings.Split(toMatch, ";")
+	toMatchArr, err := unMarshalArray(toMatch)
+	if err != nil {
+		return false
+	}
 	ignoreUnknown := util.GetBoolOrDefault(config, IGNORE_UNKNOWN, false)
 	ignoreOrder := util.GetBoolOrDefault(config, IGNORE_ORDER, false)
 	ignoreOccurrences := util.GetBoolOrDefault(config, IGNORE_OCCURRENCES, false)
@@ -29,6 +34,19 @@ func ArrayMatch(match interface{}, toMatch string, config map[string]interface{}
 		(ignoreOrder || isInSameOrder(matchStringArr, toMatchArr))
 }
 
+func unMarshalArray(jsonArrStr string) ([]string, error) {
+
+	var arr []interface{}
+	if err := json.Unmarshal([]byte(jsonArrStr), &arr); err != nil {
+		log.Errorf("Cannot unmarshal to array %s", err.Error())
+		return []string{}, err
+	}
+	var strArr []string
+	for _, value := range arr {
+		strArr = append(strArr, fmt.Sprint(value))
+	}
+	return strArr, nil
+}
 func hasSameNoOfOccurrences(matchGroup, toMatch []string) bool {
 
 	matchGroupSet := make(map[string]int)

--- a/core/matching/matchers/array_match_test.go
+++ b/core/matching/matchers/array_match_test.go
@@ -19,7 +19,16 @@ func Test_ArrayMatch_ReturnsTrueWithIdenticalArray(t *testing.T) {
 
 	configMap := getConfiguration(false, false, false)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q2;q3", configMap)).To(BeTrue())
+	Expect(matchers.ArrayMatch(arr[:], `["q1", "q2", "q3"]`, configMap)).To(BeTrue())
+}
+
+func Test_ArrayMatch_ReturnsTrueWithIdenticalIntegerArray(t *testing.T) {
+	RegisterTestingT(t)
+
+	configMap := getConfiguration(false, false, false)
+	arr := [3]string{"1", "2", "3"}
+	isMatched := matchers.ArrayMatch(arr[:], `[1, 2, 3]`, configMap)
+	Expect(isMatched).To(BeTrue())
 }
 
 func Test_ArrayMatch_ReturnsTrueWithAllKnownsInArrayAndNotIgnoringUnkowns(t *testing.T) {
@@ -27,14 +36,14 @@ func Test_ArrayMatch_ReturnsTrueWithAllKnownsInArrayAndNotIgnoringUnkowns(t *tes
 
 	configMap := getConfiguration(false, true, true)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q2;q1;q3", configMap)).To(BeTrue())
+	Expect(matchers.ArrayMatch(arr[:], `["q1","q3","q2","q1","q3"]`, configMap)).To(BeTrue())
 }
 func Test_ArrayMatch_ReturnsFalseWithUnkownsInArrayAndNotIgnoringUnkowns(t *testing.T) {
 	RegisterTestingT(t)
 
 	configMap := getConfiguration(false, true, true)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q4;q3;q2", configMap)).To(BeFalse())
+	Expect(matchers.ArrayMatch(arr[:], `["q1", "q4", "q3", "q2"]`, configMap)).To(BeFalse())
 }
 
 func Test_ArrayMatch_ReturnsTrueWithInSameOrderAndNotIgnoringOrder(t *testing.T) {
@@ -42,7 +51,7 @@ func Test_ArrayMatch_ReturnsTrueWithInSameOrderAndNotIgnoringOrder(t *testing.T)
 
 	configMap := getConfiguration(true, true, false)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q2;q3;q2;q4", configMap)).To(BeTrue())
+	Expect(matchers.ArrayMatch(arr[:], `["q1","q2","q3","q2","q4"]`, configMap)).To(BeTrue())
 }
 
 func Test_ArrayMatch_ReturnsFalseWithOutOfOrderAndNotIgnoringOrder(t *testing.T) {
@@ -50,7 +59,7 @@ func Test_ArrayMatch_ReturnsFalseWithOutOfOrderAndNotIgnoringOrder(t *testing.T)
 
 	configMap := getConfiguration(true, true, false)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q3;q2;q4", configMap)).To(BeFalse())
+	Expect(matchers.ArrayMatch(arr[:], `["q1","q3","q3","q2","q4"]`, configMap)).To(BeFalse())
 }
 
 func Test_ArrayMatch_ReturnsTrueWithSameOccurrencesAndNotIgnoringOccurrences(t *testing.T) {
@@ -58,7 +67,7 @@ func Test_ArrayMatch_ReturnsTrueWithSameOccurrencesAndNotIgnoringOccurrences(t *
 
 	configMap := getConfiguration(true, false, true)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q0;q2;q4", configMap)).To(BeTrue())
+	Expect(matchers.ArrayMatch(arr[:], `["q1","q3","q0","q2","q4"]`, configMap)).To(BeTrue())
 }
 
 func Test_ArrayMatch_ReturnsFalseWithDifferentNoOfOccurrencesAndNotIgnoringOccurrences(t *testing.T) {
@@ -66,7 +75,7 @@ func Test_ArrayMatch_ReturnsFalseWithDifferentNoOfOccurrencesAndNotIgnoringOccur
 
 	configMap := getConfiguration(true, false, true)
 	arr := [3]string{"q1", "q2", "q3"}
-	Expect(matchers.ArrayMatch(arr[:], "q1;q3;q3;q2;q4", configMap)).To(BeFalse())
+	Expect(matchers.ArrayMatch(arr[:], `["q1","q3","q3","q2","q4"]`, configMap)).To(BeFalse())
 }
 
 func getConfiguration(ignoreUnknown, ignoreOccurrences, ignoreOrder bool) map[string]interface{} {

--- a/core/matching/query_matching.go
+++ b/core/matching/query_matching.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/SpectoLabs/hoverfly/core/models"
+	"github.com/SpectoLabs/hoverfly/core/util"
 )
 
 func QueryMatching(requestMatcher models.RequestMatcher, toMatch map[string][]string) *FieldMatch {
@@ -45,7 +46,7 @@ func QueryMatching(requestMatcher models.RequestMatcher, toMatch map[string][]st
 			continue
 		}
 
-		fieldMatch := FieldMatcher(matcherQueryValue, strings.Join(toMatchQueryValues, ";"))
+		fieldMatch := FieldMatcher(matcherQueryValue, getStringToBePassedForMatching(toMatchQueryValues))
 		matcherHeaderValueMatched = fieldMatch.Matched
 		score += fieldMatch.Score
 
@@ -58,4 +59,16 @@ func QueryMatching(requestMatcher models.RequestMatcher, toMatch map[string][]st
 		Matched: matched,
 		Score:   score,
 	}
+}
+
+func getStringToBePassedForMatching(strArr []string) string {
+
+	if len(strArr) <= 1 {
+		return strings.Join(strArr, ";")
+	}
+	byteArr, err := util.JSONMarshal(strArr)
+	if err != nil {
+		return strings.Join(strArr, ";")
+	}
+	return string(byteArr[:])
 }

--- a/core/util/util.go
+++ b/core/util/util.go
@@ -306,7 +306,7 @@ func ContainsOnly(first, second []string) bool {
 
 func GetStringArray(data interface{}) ([]string, bool) {
 	val := reflect.ValueOf(data)
-	if val.Kind() != reflect.Slice {
+	if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {
 		return nil, false
 	}
 	var dataArr []string


### PR DESCRIPTION
@tommysitu  As of now, FieldMatcher takes the toMatch value as a semi-colon delimited string as one of the arguments. ArrayMatcher internally splits the string and again converts it back to an array. It was fine till now. 

But after introducing matcher chaining, there might be a scenario where the user first matches via JSON path and get value as JSON array and now wants to use array matcher to do further matching. To incorporate that scenario, I have made the necessary changes. I have passed json string array to FieldMatcher from QueryMatching as of now. As the probability of more than one value for same name is there for queries. Later, we can think of doing from other places as well. Also, none of other matchers apart from ArrayMatcher is splitting string and converting into array.

Also, as part of this PR, I upgraded simulation schema version to 5.2