### PR TITLE
Update go to 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.22
 
     environment:
       GOPATH: /home/circleci/go
@@ -32,7 +32,7 @@ jobs:
 
   deploy-master:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.22
 
     environment:
       GOPATH: /home/circleci/go
@@ -88,7 +88,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.22
 
     environment:
       GOPATH: /home/circleci/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.10 AS build-env
+FROM golang:1.22.1 AS build-env
 WORKDIR /usr/local/go/src/github.com/SpectoLabs/hoverfly
 COPY . /usr/local/go/src/github.com/SpectoLabs/hoverfly    
 RUN cd core/cmd/hoverfly && CGO_ENABLED=0 GOOS=linux go install -ldflags "-s -w"

--- a/docs/pages/contributing.rst
+++ b/docs/pages/contributing.rst
@@ -16,7 +16,7 @@ Learn more about the `forking workflow here <https://www.atlassian.com/git/tutor
 Building, running & testing
 ---------------------------
 
-You will need `Go 1.18 <https://golang.org>`_ . Instructions on how to set up your Go environment can be `found here <https://golang.org/doc/install>`_.
+You will need `Go 1.22 <https://golang.org>`_ . Instructions on how to set up your Go environment can be `found here <https://golang.org/doc/install>`_.
 
 .. code:: bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SpectoLabs/hoverfly
 
-go 1.18
+go 1.22
 
 require (
 	github.com/ChrisTrenkamp/xsel v0.9.6


### PR DESCRIPTION
There are some critical vulnerabilities reported by grype for old versions. Updating go to fix them.
```
stdlib         go1.18.10             go-module  CVE-2023-29405  Critical  
stdlib         go1.18.10             go-module  CVE-2023-29404  Critical  
stdlib         go1.18.10             go-module  CVE-2023-29402  Critical  
```