### PR TITLE
docs: update install code for MacOS

### DIFF
--- a/docs/pages/introduction/downloadinstallation.rst
+++ b/docs/pages/introduction/downloadinstallation.rst
@@ -20,7 +20,7 @@ If you have `homebrew <http://brew.sh/>`_, you can install Hoverfly using the ``
 
 .. code:: bash
 
-    brew install SpectoLabs/tap/hoverfly
+    brew install hoverfly
 
 To upgrade your existing hoverfly to the latest release:
 


### PR DESCRIPTION
Update docs as this can now be installed with `brew install hoverfly` by https://github.com/Homebrew/homebrew-core/pull/136714 .
Created PR without creating an issue because of the minor changes.