### PR TITLE
Bump Go versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/go:1.23.5
+      - image: cimg/go:1.23.6
 
     environment:
       GOPATH: /home/circleci/go
@@ -32,7 +32,7 @@ jobs:
 
   deploy-master:
     docker:
-      - image: cimg/go:1.23.5
+      - image: cimg/go:1.23.6
 
     environment:
       GOPATH: /home/circleci/go
@@ -87,7 +87,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: cimg/go:1.23.5
+      - image: cimg/go:1.23.6
 
     environment:
       GOPATH: /home/circleci/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.5 AS build-env
+FROM golang:1.23.6 AS build-env
 WORKDIR /usr/local/go/src/github.com/SpectoLabs/hoverfly
 COPY . /usr/local/go/src/github.com/SpectoLabs/hoverfly
 RUN cd core/cmd/hoverfly && CGO_ENABLED=0 GOOS=linux go install -ldflags "-s -w"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SpectoLabs/hoverfly
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/ChrisTrenkamp/xsel v0.9.16


### PR DESCRIPTION
To fix https://nvd.nist.gov/vuln/detail/CVE-2025-22866 
