### PR TITLE
Support compound param query

### DIFF
--- a/core/models/payload_test.go
+++ b/core/models/payload_test.go
@@ -249,6 +249,15 @@ func Test_NewRequestDetailsFromHttpRequest_SortsQueryString(t *testing.T) {
 	Expect(requestDetails.QueryString()).To(Equal("a=a&a=b"))
 }
 
+func Test_NewRequestDetailsFromHttpRequest_ParseCompoundQueryParam(t *testing.T) {
+	RegisterTestingT(t)
+	request, _ := http.NewRequest("GET", "http://test.org/?qq=country=BEL;postalCode=1234;city=SomeCity;street=SomeStreet;houseNumber=25%20a", nil)
+	requestDetails, err := models.NewRequestDetailsFromHttpRequest(request)
+	Expect(err).To(BeNil())
+
+	Expect(requestDetails.Query["qq"]).To(ContainElement("country=BEL;postalCode=1234;city=SomeCity;street=SomeStreet;houseNumber=25 a"))
+}
+
 func Test_NewRequestDetailsFromHttpRequest_WithFormDataHavingNonEmptyBody(t *testing.T) {
 	RegisterTestingT(t)
 	form := url.Values{}

--- a/core/models/payload_test.go
+++ b/core/models/payload_test.go
@@ -240,13 +240,14 @@ func GzipString(s string) string {
 
 func Test_NewRequestDetailsFromHttpRequest_SortsQueryString(t *testing.T) {
 	RegisterTestingT(t)
-	request, _ := http.NewRequest("GET", "http://test.org/?a=b&a=a", nil)
+	request, _ := http.NewRequest("GET", "http://test.org/?b=a&a=b&a=a", nil)
 	requestDetails, err := models.NewRequestDetailsFromHttpRequest(request)
 	Expect(err).To(BeNil())
 
 	Expect(requestDetails.Query["a"]).To(ContainElement("a"))
 	Expect(requestDetails.Query["a"]).To(ContainElement("b"))
-	Expect(requestDetails.QueryString()).To(Equal("a=a&a=b"))
+	Expect(requestDetails.Query["b"]).To(ContainElement("a"))
+	Expect(requestDetails.QueryString()).To(Equal("a=a&a=b&b=a"))
 }
 
 func Test_NewRequestDetailsFromHttpRequest_ParseCompoundQueryParam(t *testing.T) {
@@ -256,6 +257,7 @@ func Test_NewRequestDetailsFromHttpRequest_ParseCompoundQueryParam(t *testing.T)
 	Expect(err).To(BeNil())
 
 	Expect(requestDetails.Query["qq"]).To(ContainElement("country=BEL;postalCode=1234;city=SomeCity;street=SomeStreet;houseNumber=25 a"))
+	Expect(requestDetails.QueryString()).To(Equal("qq=country=BEL;postalCode=1234;city=SomeCity;street=SomeStreet;houseNumber=25 a"))
 }
 
 func Test_NewRequestDetailsFromHttpRequest_WithFormDataHavingNonEmptyBody(t *testing.T) {

--- a/core/util/util.go
+++ b/core/util/util.go
@@ -112,7 +112,7 @@ func SortQueryString(query string) string {
 	keyValues := make(url.Values)
 	for query != "" {
 		key := query
-		if i := strings.IndexAny(key, "&;"); i >= 0 {
+		if i := strings.IndexAny(key, "&"); i >= 0 {
 			key, query = key[:i], key[i+1:]
 		} else {
 			query = ""


### PR DESCRIPTION
Fix https://github.com/SpectoLabs/hoverfly/issues/1111 based on the assumption that `&` is the only valid separator for query params.