### PR TITLE
chore: fix tests for latest darwin

### DIFF
--- a/functional-tests/core/ft_tls_verification_test.go
+++ b/functional-tests/core/ft_tls_verification_test.go
@@ -50,7 +50,10 @@ var _ = Describe("When I run Hoverfly", func() {
 
 			Expect(string(responseBody)).To(ContainSubstring("Hoverfly Error!"))
 			Expect(string(responseBody)).To(ContainSubstring("There was an error when forwarding the request to the intended destination"))
-			Expect(string(responseBody)).To(ContainSubstring("x509: certificate signed by unknown authority"))
+			Expect(string(responseBody)).To(SatisfyAny(
+				ContainSubstring("certificate is not trusted"),
+				ContainSubstring("x509: certificate signed by unknown authority")),
+			)
 		})
 	})
 
@@ -79,7 +82,10 @@ var _ = Describe("When I run Hoverfly", func() {
 
 			Expect(string(responseBody)).To(ContainSubstring("Hoverfly Error!"))
 			Expect(string(responseBody)).To(ContainSubstring("There was an error when forwarding the request to the intended destination"))
-			Expect(string(responseBody)).To(ContainSubstring("x509: certificate signed by unknown authority"))
+			Expect(string(responseBody)).To(SatisfyAny(
+				ContainSubstring("certificate is not trusted"),
+				ContainSubstring("x509: certificate signed by unknown authority")),
+			)
 		})
 	})
 

--- a/functional-tests/core/ft_tls_verification_test.go
+++ b/functional-tests/core/ft_tls_verification_test.go
@@ -4,9 +4,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 
-	"github.com/SpectoLabs/hoverfly/functional-tests"
+	functional_tests "github.com/SpectoLabs/hoverfly/functional-tests"
 	"github.com/dghubble/sling"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -51,11 +50,7 @@ var _ = Describe("When I run Hoverfly", func() {
 
 			Expect(string(responseBody)).To(ContainSubstring("Hoverfly Error!"))
 			Expect(string(responseBody)).To(ContainSubstring("There was an error when forwarding the request to the intended destination"))
-			if runtime.GOOS == "darwin" {
-				Expect(string(responseBody)).To(ContainSubstring("certificate is not trusted"))
-			} else {
-				Expect(string(responseBody)).To(ContainSubstring("x509: certificate signed by unknown authority"))
-			}
+			Expect(string(responseBody)).To(ContainSubstring("x509: certificate signed by unknown authority"))
 		})
 	})
 
@@ -84,12 +79,7 @@ var _ = Describe("When I run Hoverfly", func() {
 
 			Expect(string(responseBody)).To(ContainSubstring("Hoverfly Error!"))
 			Expect(string(responseBody)).To(ContainSubstring("There was an error when forwarding the request to the intended destination"))
-			if runtime.GOOS == "darwin" {
-				Expect(string(responseBody)).To(ContainSubstring("certificate is not trusted"))
-			} else {
-				Expect(string(responseBody)).To(ContainSubstring("x509: certificate signed by unknown authority"))
-			}
-
+			Expect(string(responseBody)).To(ContainSubstring("x509: certificate signed by unknown authority"))
 		})
 	})
 


### PR DESCRIPTION
Tests are failing in the latest macOs (Ventura 13.1)

```shell
•2023/01/28 18:59:09 http: TLS handshake error from 127.0.0.1:58222: remote error: tls: bad certificate

------------------------------
• Failure [0.126 seconds]
When I run Hoverfly
/Users/kostas/Projects/forks/hoverfly/functional-tests/core/ft_tls_verification_test.go:15
  tls-verification=true
  /Users/kostas/Projects/forks/hoverfly/functional-tests/core/ft_tls_verification_test.go:62
    should not error with https with bad certificate [It]
    /Users/kostas/Projects/forks/hoverfly/functional-tests/core/ft_tls_verification_test.go:69

    Expected
        <string>: Hoverfly Error!

        There was an error when forwarding the request to the intended destination

        Got error: Get "https://127.0.0.1:58143/": x509: certificate signed by unknown authority
    to contain substring
        <string>: certificate is not trusted

    /Users/kostas/Projects/forks/hoverfly/functional-tests/core/ft_tls_verification_test.go:88
------------------------------
•••••••••••••••••••2023/01/28 18:59:11 http: TLS handshake error from 127.0.0.1:58848: remote error: tls: bad certificate
••••2023/01/28 18:59:12 http: TLS handshake error from 127.0.0.1:58890: remote error: tls: bad certificate
••••••••••••••••••••••••••••••••••••••
```