### PR TITLE
Bugfix issue #1169

### DIFF
--- a/core/matching/matchers/json_match.go
+++ b/core/matching/matchers/json_match.go
@@ -1,6 +1,7 @@
 package matchers
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 )
@@ -17,13 +18,17 @@ func JsonMatch(match interface{}, toMatch string) bool {
 		return true
 	}
 	var matchingObject interface{}
-	err := json.Unmarshal([]byte(matchString), &matchingObject)
+	d := json.NewDecoder(bytes.NewBuffer([]byte(matchString)))
+	d.UseNumber()
+	err := d.Decode(&matchingObject)
 	if err != nil {
 		return false
 	}
 
 	var toMatchObject interface{}
-	err = json.Unmarshal([]byte(toMatch), &toMatchObject)
+	d = json.NewDecoder(bytes.NewBuffer([]byte(toMatch)))
+	d.UseNumber()
+	err = d.Decode(&toMatchObject)
 	if err != nil {
 		return false
 	}

--- a/core/matching/matchers/json_match_test.go
+++ b/core/matching/matchers/json_match_test.go
@@ -104,10 +104,20 @@ func Test_JsonMatch_MatchesTrueWithUnminifiedJSONRootAsArray(t *testing.T) {
 	]`)).To(BeTrue())
 }
 
-
 func Test_JsonMatch_MatchesTrueWithJSONRootAsArray_WithDataInDifferentOrder(t *testing.T) {
 	RegisterTestingT(t)
 
 	Expect(matchers.JsonMatch(`[{"minified":true, "json":true}]`, `[{"json":true,"minified":true}]`)).To(BeTrue())
 }
 
+func Test_JsonMatch_MatchesFalseWithJSON_WithInt64(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JsonMatch(`{"test":{"id":112769992360719990160}}`, `{"test":{"id":112769992360719990161}}`)).To(BeFalse())
+}
+
+func Test_JsonMatch_MatchesTrueWithJSON_WithInt64(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JsonMatch(`{"test":{"id":112769992360719990160}}`, `{"test":{"id":112769992360719990160}}`)).To(BeTrue())
+}

--- a/core/matching/matchers/json_match_test.go
+++ b/core/matching/matchers/json_match_test.go
@@ -121,3 +121,15 @@ func Test_JsonMatch_MatchesTrueWithJSON_WithInt64(t *testing.T) {
 
 	Expect(matchers.JsonMatch(`{"test":{"id":112769992360719990160}}`, `{"test":{"id":112769992360719990160}}`)).To(BeTrue())
 }
+
+func Test_JsonMatch_MatchesFalseWithJSON_WithFloat64(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JsonMatch(`{"test":{"id":11.2769992360719990160}}`, `{"test":{"id":11.2769992360719990161}}`)).To(BeFalse())
+}
+
+func Test_JsonMatch_MatchesTrueWithJSON_WithFloat64(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JsonMatch(`{"test":{"id":11.2769992360719990160}}`, `{"test":{"id":11.2769992360719990160}}`)).To(BeTrue())
+}

--- a/core/matching/matchers/json_partial_match.go
+++ b/core/matching/matchers/json_partial_match.go
@@ -1,6 +1,7 @@
 package matchers
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -14,8 +15,12 @@ func JsonPartialMatch(match interface{}, toMatch string) bool {
 		return false
 	}
 
-	err0 := json.Unmarshal([]byte(toMatch), &toMatchType)
-	err1 := json.Unmarshal([]byte(matchString), &expected)
+	d := json.NewDecoder(bytes.NewBuffer([]byte(toMatch)))
+	d.UseNumber()
+	err0 := d.Decode(&toMatchType)
+	d = json.NewDecoder(bytes.NewBuffer([]byte(matchString)))
+	d.UseNumber()
+	err1 := d.Decode(&expected)
 	if err0 != nil || err1 != nil {
 		return false
 	}

--- a/core/matching/matchers/json_partial_match_test.go
+++ b/core/matching/matchers/json_partial_match_test.go
@@ -361,7 +361,6 @@ func Test_JsonPartialMatch_MatchesTrueWithJSONRootAsArrayAgainstJSONRootAsArray(
 	}]`)).To(BeTrue())
 }
 
-
 func Test_JsonPartialMatch_MatchesFalseWithJSONRootAsArrayAgainstJSONRootAsArrayWithDifferentElement(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -379,4 +378,16 @@ func Test_JsonPartialMatch_MatchesFalseWithJSONRootAsArrayAgainstJSONRootAsArray
 		"set": false,
 		"age": 400
 	}]`)).To(BeFalse())
+}
+
+func Test_JsonPartialMatch_MatchesFalseWithJSON_WithInt64(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JsonMatch(`{"test":{"id":112769992360719990160}}`, `{"test":{"id":112769992360719990161}}`)).To(BeFalse())
+}
+
+func Test_JsonPartialMatch_MatchesTrueWithJSON_WithInt64(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JsonMatch(`{"test":{"id":112769992360719990160}}`, `{"test":{"id":112769992360719990160}}`)).To(BeTrue())
 }

--- a/core/matching/matchers/json_partial_match_test.go
+++ b/core/matching/matchers/json_partial_match_test.go
@@ -391,3 +391,15 @@ func Test_JsonPartialMatch_MatchesTrueWithJSON_WithInt64(t *testing.T) {
 
 	Expect(matchers.JsonMatch(`{"test":{"id":112769992360719990160}}`, `{"test":{"id":112769992360719990160}}`)).To(BeTrue())
 }
+
+func Test_JsonPartialMatch_MatchesFalseWithJSON_WithFloat64(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JsonMatch(`{"test":{"id":11.2769992360719990160}}`, `{"test":{"id":11.2769992360719990161}}`)).To(BeFalse())
+}
+
+func Test_JsonPartialMatch_MatchesTrueWithJSON_WithFloat64(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(matchers.JsonMatch(`{"test":{"id":11.2769992360719990160}}`, `{"test":{"id":11.2769992360719990160}}`)).To(BeTrue())
+}


### PR DESCRIPTION
Fixed integer precision loss via matching JSONs. It is caused by unmarshaling JSON that contains bigints to type interface{}. Now decoder.UseNumber() is used.