### PR TITLE
SQL over CSV with tests and docs

### DIFF
--- a/core/templating/datasource.go
+++ b/core/templating/datasource.go
@@ -27,7 +27,7 @@ func NewCsvDataSource(fileName, fileContent string) (*DataSource, error) {
 	return &DataSource{"csv", fileName, records, sync.Mutex{}}, nil
 }
 
-func (dataSource DataSource) GetDataSourceView() (v2.CSVDataSourceView, error) {
+func (dataSource *DataSource) GetDataSourceView() (v2.CSVDataSourceView, error) {
 
 	content, err := getData(dataSource)
 	if err != nil {
@@ -36,7 +36,7 @@ func (dataSource DataSource) GetDataSourceView() (v2.CSVDataSourceView, error) {
 	return v2.CSVDataSourceView{Name: dataSource.Name, Data: content}, nil
 }
 
-func getData(source DataSource) (string, error) {
+func getData(source *DataSource) (string, error) {
 
 	var csvData strings.Builder
 	csvWriter := csv.NewWriter(&csvData)

--- a/core/templating/datasource.go
+++ b/core/templating/datasource.go
@@ -53,3 +53,12 @@ func getData(source *DataSource) (string, error) {
 	}
 	return csvData.String(), nil
 }
+
+func dataSourceExists(dataSources map[string]*DataSource, name string) bool {
+	for _, dataSource := range dataSources {
+		if dataSource.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/core/templating/datasource_query.go
+++ b/core/templating/datasource_query.go
@@ -1,0 +1,162 @@
+package templating
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// A mock structure representing your CSV data
+// var data = [][]string{
+// 	{"id", "name", "age", "city"},
+// 	{"1", "John", "30", "New York"},
+// 	{"2", "Jane", "25", "Los Angeles"},
+// 	{"3", "Doe", "40", "New York"},
+// }
+
+// RowMap represents a single row in the result set
+type RowMap map[string]string
+
+// Condition represents a single condition in the WHERE clause
+type Condition struct {
+	Column   string
+	Operator string
+	Value    string
+}
+
+// SelectQuery represents a simple SQL-like SELECT query
+type SelectQuery struct {
+	Columns    []string
+	Conditions []Condition
+}
+
+// ParseQuery parses a query string into a SelectQuery struct
+func ParseQuery(query string) (SelectQuery, error) {
+	query = strings.TrimSpace(query)
+
+	selectRegex := regexp.MustCompile(`(?i)^SELECT\s+(.+)\s+WHERE\s+(.+)$`)
+	matches := selectRegex.FindStringSubmatch(query)
+	if len(matches) != 3 {
+		return SelectQuery{}, errors.New("invalid query format")
+	}
+
+	columnsPart := matches[1]
+	wherePart := matches[2]
+
+	columns := strings.Split(columnsPart, ",")
+	for i, column := range columns {
+		columns[i] = strings.TrimSpace(column)
+	}
+
+	conditions, err := parseConditions(wherePart)
+	if err != nil {
+		return SelectQuery{}, err
+	}
+
+	return SelectQuery{
+		Columns:    columns,
+		Conditions: conditions,
+	}, nil
+}
+
+// parseConditions parses the WHERE part of the query into a slice of Conditions
+func parseConditions(wherePart string) ([]Condition, error) {
+	conditions := []Condition{}
+
+	conditionRegex := regexp.MustCompile(`(\w+)\s*(==|!=)\s*'([^']*)'`)
+	conditionMatches := conditionRegex.FindAllStringSubmatch(wherePart, -1)
+
+	if len(conditionMatches) == 0 {
+		return nil, errors.New("no valid conditions found")
+	}
+
+	for _, match := range conditionMatches {
+		if len(match) != 4 {
+			return nil, errors.New("invalid condition format")
+		}
+		conditions = append(conditions, Condition{
+			Column:   match[1],
+			Operator: match[2],
+			Value:    match[3],
+		})
+	}
+
+	return conditions, nil
+}
+
+// ExecuteQuery runs the query against the in-memory data
+func ExecuteQuery(data [][]string, query SelectQuery) []RowMap {
+	headers := data[0] // first row as header
+	results := []RowMap{}
+
+	for _, row := range data[1:] {
+		rowMap := mapRow(headers, row)
+		if matchesConditions(rowMap, query.Conditions) {
+			results = append(results, projectRow(rowMap, query.Columns))
+		}
+	}
+	return results
+}
+
+// mapRow converts a CSV row into a map with column names as keys
+func mapRow(headers, row []string) RowMap {
+	rowMap := make(RowMap)
+	for i, header := range headers {
+		rowMap[header] = row[i]
+	}
+	return rowMap
+}
+
+// projectRow filters the row based on the selected columns
+func projectRow(row RowMap, columns []string) RowMap {
+	if len(columns) == 0 {
+		return row
+	}
+	projected := make(RowMap)
+	for _, col := range columns {
+		if val, ok := row[col]; ok {
+			projected[col] = val
+		}
+	}
+	return projected
+}
+
+// matchesConditions checks if a row matches all given conditions
+func matchesConditions(row RowMap, conditions []Condition) bool {
+	for _, condition := range conditions {
+		val, ok := row[condition.Column]
+		if !ok {
+			return false // Column doesn't exist
+		}
+
+		switch condition.Operator {
+		case "==":
+			if val != condition.Value {
+				return false
+			}
+		case "!=":
+			if val == condition.Value {
+				return false
+			}
+		default:
+			return false // Unsupported operator
+		}
+	}
+	return true // All conditions matched
+}
+
+// Example usage
+// func main() {
+// 	queryStr := "SELECT age, city WHERE age!='30' AND city=='New York'"
+
+// 	query, err := ParseQuery(queryStr)
+// 	if err != nil {
+// 		fmt.Println("Error:", err)
+// 		return
+// 	}
+
+// 	results := ExecuteQuery(data, query)
+// 	for _, row := range results {
+// 		fmt.Println(row)
+// 	}
+// }

--- a/core/templating/datasource_query_test.go
+++ b/core/templating/datasource_query_test.go
@@ -1,0 +1,256 @@
+package templating
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestParseQuery(t *testing.T) {
+	dataSource := map[string]*DataSource{
+		"employees": {
+			SourceType: "csv",
+			Name:       "employees",
+			Data: [][]string{
+				{"id", "name", "age", "department"},
+				{"1", "John Doe", "30", "Engineering"},
+				{"2", "Jane Smith", "40", "Marketing"},
+			},
+			mu: sync.Mutex{},
+		},
+	}
+
+	tests := []struct {
+		query       string
+		expected    SQLStatement
+		expectError bool
+	}{
+		{
+			query: "SELECT name, age FROM employees WHERE age >= '30'",
+			expected: SQLStatement{
+				Type:           "SELECT",
+				Columns:        []string{"name", "age"},
+				Conditions:     []Condition{{Column: "age", Operator: ">=", Value: "30"}},
+				DataSourceName: "employees",
+			},
+			expectError: false,
+		},
+		{
+			query:       "SELECT * FROM employees WHERE department == 'Engineering'",
+			expected:    SQLStatement{Type: "SELECT", Columns: []string{"id", "name", "age", "department"}, Conditions: []Condition{{Column: "department", Operator: "==", Value: "Engineering"}}, DataSourceName: "employees"},
+			expectError: false,
+		},
+		{
+			query:       "UPDATE employees SET age = '35' WHERE name == 'John Doe'",
+			expected:    SQLStatement{Type: "UPDATE", Conditions: []Condition{{Column: "name", Operator: "==", Value: "John Doe"}}, SetClauses: map[string]string{"age": "35"}, DataSourceName: "employees"},
+			expectError: false,
+		},
+		{
+			query:       "DELETE FROM employees WHERE age < '30'",
+			expected:    SQLStatement{Type: "DELETE", Conditions: []Condition{{Column: "age", Operator: "<", Value: "30"}}, DataSourceName: "employees"},
+			expectError: false,
+		},
+		{
+			query:       "INVALID QUERY",
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := parseQuery(test.query, dataSource)
+		if test.expectError {
+			if err == nil {
+				t.Errorf("expected error but got none for query: %s", test.query)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error for query %s: %v", test.query, err)
+			}
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("expected %v, got %v for query: %s", test.expected, result, test.query)
+			}
+		}
+	}
+}
+
+func TestTrimQuotes(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`"hello"`, "hello"},
+		{`'world'`, "world"},
+		{`"12345`, `"12345`},
+		{`hello`, "hello"},
+		{`''`, ""},
+	}
+
+	for _, test := range tests {
+		result := trimQuotes(test.input)
+		if result != test.expected {
+			t.Errorf("expected %v, got %v for input %s", test.expected, result, test.input)
+		}
+	}
+}
+
+func TestParseSetClauses(t *testing.T) {
+	input := "age = '35', department = 'Engineering'"
+	expected := map[string]string{
+		"age":        "35",
+		"department": "Engineering",
+	}
+
+	result := parseSetClauses(input)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %v, got %v", expected, result)
+	}
+}
+
+func TestParseConditions_ValidInput(t *testing.T) {
+	wherePart := "id == '1' AND name != 'John' AND age >= '30'"
+	expected := []Condition{
+		{"id", "==", "1"},
+		{"name", "!=", "John"},
+		{"age", ">=", "30"},
+	}
+
+	conditions, err := parseConditions(wherePart)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(conditions, expected) {
+		t.Errorf("expected %v, got %v", expected, conditions)
+	}
+}
+
+func TestParseConditions_EmptyInput(t *testing.T) {
+	wherePart := ""
+	expected := []Condition{}
+
+	conditions, err := parseConditions(wherePart)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(conditions, expected) {
+		t.Errorf("expected %v, got %v", expected, conditions)
+	}
+}
+
+func TestParseConditions_SingleCondition(t *testing.T) {
+	wherePart := "name == 'Alice'"
+	expected := []Condition{
+		{"name", "==", "Alice"},
+	}
+
+	conditions, err := parseConditions(wherePart)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(conditions, expected) {
+		t.Errorf("expected %v, got %v", expected, conditions)
+	}
+}
+
+func TestParseConditions_MultipleConditions(t *testing.T) {
+	wherePart := "id == '1' AND age < '40'"
+	expected := []Condition{
+		{"id", "==", "1"},
+		{"age", "<", "40"},
+	}
+
+	conditions, err := parseConditions(wherePart)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(conditions, expected) {
+		t.Errorf("expected %v, got %v", expected, conditions)
+	}
+}
+
+func TestExecuteSelectQuery(t *testing.T) {
+	data := [][]string{
+		{"id", "name", "age", "department"},
+		{"1", "John Doe", "30", "Engineering"},
+		{"2", "Jane Smith", "40", "Marketing"},
+	}
+
+	query := SQLStatement{
+		Type:           "SELECT",
+		Columns:        []string{"name", "age"},
+		Conditions:     []Condition{{Column: "department", Operator: "==", Value: "Engineering"}},
+		DataSourceName: "employees",
+	}
+
+	expected := []RowMap{
+		{"name": "John Doe", "age": "30"},
+	}
+
+	result := executeSelectQuery(data, query)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %v, got %v", expected, result)
+	}
+}
+
+func TestExecuteUpdateQuery(t *testing.T) {
+	data := [][]string{
+		{"id", "name", "age", "department"},
+		{"1", "John Doe", "30", "Engineering"},
+		{"2", "Jane Smith", "40", "Marketing"},
+	}
+
+	query := SQLStatement{
+		Type:           "UPDATE",
+		Conditions:     []Condition{{Column: "name", Operator: "==", Value: "John Doe"}},
+		SetClauses:     map[string]string{"age": "35"},
+		DataSourceName: "employees",
+	}
+
+	expected := [][]string{
+		{"id", "name", "age", "department"},
+		{"1", "John Doe", "35", "Engineering"},
+		{"2", "Jane Smith", "40", "Marketing"},
+	}
+
+	err := executeUpdateQuery(&data, query)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(data, expected) {
+		t.Errorf("expected %v, got %v", expected, data)
+	}
+}
+
+func TestExecuteDeleteQuery(t *testing.T) {
+	data := [][]string{
+		{"id", "name", "age", "department"},
+		{"1", "John Doe", "30", "Engineering"},
+		{"2", "Jane Smith", "40", "Marketing"},
+	}
+
+	query := SQLStatement{
+		Type:           "DELETE",
+		Conditions:     []Condition{{Column: "age", Operator: "==", Value: "30"}},
+		DataSourceName: "employees",
+	}
+
+	expected := [][]string{
+		{"id", "name", "age", "department"},
+		{"2", "Jane Smith", "40", "Marketing"},
+	}
+
+	err := executeDeleteQuery(&data, query)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(data, expected) {
+		t.Errorf("expected %v, got %v", expected, data)
+	}
+}

--- a/core/templating/template_helpers.go
+++ b/core/templating/template_helpers.go
@@ -135,74 +135,130 @@ func (t templateHelpers) isBool(s string) bool {
 	return err == nil
 }
 
-func isGreaterThan(valueToCheck, minimumValue string) bool {
-	num1, err := strconv.ParseFloat(valueToCheck, 64)
+// func isGreaterThan(valueToCheck, minimumValue string) bool {
+// 	num1, err := strconv.ParseFloat(valueToCheck, 64)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	num2, err := strconv.ParseFloat(minimumValue, 64)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	return num1 > num2
+// }
+
+// func (t templateHelpers) isGreaterThan(valueToCheck, minimumValue string) bool {
+// 	return isGreaterThan(valueToCheck, minimumValue)
+// }
+
+// func isGreaterThanOrEqual(valueToCheck, minimumValue string) bool {
+// 	num1, err := strconv.ParseFloat(valueToCheck, 64)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	num2, err := strconv.ParseFloat(minimumValue, 64)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	return num1 >= num2
+// }
+
+// func (t templateHelpers) isGreaterThanOrEqual(valueToCheck, minimumValue string) bool {
+// 	return isGreaterThan(valueToCheck, minimumValue)
+// }
+
+// func isLessThan(valueToCheck, maximumValue string) bool {
+// 	num1, err := strconv.ParseFloat(valueToCheck, 64)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	num2, err := strconv.ParseFloat(maximumValue, 64)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	return num1 < num2
+// }
+
+// func (t templateHelpers) isLessThan(valueToCheck, maximumValue string) bool {
+// 	return isLessThan(valueToCheck, maximumValue)
+// }
+
+// func isLessThanOrEqual(valueToCheck, maximumValue string) bool {
+// 	num1, err := strconv.ParseFloat(valueToCheck, 64)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	num2, err := strconv.ParseFloat(maximumValue, 64)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	return num1 <= num2
+// }
+
+// func (t templateHelpers) isLessThanOrEqual(valueToCheck, maximumValue string) bool {
+// 	return isLessThan(valueToCheck, maximumValue)
+// }
+
+// func (t templateHelpers) isBetween(valueToCheck, minimumValue, maximumValue string) bool {
+// 	return t.isGreaterThan(valueToCheck, minimumValue) && t.isLessThan(valueToCheck, maximumValue)
+// }
+
+//########################
+
+// Comparison function type that takes two float64 values and returns a boolean.
+type comparator func(float64, float64) bool
+
+// Generic comparison function that parses strings to floats and applies the given comparison function.
+func compareValues(value1, value2 string, comp comparator) bool {
+	num1, err := strconv.ParseFloat(value1, 64)
 	if err != nil {
 		return false
 	}
-	num2, err := strconv.ParseFloat(minimumValue, 64)
+	num2, err := strconv.ParseFloat(value2, 64)
 	if err != nil {
 		return false
 	}
-	return num1 > num2
+	return comp(num1, num2)
 }
 
-func (t templateHelpers) isGreaterThan(valueToCheck, minimumValue string) bool {
-	return isGreaterThan(valueToCheck, minimumValue)
+// Specific comparison functions using the generic compareValues function.
+func isGreaterThan(value1, value2 string) bool {
+	return compareValues(value1, value2, func(a, b float64) bool { return a > b })
 }
 
-func isGreaterThanOrEqual(valueToCheck, minimumValue string) bool {
-	num1, err := strconv.ParseFloat(valueToCheck, 64)
-	if err != nil {
-		return false
-	}
-	num2, err := strconv.ParseFloat(minimumValue, 64)
-	if err != nil {
-		return false
-	}
-	return num1 >= num2
+func isGreaterThanOrEqual(value1, value2 string) bool {
+	return compareValues(value1, value2, func(a, b float64) bool { return a >= b })
 }
 
-func (t templateHelpers) isGreaterThanOrEqual(valueToCheck, minimumValue string) bool {
-	return isGreaterThan(valueToCheck, minimumValue)
+func isLessThan(value1, value2 string) bool {
+	return compareValues(value1, value2, func(a, b float64) bool { return a < b })
 }
 
-func isLessThan(valueToCheck, maximumValue string) bool {
-	num1, err := strconv.ParseFloat(valueToCheck, 64)
-	if err != nil {
-		return false
-	}
-	num2, err := strconv.ParseFloat(maximumValue, 64)
-	if err != nil {
-		return false
-	}
-	return num1 < num2
+func isLessThanOrEqual(value1, value2 string) bool {
+	return compareValues(value1, value2, func(a, b float64) bool { return a <= b })
 }
 
-func (t templateHelpers) isLessThan(valueToCheck, maximumValue string) bool {
-	return isLessThan(valueToCheck, maximumValue)
+func (t templateHelpers) isGreaterThan(value1, value2 string) bool {
+	return isGreaterThan(value1, value2)
 }
 
-func isLessThanOrEqual(valueToCheck, maximumValue string) bool {
-	num1, err := strconv.ParseFloat(valueToCheck, 64)
-	if err != nil {
-		return false
-	}
-	num2, err := strconv.ParseFloat(maximumValue, 64)
-	if err != nil {
-		return false
-	}
-	return num1 <= num2
+func (t templateHelpers) isGreaterThanOrEqual(value1, value2 string) bool {
+	return isGreaterThanOrEqual(value1, value2)
 }
 
-func (t templateHelpers) isLessThanOrEqual(valueToCheck, maximumValue string) bool {
-	return isLessThan(valueToCheck, maximumValue)
+func (t templateHelpers) isLessThan(value1, value2 string) bool {
+	return isLessThan(value1, value2)
 }
 
-func (t templateHelpers) isBetween(valueToCheck, minimumValue, maximumValue string) bool {
-	return t.isGreaterThan(valueToCheck, minimumValue) && t.isLessThan(valueToCheck, maximumValue)
+func (t templateHelpers) isLessThanOrEqual(value1, value2 string) bool {
+	return isLessThanOrEqual(value1, value2)
 }
 
+func (t templateHelpers) isBetween(value, min, max string) bool {
+	return t.isGreaterThan(value, min) && t.isLessThan(value, max)
+}
+
+// ########################
 func (t templateHelpers) matchesRegex(valueToCheck, pattern string) bool {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
@@ -439,28 +495,11 @@ func (t templateHelpers) csvCountRows(dataSourceName string) string {
 	return fmt.Sprintf("%d", numRows)
 }
 
-//	func (t templateHelpers) csvSQL(dataSourceName, queryString string) []RowMap {
-//		templateDataSources := t.TemplateDataSource.DataSources
-//		source, exists := templateDataSources[dataSourceName]
-//		if !exists {
-//			log.Debug("could not find datasource " + dataSourceName)
-//			return []RowMap{}
-//		}
-//		source.mu.Lock()
-//		defer source.mu.Unlock()
-//		query, err := ParseQuery(queryString, source.Data[0])
-//		if err != nil {
-//			log.Error("Error:", err)
-//			return []RowMap{}
-//		}
-//		results := ExecuteQuery(source.Data, query)
-//		return results
-//	}
 func (t templateHelpers) csvSQL(queryString string) []RowMap {
 	templateDataSources := t.TemplateDataSource.DataSources
 
 	// Parse the query string to get the SelectQuery
-	query, err := ParseQuery(queryString, templateDataSources)
+	query, err := parseQuery(strings.TrimSpace(queryString), templateDataSources)
 	if err != nil {
 		log.Debug("Error parsing query:", err)
 		return []RowMap{}
@@ -476,9 +515,33 @@ func (t templateHelpers) csvSQL(queryString string) []RowMap {
 	source.mu.Lock()
 	defer source.mu.Unlock()
 
-	// Execute the query against the data source
-	results := ExecuteQuery(source.Data, query)
-	return results
+	var results []RowMap
+	var execErr error
+
+	switch query.Type {
+	case "SELECT":
+		results = executeSelectQuery(source.Data, query) //This is not by reference as we are not changing the data
+	case "UPDATE":
+		execErr = executeUpdateQuery(&source.Data, query) //This must be by reference as we are not changing the data
+	case "DELETE":
+		execErr = executeDeleteQuery(&source.Data, query) //This must be by reference as we are not changing the data
+	default:
+		log.Debug(fmt.Errorf("unsupported query type %s", query.Type))
+		return nil
+	}
+
+	if execErr != nil {
+		log.Debug(fmt.Errorf("error executing query: %w", execErr))
+		return nil
+	}
+
+	// For SELECT queries, return results
+	if query.Type == "SELECT" {
+		return results
+	}
+
+	// No results to return for UPDATE and DELETE queries
+	return nil
 }
 
 func (t templateHelpers) parseJournalBasedOnIndex(indexName, keyValue, dataSource, queryType, lookupQuery string, options *raymond.Options) interface{} {

--- a/core/templating/template_helpers.go
+++ b/core/templating/template_helpers.go
@@ -399,6 +399,7 @@ func (t templateHelpers) csvAsArray(dataSourceName string) [][]string {
 }
 
 func (t templateHelpers) csvAsMap(dataSourceName string) []RowMap {
+
 	templateDataSources := t.TemplateDataSource.DataSources
 	source, exists := templateDataSources[dataSourceName]
 	if !exists {
@@ -497,10 +498,11 @@ func (t templateHelpers) csvCountRows(dataSourceName string) string {
 
 func (t templateHelpers) csvSQL(queryString string) []RowMap {
 	templateDataSources := t.TemplateDataSource.DataSources
-
 	// Parse the query string to get the SelectQuery
 	query, err := parseQuery(strings.TrimSpace(queryString), templateDataSources)
 	if err != nil {
+		// Debugging: Print the parsed query
+		fmt.Printf("Error parsing query:: %+v\n", err)
 		log.Debug("Error parsing query:", err)
 		return []RowMap{}
 	}

--- a/core/templating/templating.go
+++ b/core/templating/templating.go
@@ -95,7 +95,9 @@ func NewTemplator() *Templator {
 	helperMethodMap["isAlphanumeric"] = t.isAlphanumeric
 	helperMethodMap["isBool"] = t.isBool
 	helperMethodMap["isGreaterThan"] = t.isGreaterThan
+	helperMethodMap["isGreaterThanOrEqual"] = t.isGreaterThanOrEqual
 	helperMethodMap["isLessThan"] = t.isLessThan
+	helperMethodMap["isLessThanOrEqual"] = t.isLessThanOrEqual
 	helperMethodMap["isBetween"] = t.isBetween
 	helperMethodMap["matchesRegex"] = t.matchesRegex
 	helperMethodMap["faker"] = t.faker

--- a/core/templating/templating.go
+++ b/core/templating/templating.go
@@ -107,6 +107,7 @@ func NewTemplator() *Templator {
 	helperMethodMap["csvAddRow"] = t.csvAddRow
 	helperMethodMap["csvDeleteRows"] = t.csvDeleteRows
 	helperMethodMap["csvCountRows"] = t.csvCountRows
+	helperMethodMap["csvSQL"] = t.csvSQL
 	helperMethodMap["journal"] = t.parseJournalBasedOnIndex
 	helperMethodMap["hasJournalKey"] = t.hasJournalKey
 	helperMethodMap["setStatusCode"] = t.setStatusCode

--- a/core/templating/templating_test backup.txt
+++ b/core/templating/templating_test backup.txt
@@ -147,19 +147,15 @@ func Test_ApplyTemplate_CsvAddRow(t *testing.T) {
 
 	Expect(err).To(BeNil())
 	Expect(template).To(Equal(`Violet`))
-	//Revert the data to original state
-	_, _ = ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{csvDeleteRows 'test-csv' 'id' '99' false}}`)
 }
 
 func Test_ApplyTemplate_CsvDeleteRows(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{csvDeleteRows 'test-csv' 'id' '*' true}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{csvDeleteRows 'test-csv' 'id' '2' true}}`)
 
 	Expect(err).To(BeNil())
 	Expect(template).To(Equal(`1`))
-	//Revert the data to original state
-	_, _ = ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{addToArray 'newMark' '*' false}}{{addToArray 'newMark' 'Dummy' false}}{{addToArray 'newMark' 'ABSENT' false}}{{csvAddRow 'test-csv' (getArray 'newMark')}}`)
 }
 
 func Test_ApplyTemplate_CsvDeleteMissingDataset(t *testing.T) {
@@ -228,7 +224,7 @@ func Test_ApplyTemplate_CsvAsMapAndReturnMatchedString2(t *testing.T) {
 func Test_ApplyTemplate_CsvSQL_SelectAll(t *testing.T) {
 	RegisterTestingT(t)
 
-	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvSQL "SELECT * FROM test-csv WHERE 1==1")}}{{this.id}},{{this.name}},{{this.marks}};{{/each}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvSQL "SELECT * FROM test-csv")}}{{this.id}},{{this.name}},{{this.marks}};{{/each}}`)
 
 	Expect(err).To(BeNil())
 	Expect(template).To(Equal(`1,Test1,55;2,Test2,56;*,Dummy,ABSENT;`))
@@ -266,7 +262,7 @@ func Test_ApplyTemplate_CsvSQL_InvalidQuery(t *testing.T) {
 	RegisterTestingT(t)
 
 	// An invalid query that should fail
-	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvSQL "SELECT foo FROM bar WHERE id == '1'")}} {{/each}}`)
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{csvSQL "SELECT foo FROM bar WHERE id == '1'"}}`)
 
 	Expect(err).To(BeNil())
 	Expect(template).To(Equal(``)) // No valid data should be returned


### PR DESCRIPTION
Added support for SELECT, UPDATE, DELETE over CSV data sources in csvSQL template function.

Intention is to allow users to simulate a persistent CRUD datastore in a straightforward manner.

This in addition to template function earlier for simpler datasource manipulation.

Have included tests and documentation.

I am not sure how the documentation will render once compiled.