### PR TITLE
Bump go from 1.22.4 to 1.22.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/go:1.22.4
+      - image: cimg/go:1.22.10
 
     environment:
       GOPATH: /home/circleci/go
@@ -32,7 +32,7 @@ jobs:
 
   deploy-master:
     docker:
-      - image: cimg/go:1.22.4
+      - image: cimg/go:1.22.10
 
     environment:
       GOPATH: /home/circleci/go
@@ -87,7 +87,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: cimg/go:1.22.4
+      - image: cimg/go:1.22.10
 
     environment:
       GOPATH: /home/circleci/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.4 AS build-env
+FROM golang:1.22.10 AS build-env
 WORKDIR /usr/local/go/src/github.com/SpectoLabs/hoverfly
 COPY . /usr/local/go/src/github.com/SpectoLabs/hoverfly    
 RUN cd core/cmd/hoverfly && CGO_ENABLED=0 GOOS=linux go install -ldflags "-s -w"

--- a/docs/pages/contributing.rst
+++ b/docs/pages/contributing.rst
@@ -16,7 +16,7 @@ Learn more about the `forking workflow here <https://www.atlassian.com/git/tutor
 Building, running & testing
 ---------------------------
 
-You will need `Go 1.22.4 <https://golang.org>`_ . Instructions on how to set up your Go environment can be `found here <https://golang.org/doc/install>`_.
+You will need `Go 1.22.10 <https://golang.org>`_ . Instructions on how to set up your Go environment can be `found here <https://golang.org/doc/install>`_.
 
 .. code:: bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SpectoLabs/hoverfly
 
-go 1.22.4
+go 1.22.10
 
 require (
 	github.com/ChrisTrenkamp/xsel v0.9.16


### PR DESCRIPTION
Bumping to the latest patch version of go 1.22.

Our glorious build tooling identified https://nvd.nist.gov/vuln/detail/CVE-2024-24790 as a critical issue. This issue is fixed in go 1.22.7 and up. 