### PR TITLE
Optimise and Refactor code to marshal/unmarshal form matcher value

### DIFF
--- a/core/hoverfly_funcs.go
+++ b/core/hoverfly_funcs.go
@@ -312,7 +312,7 @@ func (hf *Hoverfly) Save(request *models.RequestDetails, response *models.Respon
 		}
 	} else if contentType == "form" {
 		if len(request.FormData) > 0 {
-			form := make(map[string]interface{})
+			form := make(map[string][]models.RequestFieldMatchers)
 			for formKey, formValue := range request.FormData {
 				form[formKey] = []models.RequestFieldMatchers{
 					{

--- a/core/matching/body_formdata_matchin_test.go
+++ b/core/matching/body_formdata_matchin_test.go
@@ -1,7 +1,6 @@
 package matching_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/SpectoLabs/hoverfly/core/matching"
@@ -59,11 +58,11 @@ var bodyMatchingTests = []bodyMatchingTest{
 		matchers: []models.RequestFieldMatchers{
 			{
 				Matcher: "form",
-				Value: map[string]interface{}{
-					"name": []map[string]interface{}{
+				Value: map[string][]models.RequestFieldMatchers{
+					"name": {
 						{
-							"matcher": matchers.Exact,
-							"value":   "foo",
+							Matcher: matchers.Exact,
+							Value:   "foo",
 						},
 					},
 				},
@@ -79,11 +78,11 @@ var bodyMatchingTests = []bodyMatchingTest{
 		matchers: []models.RequestFieldMatchers{
 			{
 				Matcher: "form",
-				Value: map[string]interface{}{
-					"name": []map[string]interface{}{
+				Value: map[string][]models.RequestFieldMatchers{
+					"name": {
 						{
-							"matcher": matchers.Exact,
-							"value":   "foo",
+							Matcher: matchers.Exact,
+							Value:   "foo",
 						},
 					},
 				},
@@ -100,7 +99,6 @@ func Test_BodyMatching(t *testing.T) {
 	RegisterTestingT(t)
 
 	for _, test := range bodyMatchingTests {
-		fmt.Println("Test matchers is ", test.matchers)
 		result := matching.BodyMatching(test.matchers, test.toMatch)
 
 		Expect(result.Matched).To(test.equals, test.name)

--- a/core/matching/body_formdata_matching.go
+++ b/core/matching/body_formdata_matching.go
@@ -1,8 +1,6 @@
 package matching
 
 import (
-	"encoding/json"
-
 	"github.com/SpectoLabs/hoverfly/core/models"
 )
 
@@ -22,7 +20,7 @@ func BodyMatching(fields []models.RequestFieldMatchers, req models.RequestDetail
 	for _, field := range fields {
 		if field.Matcher == "form" {
 			hasForm = true
-			formMatchers := field.Value.(map[string]interface{})
+			formMatchers := field.Value.(map[string][]models.RequestFieldMatchers)
 			formMatched := processFormMatcher(formMatchers, req.FormData)
 			if !formMatched.Matched {
 				matched = false
@@ -44,20 +42,17 @@ func BodyMatching(fields []models.RequestFieldMatchers, req models.RequestDetail
 	}
 }
 
-func processFormMatcher(formFields map[string]interface{}, formData map[string][]string) *FieldMatch {
+func processFormMatcher(formFields map[string][]models.RequestFieldMatchers, formData map[string][]string) *FieldMatch {
 	matched := true
 	var score int
 
-	var matchers []models.RequestFieldMatchers
 	for formField, formMatchers := range formFields {
 		formValue, ok := formData[formField]
 		if !ok {
 			matched = false
 			continue
 		}
-		marshaledFormMatchers, _ := json.Marshal(formMatchers)
-		json.Unmarshal(marshaledFormMatchers, &matchers)
-		formMatched := FieldMatcher(matchers, formValue[0])
+		formMatched := FieldMatcher(formMatchers, formValue[0])
 		if !formMatched.Matched {
 			matched = false
 		}

--- a/core/models/request_matcher.go
+++ b/core/models/request_matcher.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"net/url"
 
 	v2 "github.com/SpectoLabs/hoverfly/core/handlers/v2"
@@ -22,14 +23,40 @@ func NewRequestFieldMatchersFromView(matchers []v2.MatcherViewV5) []RequestField
 	convertedMatchers := []RequestFieldMatchers{}
 	for _, matcher := range matchers {
 		doMatch := getDoMatchRequestFromMatcherView(matcher.DoMatch)
+		value := getValueFromMatcherView(&matcher)
 		convertedMatchers = append(convertedMatchers, RequestFieldMatchers{
 			Matcher: matcher.Matcher,
-			Value:   matcher.Value,
+			Value:   value,
 			Config:  matcher.Config,
 			DoMatch: doMatch,
 		})
 	}
 	return convertedMatchers
+}
+
+func getValueFromMatcherView(matcher *v2.MatcherViewV5) interface{} {
+
+	if matcher.Matcher == "form" {
+		formFieldsMap, ok := matcher.Value.(map[string]interface{})
+		if !ok {
+			//return default value incase of any issue
+			return matcher.Value
+		}
+		returnValue := make(map[string][]RequestFieldMatchers)
+		for formField, formMatchers := range formFieldsMap {
+			marshalledFormMatcherValue, _ := json.Marshal(formMatchers)
+			var matchers []RequestFieldMatchers
+			err := json.Unmarshal(marshalledFormMatcherValue, &matchers)
+			if err != nil {
+				//return default value incase of any issue
+				return matcher.Value
+			}
+			returnValue[formField] = matchers
+		}
+		return returnValue
+	} else {
+		return matcher.Value
+	}
 }
 
 func getDoMatchRequestFromMatcherView(matcher *v2.MatcherViewV5) *RequestFieldMatchers {
@@ -75,11 +102,30 @@ func NewQueryRequestFieldMatchersFromMapView(mapMatchers *v2.QueryMatcherViewV5)
 
 func (this RequestFieldMatchers) BuildView() v2.MatcherViewV5 {
 	doMatch := getViewFromRequestFieldMatcher(this.DoMatch)
+	value := getValueFromRequestFieldMatcher(&this)
 	return v2.MatcherViewV5{
 		Matcher: this.Matcher,
-		Value:   this.Value,
+		Value:   value,
 		Config:  this.Config,
 		DoMatch: doMatch,
+	}
+}
+
+func getValueFromRequestFieldMatcher(matcher *RequestFieldMatchers) interface{} {
+
+	if matcher.Matcher == "form" {
+		formFieldMatchers := matcher.Value.(map[string][]RequestFieldMatchers)
+		returnValue := make(map[string][]v2.MatcherViewV5)
+		for formField, matchers := range formFieldMatchers {
+			var matchersView []v2.MatcherViewV5
+			for _, matcher := range matchers {
+				matchersView = append(matchersView, matcher.BuildView())
+			}
+			returnValue[formField] = matchersView
+		}
+		return returnValue
+	} else {
+		return matcher.Value
 	}
 }
 


### PR DESCRIPTION
@tommysitu could you please review this PR. It fixes an issue with the form matcher value as you reported.

"body": [
{
"matcher": "form",
"value": {
"json": [
{
"Matcher": "exact",
"Value": "{\"key\":\"value\"}",
"Config": null,
"DoMatch": null
}
]
}
}
]
```