### PR TITLE
Fix invalid JSON on Requiring State in order to Match

### DIFF
--- a/docs/pages/keyconcepts/state/settingstate.rst
+++ b/docs/pages/keyconcepts/state/settingstate.rst
@@ -20,7 +20,7 @@ A response includes two fields, `transitionsState` and `removesState` which alte
         "status": 200,
         "body": "eggs and large bacon",
         "transitionsState" : {
-            "payment-flow" : "complete",
+            "payment-flow" : "complete"
         },
         "removesState" : [
             "basket"


### PR DESCRIPTION
This addresses a small JSON formatting error in the documentation.