### PR TITLE
feature - MVP for csv templating function for dynamic response

### DIFF
--- a/core/cmd/hoverfly/main.go
+++ b/core/cmd/hoverfly/main.go
@@ -58,6 +58,7 @@ func (i *arrayFlags) Set(value string) error {
 
 var importFlags arrayFlags
 var postServeActionFlags arrayFlags
+var templatingDataSourceFlags arrayFlags
 var destinationFlags arrayFlags
 var logOutputFlags arrayFlags
 var responseBodyFilesPath string
@@ -201,6 +202,7 @@ func main() {
 
 	flag.Var(&importFlags, "import", "Import from file or from URL (i.e. '-import my_service.json' or '-import http://mypage.com/service_x.json'")
 	flag.Var(&postServeActionFlags, "post-serve-action", "Set post serve action by passing the action name, binary and the path of the action script and delay in Ms separated by space. (i.e. i.e. '-post-serve-action \"webhook python script.py 2000\"')")
+	flag.Var(&templatingDataSourceFlags, "templating-data-source", "Set template data source (i.e. '-templating-data-source \"<datasource name> <file path>')")
 	flag.Var(&destinationFlags, "dest", "Specify which hosts to process (i.e. '-dest fooservice.org -dest barservice.org -dest catservice.org') - other hosts will be ignored will passthrough'")
 	flag.Var(&logOutputFlags, "logs-output", "Specify locations for output logs, options are \"console\" and \"file\" (default \"console\")")
 	flag.StringVar(&responseBodyFilesPath, "response-body-files-path", "", "When a response contains a relative bodyFile, it will be resolved against this path (default is CWD)")
@@ -567,6 +569,34 @@ func main() {
 				}
 			}
 		}
