### PR TITLE
Methods to retrieve CSV data as array or map

### DIFF
--- a/core/templating/templating.go
+++ b/core/templating/templating.go
@@ -100,7 +100,10 @@ func NewTemplator() *Templator {
 	helperMethodMap["matchesRegex"] = t.matchesRegex
 	helperMethodMap["faker"] = t.faker
 	helperMethodMap["requestBody"] = t.requestBody
-	helperMethodMap["csv"] = t.parseCsv
+	helperMethodMap["csv"] = t.fetchSingleFieldCsv
+	helperMethodMap["csvMatchingRows"] = t.fetchMatchingRowsCsv
+	helperMethodMap["csvAsArray"] = t.csvAsArray
+	helperMethodMap["csvAsMap"] = t.csvAsMap
 	helperMethodMap["journal"] = t.parseJournalBasedOnIndex
 	helperMethodMap["hasJournalKey"] = t.hasJournalKey
 	helperMethodMap["setStatusCode"] = t.setStatusCode

--- a/core/templating/templating_test.go
+++ b/core/templating/templating_test.go
@@ -1,8 +1,9 @@
 package templating_test
 
 import (
-	"github.com/SpectoLabs/hoverfly/core/journal"
 	"testing"
+
+	"github.com/SpectoLabs/hoverfly/core/journal"
 
 	"github.com/SpectoLabs/hoverfly/core/models"
 	"github.com/SpectoLabs/hoverfly/core/templating"
@@ -70,6 +71,74 @@ func Test_ApplyTemplate_ParseCsv_WithEachBlockAndMissingDataSource(t *testing.T)
 	Expect(err).To(BeNil())
 	Expect(template).To(Equal(` 0 : Product Name with productId 1 is {{ csv products productId 1 productName }}  1 : Product Name with productId 2 is {{ csv products productId 2 productName }} `))
 }
+
+// --------------------------------------
+func Test_ApplyTemplate_MatchingRowsCsvAndReturnMatchedString(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvMatchingRows 'test-csv1' 'id' '2')}}{{this.name}}{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(`Test2`))
+}
+
+func Test_ApplyTemplate_MatchingRowsCsvMissingDataSource(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvMatchingRows 'test-csv99' 'id' '2')}}{{this.name}}{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(``))
+}
+
+func Test_ApplyTemplate_MatchingRowsCsvInvalidKey(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvMatchingRows 'test-csv1' 'id' '99')}}{{this.name}}{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(``))
+}
+
+// -------------------------------
+func Test_ApplyTemplate_CsvAsArrayAndReturnMatchedString(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvAsArray 'test-csv1')}}{{#each this}}{{this}}{{/each}}{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(`idnamemarks1Test1552Test256*DummyABSENT`))
+}
+
+func Test_ApplyTemplate_CsvAsArrayMissingDataSource(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvAsArray 'test-csv99')}}{{#each this}}{{this}}{{/each}}{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(``))
+}
+
+// -------------------------------
+func Test_ApplyTemplate_CsvAsMapAndReturnMatchedString(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvAsMap 'test-csv1')}}{{this.name}}{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(`Test1Test2Dummy`))
+}
+
+func Test_ApplyTemplate_CsvAsMapMissingDataSource(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvAsMap 'test-csv99')}}{{this.name}}{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(``))
+}
+
+// -------------------------------
 
 func Test_ApplyTemplate_EachBlockWithSplitTemplatingFunction(t *testing.T) {
 	RegisterTestingT(t)
@@ -642,7 +711,7 @@ func Test_ApplyTemplate_Arithmetic_Ops_With_Each_Block(t *testing.T) {
 	Expect(result).To(Equal(` 3.5  9  total: 12.50`))
 
 	// Running the second time should produce the same result because each execution has its own context data.
-	result, err = templator.RenderTemplate(template, requestDetails, nil,  &models.Literals{}, &models.Variables{}, state, &journal.Journal{})
+	result, err = templator.RenderTemplate(template, requestDetails, nil, &models.Literals{}, &models.Variables{}, state, &journal.Journal{})
 	Expect(err).To(BeNil())
 	Expect(result).To(Equal(` 3.5  9  total: 12.50`))
 }


### PR DESCRIPTION
Hi!

I added three methods to make iterating over CSV data possible from templating.

- csvAsMap - returns an array of maps of string representing the data in the CSV which makes this.fieldname possible: within an each block
- csvMatchingRows - is the same thing but filters records based on a fieldvalue and field to match
- csvAsArray - just returns the whole thing as an array of arrays of string. 

I also changed the name of the previous parseCSV to fetchSingleFieldCSV (to be more descriptive given these new ones.)
I have not updated the documentation. Will do so once you've reviewed.
