### PR TITLE
feature - JWT matcher

### DIFF
--- a/core/matching/field_matcher_test.go
+++ b/core/matching/field_matcher_test.go
@@ -193,6 +193,17 @@ var fieldMatcherTests = []fieldMatcherTest{
 		toMatch: `<document><details>{"name":"Test", "id":"12345"}</details></document>`,
 		equals:  BeTrue(),
 	},
+	{
+		name: "TestJwtMatcher",
+		matchers: []models.RequestFieldMatchers{
+			{
+				Matcher: "jwt",
+				Value:   `{"header":{"alg":"HS256"},"payload":{"sub":"1234567890","name":"John Doe"}}`,
+			},
+		},
+		toMatch: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`,
+		equals:  BeTrue(),
+	},
 }
 
 func Test_FieldMatcher(t *testing.T) {

--- a/core/matching/matchers/jwt_match.go
+++ b/core/matching/matchers/jwt_match.go
@@ -13,17 +13,16 @@ var JWT = "jwt"
 
 func JwtMatcher(data interface{}, toMatch string) bool {
 
-	jwt, err := GetJWT(toMatch)
+	jwt, err := ParseJWT(toMatch)
 	if err != nil {
 		log.Errorf("Error occurred while fetching jwt token %s", err.Error())
 		return false
 	}
-	fmt.Println(jwt)
 	return JsonPartialMatch(data, jwt)
 
 }
 
-func GetJWT(str string) (string, error) {
+func ParseJWT(str string) (string, error) {
 	toMatchArr := strings.Split(str, ".")
 	if len(toMatchArr) != 3 {
 		//invalid json token

--- a/core/matching/matchers/jwt_match.go
+++ b/core/matching/matchers/jwt_match.go
@@ -1,0 +1,59 @@
+package matchers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var JWT = "jwt"
+
+func JwtMatcher(data interface{}, toMatch string) bool {
+
+	jwt, err := GetJWT(toMatch)
+	if err != nil {
+		log.Errorf("Error occurred while fetching jwt token %s", err.Error())
+		return false
+	}
+	fmt.Println(jwt)
+	return JsonPartialMatch(data, jwt)
+
+}
+
+func GetJWT(str string) (string, error) {
+	toMatchArr := strings.Split(str, ".")
+	if len(toMatchArr) != 3 {
+		//invalid json token
+		return "", fmt.Errorf("invalid json token passed %s", str)
+	}
+	jwtToken := make(map[string]interface{})
+	if header, err := GetDecodedJsonData(toMatchArr[0]); err == nil {
+		jwtToken["header"] = header
+	}
+	if payload, err := GetDecodedJsonData(toMatchArr[1]); err == nil {
+		jwtToken["payload"] = payload
+	}
+	if jsonByteArr, err := json.Marshal(jwtToken); err == nil {
+		return string(jsonByteArr), nil
+	} else {
+		return "", err
+	}
+
+}
+
+func GetDecodedJsonData(str string) (interface{}, error) {
+
+	strByteArr, err := base64.RawURLEncoding.DecodeString(str)
+	if err != nil {
+		log.Errorf("Error occurred while decoding jwt part %s", str)
+		return nil, err
+	}
+	var jsonData interface{}
+	if err := json.Unmarshal(strByteArr, &jsonData); err != nil {
+		return nil, err
+	}
+	return jsonData, nil
+}

--- a/core/matching/matchers/jwt_match_test.go
+++ b/core/matching/matchers/jwt_match_test.go
@@ -1,0 +1,28 @@
+package matchers_test
+
+import (
+	"testing"
+
+	"github.com/SpectoLabs/hoverfly/core/matching/matchers"
+	. "github.com/onsi/gomega"
+)
+
+func TestJwtMatcher_ReturnsFalseForInvalidJwtToken(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JwtMatcher("value", "apple")).To(BeFalse())
+}
+
+func TestJwtMatcher_ReturnsTrue_ValidTokenWithMatchingValue(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JwtMatcher(`{"header":{"alg":"HS256"},"payload":{"sub":"1234567890","name":"John Doe"}}`,
+		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).To(BeTrue())
+}
+
+func TestJwtMatcher_ReturnsFalse_ValidTokenWithDifferentMatcherValue(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JwtMatcher(`{"header":{"alg":"HS256"},"payload":{"sub":"123416767890","name":"JohnDoe"}}`,
+		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).To(BeFalse())
+}

--- a/core/matching/matchers/matcher_value_generator.go
+++ b/core/matching/matchers/matcher_value_generator.go
@@ -79,10 +79,10 @@ func XPathMatchValueGenerator(match interface{}, toMatch string) string {
 
 func JwtMatchValueGenerator(match interface{}, toMatch string) string {
 
-	if jwt, err := GetJWT(toMatch); err == nil {
+	if jwt, err := ParseJWT(toMatch); err == nil {
 		return jwt
 	} else {
-		log.Errorf("Failed to generate jwt value %s", err.Error())
+		log.Errorf("Failed to parse JWT %s", err.Error())
 		return ""
 	}
 }

--- a/core/matching/matchers/matcher_value_generator.go
+++ b/core/matching/matchers/matcher_value_generator.go
@@ -76,3 +76,13 @@ func XPathMatchValueGenerator(match interface{}, toMatch string) string {
 	}
 	return results.String()
 }
+
+func JwtMatchValueGenerator(match interface{}, toMatch string) string {
+
+	if jwt, err := GetJWT(toMatch); err == nil {
+		return jwt
+	} else {
+		log.Errorf("Failed to generate jwt value %s", err.Error())
+		return ""
+	}
+}

--- a/core/matching/matchers/matcher_value_generator_test.go
+++ b/core/matching/matchers/matcher_value_generator_test.go
@@ -53,3 +53,10 @@ func Test_XPathValueGenerator_ReturnsEmbeddedJson(t *testing.T) {
 	value := matchers.XPathMatchValueGenerator("/document/details", `<document><details>{"id":1234,"name":"test"}</details></document>`)
 	Expect(value).Should(Equal(`{"id":1234,"name":"test"}`))
 }
+
+func TestJwtMatchValueGenerator_ReturnsJWTAsJson(t *testing.T) {
+	RegisterTestingT(t)
+	value := matchers.JwtMatchValueGenerator(`{"header":{"alg":"HS256"},"payload":{"sub":"1234567890","name":"John Doe"}}`,
+		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+	Expect(value).Should(Equal(`{"header":{"alg":"HS256","typ":"JWT"},"payload":{"iat":1516239022,"name":"John Doe","sub":"1234567890"}}`))
+}

--- a/core/matching/matchers/matchers.go
+++ b/core/matching/matchers/matchers.go
@@ -60,6 +60,10 @@ var Matchers = map[string]MatcherDetails{
 		MatcherFunction:     ContainsExactlyMatch,
 		MatchValueGenerator: IdentityValueGenerator,
 	},
+	JWT: {
+		MatcherFunction:     JwtMatcher,
+		MatchValueGenerator: JwtMatchValueGenerator,
+	},
 }
 
 type MatcherDetails struct {

--- a/docs/pages/reference/hoverfly/request_matchers.rst
+++ b/docs/pages/reference/hoverfly/request_matchers.rst
@@ -590,9 +590,6 @@ Matcher value contains only keys that they want to match in JWT.
 Example
 """""""
     .. code:: json
-        
-        "matcher": "jwt"
-        "value": "?"
 
         "matcher": "jwt"
         "value": "{\"header\":{\"alg\":\"HS256\"},\"payload\":{\"sub\":\"1234567890\",\"name\":\"John Doe\"}}"

--- a/docs/pages/reference/hoverfly/request_matchers.rst
+++ b/docs/pages/reference/hoverfly/request_matchers.rst
@@ -580,6 +580,24 @@ Example
             "profile:vd"
     ]
 
+JWT Matcher
+-----------
+
+This matcher is primarily used for matching JWT tokens. This matcher converts base64 encoded JWT to JSON document ({"header": {}, "payload": ""}) and does partial match with the matcher value. 
+
+Matcher value contains only keys that they want to match in JWT.
+
+Example
+"""""""
+    .. code:: json
+        
+        "matcher": "jwt"
+        "value": "?"
+
+        "matcher": "jwt"
+        "value": "{\"header\":{\"alg\":\"HS256\"},\"payload\":{\"sub\":\"1234567890\",\"name\":\"John Doe\"}}"
+
+
 Matcher Chaining
 ----------------
 


### PR DESCRIPTION
Resolves #902 

JWT Matcher
-----------

This matcher is primarily used for matching JWT tokens. This matcher converts base64 encoded JWT to JSON document ({"header": {}, "payload": ""}) and does partial match with the matcher value. 

Matcher value contains only keys that they want to match in JWT.

Example
"""""""
    .. code:: json
        
        "matcher": "jwt"
        "value": "?"

        "matcher": "jwt"
        "value": "{\"header\":{\"alg\":\"HS256\"},\"payload\":{\"sub\":\"1234567890\",\"name\":\"John Doe\"}}"

@tommysitu  you can review feature for JWT Matcher. Tested once and added necessary documentation.