### PR TITLE
Fix update SET part to handle commas

### DIFF
--- a/core/templating/datasource_sql_over_csv.go
+++ b/core/templating/datasource_sql_over_csv.go
@@ -244,7 +244,7 @@ func splitOnCommasOutsideQuotes(s string) ([]string, error) {
 func parseConditions(wherePart string) ([]Condition, error) {
 	conditions := []Condition{}
 
-	conditionRegex := regexp.MustCompile(`(\w+)\s*(==|!=|<=|>=|<|>)\s*'([^']*)'`)
+	conditionRegex := regexp.MustCompile(`(\w+)\s*(==|=|!=|<=|>=|<|>)\s*'([^']*)'`)
 	conditionMatches := conditionRegex.FindAllStringSubmatch(wherePart, -1)
 
 	if len(conditionMatches) == 0 {
@@ -379,7 +379,7 @@ func matchesConditions(row RowMap, conditions []Condition) bool {
 			return false
 		}
 		switch condition.Operator {
-		case "==":
+		case "==", "=":
 			if val != condition.Value {
 				return false
 			}

--- a/core/templating/datasource_sql_over_csv_test.go
+++ b/core/templating/datasource_sql_over_csv_test.go
@@ -44,6 +44,11 @@ func TestParseCommand(t *testing.T) {
 			expectError: false,
 		},
 		{
+			query:       "SELECT * FROM employees WHERE department = 'Engineering'",
+			expected:    SQLStatement{Type: "SELECT", Columns: []string{"id", "name", "age", "department"}, Conditions: []Condition{{Column: "department", Operator: "=", Value: "Engineering"}}, DataSourceName: "employees"},
+			expectError: false,
+		},
+		{
 			query:       "UPDATE employees SET age = '35' WHERE name == 'John Doe'",
 			expected:    SQLStatement{Type: "UPDATE", Conditions: []Condition{{Column: "name", Operator: "==", Value: "John Doe"}}, SetClauses: map[string]string{"age": "35"}, DataSourceName: "employees"},
 			expectError: false,

--- a/core/templating/datasource_sql_over_csv_test.go
+++ b/core/templating/datasource_sql_over_csv_test.go
@@ -49,6 +49,11 @@ func TestParseCommand(t *testing.T) {
 			expectError: false,
 		},
 		{
+			query:       "UPDATE employees SET department = 'Engineering, Marketing' WHERE name == 'John Doe'",
+			expected:    SQLStatement{Type: "UPDATE", Conditions: []Condition{{Column: "name", Operator: "==", Value: "John Doe"}}, SetClauses: map[string]string{"department": "Engineering, Marketing"}, DataSourceName: "employees"},
+			expectError: false,
+		},
+		{
 			query:       "DELETE FROM employees WHERE age < '30'",
 			expected:    SQLStatement{Type: "DELETE", Conditions: []Condition{{Column: "age", Operator: "<", Value: "30"}}, DataSourceName: "employees"},
 			expectError: false,

--- a/core/templating/templating_test.go
+++ b/core/templating/templating_test.go
@@ -196,7 +196,7 @@ func Test_ApplyTemplate_CsvCountRowsMissingDataset(t *testing.T) {
 	Expect(template).To(Equal(``))
 }
 
-func Test_ApplyTemplate_CsvSQL_Select(t *testing.T) {
+func Test_ApplyTemplate_CsvSQL_Select_Double_Equal(t *testing.T) {
 	RegisterTestingT(t)
 
 	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvSqlCommand "SELECT name FROM test-csv1 WHERE id == '1'")}}{{this.name}}{{/each}}`)
@@ -205,10 +205,28 @@ func Test_ApplyTemplate_CsvSQL_Select(t *testing.T) {
 	Expect(template).To(Equal(`Test1`))
 }
 
-func Test_ApplyTemplate_CsvSQL_SelectAll(t *testing.T) {
+func Test_ApplyTemplate_CsvSQL_Select_Single_Equal(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvSqlCommand "SELECT name FROM test-csv1 WHERE id = '1'")}}{{this.name}}{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(`Test1`))
+}
+
+func Test_ApplyTemplate_CsvSQL_SelectAllWithNumbersNoQuotes(t *testing.T) {
 	RegisterTestingT(t)
 
 	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvSqlCommand "SELECT * FROM test-csv1 WHERE 1==1")}}{{this.id}},{{this.name}},{{this.marks}};{{/each}}`)
+
+	Expect(err).To(BeNil())
+	Expect(template).To(Equal(`1,Test1,55;2,Test2,56;*,Dummy,ABSENT;`))
+}
+
+func Test_ApplyTemplate_CsvSQL_SelectAllWithNumbersInQuotes(t *testing.T) {
+	RegisterTestingT(t)
+
+	template, err := ApplyTemplate(&models.RequestDetails{}, make(map[string]string), `{{#each (csvSqlCommand "SELECT * FROM test-csv1 WHERE '1'=='1'")}}{{this.id}},{{this.name}},{{this.marks}};{{/each}}`)
 
 	Expect(err).To(BeNil())
 	Expect(template).To(Equal(`1,Test1,55;2,Test2,56;*,Dummy,ABSENT;`))

--- a/docs/pages/keyconcepts/templating/templating.rst
+++ b/docs/pages/keyconcepts/templating/templating.rst
@@ -326,7 +326,7 @@ Example: Start Hoverfly with a CSV data source (pets.csv) provided below.
 | SELECT data using a SQL  | {                                        | {                                       |
 | like syntax.             |   "Dogs-With-Big-Ids-Only": [            |   "Dogs-With-Big-Ids-Only": [           |
 |                          | {{#each (csvSqlCommand "SELECT * FROM    |   {                                     |
-|                          | pets WHERE category == 'dogs' AND id >=  |       "id":2000,                        |
+|                          | pets WHERE category = 'dogs' AND id >=   |       "id":2000,                        |
 |                          | '2000'")}}                               |       "category":"dogs",                |
 |                          |   {                                      |       "name":"Violet",                  |
 |                          |       "id":{{this.id}},                  |       "status":"sold"                   |
@@ -431,7 +431,7 @@ Update the data in a CSV Data Source using SQL like syntax
     {{csvSqlCommand '(sql-update-statement)'}}
 
 Example:
-``{{ csvSqlCommand "UPDATE pets SET status = 'sold' WHERE id > '20' AND category == 'cats'" }}``
+``{{ csvSqlCommand "UPDATE pets SET status = 'sold' WHERE id > '20' AND category = 'cats'" }}``
 
 
 
@@ -449,7 +449,9 @@ Only simple conditions are supported.
 You can chain conditions using AND. OR is not supported.
 
 The following comparison operators are supported in conditions:
-== equals
+=  equals
+>  greater than
+<  less than
 >= greater than or equal to
 <= less than or equal to
 != not equal to


### PR DESCRIPTION
Fixed an issue where the SET part of an UPDATE SQL command would fail if the target value contained commas.
Also added support for = conditional operator in addition to == and changed docs