### PR TITLE
parse form drains request body

### DIFF
--- a/core/models/payload.go
+++ b/core/models/payload.go
@@ -68,13 +68,14 @@ type RequestDetails struct {
 }
 
 func NewRequestDetailsFromHttpRequest(req *http.Request) (RequestDetails, error) {
-	req.ParseForm()
+
 	if req.Body == nil {
 		req.Body = ioutil.NopCloser(bytes.NewBuffer([]byte("")))
 	}
 
 	reqBody, err := util.GetRequestBody(req)
 
+	req.ParseForm()
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err.Error(),

--- a/core/models/payload_test.go
+++ b/core/models/payload_test.go
@@ -5,9 +5,11 @@ import (
 	"compress/gzip"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"net/http"
+	"net/url"
 
 	v2 "github.com/SpectoLabs/hoverfly/core/handlers/v2"
 	"github.com/SpectoLabs/hoverfly/core/models"
@@ -227,6 +229,21 @@ func Test_NewRequestDetailsFromHttpRequest_SortsQueryString(t *testing.T) {
 	Expect(requestDetails.QueryString()).To(Equal("a=a&a=b"))
 }
 
+func Test_NewRequestDetailsFromHttpRequest_WithFormDataHavingNonEmptyBody(t *testing.T) {
+	RegisterTestingT(t)
+	form := url.Values{}
+	form.Add("key1", "value1")
+	form.Add("key2", "value2")
+	request, _ := http.NewRequest("POST", "http://test.org", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	requestDetails, err := models.NewRequestDetailsFromHttpRequest(request)
+	Expect(err).To(BeNil())
+
+	Expect(requestDetails.FormData).To(HaveLen(2))
+	Expect(requestDetails.FormData["key1"][0]).To(Equal("value1"))
+	Expect(requestDetails.FormData["key2"][0]).To(Equal("value2"))
+	Expect(requestDetails.Body).NotTo(Equal(""))
+}
 func Test_NewRequestDetailsFromHttpRequest_StripsArbitaryGolangColonEscaping(t *testing.T) {
 	RegisterTestingT(t)
 	request, _ := http.NewRequest("GET", "http://test.org/?a=b:c", nil)


### PR DESCRIPTION
@tommysitu could you please review this PR

Fixes #1066 

we recently upgraded the Go version which has caused this. In the newer version of Go, if we do request.ParseForm then it automatically drains the request.Body. While reconstructing the request, we are sending an empty body. 

https://stackoverflow.com/questions/23773183/why-does-request-parseform-drain-the-request-body
https://groups.google.com/g/golang-nuts/c/mhiYjEymNDU