### PR TITLE
Changed template function setstatuscode to accept strings instead of int

### DIFF
--- a/core/templating/template_helpers.go
+++ b/core/templating/template_helpers.go
@@ -2,12 +2,13 @@ package templating
 
 import (
 	"fmt"
-	"github.com/SpectoLabs/hoverfly/core/journal"
 	"math"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/SpectoLabs/hoverfly/core/journal"
 
 	"github.com/SpectoLabs/raymond"
 	"github.com/pborman/uuid"
@@ -187,9 +188,13 @@ func (t templateHelpers) hasJournalKey(indexName, keyValue string, options *raym
 	return journalEntry != nil
 }
 
-func (t templateHelpers) setStatusCode(statusCode int, options *raymond.Options) string {
+func (t templateHelpers) setStatusCode(statusCode string, options *raymond.Options) string {
+	intStatusCode, err := strconv.Atoi(statusCode)
+	if err != nil {
+		return ""
+	}
 	internalVars := options.ValueFromAllCtx("InternalVars").(map[string]interface{})
-	internalVars["statusCode"] = statusCode
+	internalVars["statusCode"] = intStatusCode
 	return ""
 }
 


### PR DESCRIPTION
I have changed the template function setStatusCode to accept strings so that the status code can be generated from an internally nested function, like {{csv}}. 

This will now work whereas it crashed before:
{{setStatusCode (csv 'gdcm-provisioning-data' 'Vin' (Request.Body 'jsonpath' '$.Vin') 'Response-Code')}}

I could not find any tests for it so I have not updated the tests.

Thanks
Stu