+	}
+
+	if len(templatingDataSourceFlags) > 0 {
+
+		for _, v := range templatingDataSourceFlags {
+
+			if v != "" {
+
+				splitTemplateDataSource := strings.Split(v, " ")
+				if len(splitTemplateDataSource) == 2 {
+					if fileContents, err := ioutil.ReadFile(splitTemplateDataSource[1]); err == nil {
+						err = hoverfly.SetCsvDataSource(splitTemplateDataSource[0], string(fileContents))
+						if err != nil {
+							log.WithFields(log.Fields{
+								"error":  err.Error(),
+								"import": v,
+							}).Fatal("Failed to import template data source")
+						}
+					}
+
+				} else {
+					log.WithFields(log.Fields{
+						"import": v,
+					}).Fatal("Failed to import template data source due to invalid input passed")
+				}
+			}
+		}
+
 	}
 
 	// importing stuff

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -3,6 +3,7 @@ package hoverfly
 import (
 	"errors"
 	"fmt"
+	"github.com/SpectoLabs/hoverfly/core/templating"
 	"regexp"
 
 	"github.com/SpectoLabs/hoverfly/core/action"
@@ -480,6 +481,16 @@ func (hf *Hoverfly) SetPostServeAction(actionName string, binary string, scriptC
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (hf *Hoverfly) SetCsvDataSource(dataSourceName, dataSourceContent string) error {
+
+	dataStore, err := templating.NewCsvDataSource(dataSourceName, dataSourceContent)
+	if err != nil {
+		return err
+	}
+	hf.templator.TemplateDataSource.SetDataSource(dataSourceName, dataStore)
 	return nil
 }
 

--- a/core/templating/datasource.go
+++ b/core/templating/datasource.go
@@ -1,0 +1,23 @@
+package templating
+
+import (
+	"encoding/csv"
+	"strings"
+)
+
+type DataSource struct {
+	SourceType string
+	Name       string
+	Data       [][]string
+}
+
+func NewCsvDataSource(fileName, fileContent string) (*DataSource, error) {
+
+	csvReader := csv.NewReader(strings.NewReader(fileContent))
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	return &DataSource{"csv", fileName, records}, nil
+}

--- a/core/templating/template_datasource.go
+++ b/core/templating/template_datasource.go
@@ -1,0 +1,24 @@
+package templating
+
+import (
+	"sync"
+)
+
+type TemplateDataSource struct {
+	DataSources map[string]*DataSource
+	RWMutex     sync.RWMutex
+}
+
+func NewTemplateDataSource() *TemplateDataSource {
+
+	return &TemplateDataSource{
+		DataSources: make(map[string]*DataSource),
+	}
+}
+
+func (templateDataSource *TemplateDataSource) SetDataSource(dataSourceName string, dataSource *DataSource) {
+
+	templateDataSource.RWMutex.Lock()
+	templateDataSource.DataSources[dataSourceName] = dataSource
+	templateDataSource.RWMutex.Unlock()
+}

--- a/core/templating/template_helpers.go
+++ b/core/templating/template_helpers.go
@@ -112,7 +112,9 @@ func (t templateHelpers) parseCsv(dataSourceName, searchFieldName, searchFieldVa
 			log.Error(err)
 			return getCSVEvaluationString(options)
 		}
+
 		var fallbackString string
+		searchFieldValue := getSearchFieldValue(options, searchFieldValue)
 		for i := 1; i < len(source.Data); i++ {
 			record := source.Data[i]
 			if strings.ToLower(record[searchIndex]) == strings.ToLower(searchFieldValue) {
@@ -129,6 +131,16 @@ func (t templateHelpers) parseCsv(dataSourceName, searchFieldName, searchFieldVa
 	}
 	return getCSVEvaluationString(options)
 
+}
+
+func getSearchFieldValue(options *raymond.Options, value string) string {
+
+	if tpl, err := raymond.Parse("{{ " + value + " }}"); err == nil {
+		if returnValue, err := tpl.Exec(options.Ctx()); err == nil {
+			return returnValue
+		}
+	}
+	return value
 }
 
 func getCSVEvaluationString(options *raymond.Options) string {

--- a/core/templating/templating.go
+++ b/core/templating/templating.go
@@ -17,11 +17,12 @@ import (
 const REQUEST_BODY_HELPER = "requestBody"
 
 type TemplatingData struct {
-	Request         Request
-	State           map[string]string
-	CurrentDateTime func(string, string, string) string
-	Literals        map[string]interface{}
-	Vars            map[string]interface{}
+	Request             Request
+	State               map[string]string
+	CurrentDateTime     func(string, string, string) string
+	Literals            map[string]interface{}
+	Vars                map[string]interface{}
+	TemplateDataSources map[string]*DataSource
 }
 
 type Request struct {
@@ -37,6 +38,7 @@ type Request struct {
 
 type Templator struct {
 	SupportedMethodMap map[string]interface{}
+	TemplateDataSource *TemplateDataSource
 }
 
 var helpersRegistered = false
@@ -63,13 +65,14 @@ func NewTemplator() *Templator {
 		helperMethodMap["replace"] = t.replace
 		helperMethodMap["faker"] = t.faker
 		helperMethodMap["requestBody"] = t.requestBody
-
+		helperMethodMap["csv"] = t.parseCsv
 		raymond.RegisterHelpers(helperMethodMap)
 		helpersRegistered = true
 	}
 
 	return &Templator{
 		SupportedMethodMap: helperMethodMap,
+		TemplateDataSource: NewTemplateDataSource(),
 	}
 }
 
@@ -113,9 +116,10 @@ func (t *Templator) NewTemplatingData(requestDetails *models.RequestDetails, lit
 			body:       requestDetails.Body,
 			Method:     requestDetails.Method,
 		},
-		Literals: literalMap,
-		Vars:     variableMap,
-		State:    state,
+		Literals:            literalMap,
+		Vars:                variableMap,
+		State:               state,
+		TemplateDataSources: t.TemplateDataSource.DataSources,
 		CurrentDateTime: func(a1, a2, a3 string) string {
 			return a1 + " " + a2 + " " + a3
 		},


### PR DESCRIPTION
Run this command to import csv templating datasource.

hoverfly -templating-data-source "<data source name> <path to csv file>"
Handlebar to query - {{ csv 'student-marks' 'name' 'Tommy' 'id'}}

Remaining:

- [ ] UTs
- [x] Use Request data as the parameters to the templating function
