### PR TITLE
Bump Go to 1.26.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/go:1.26.2
+      - image: cimg/go:1.26.3
 
     environment:
       GOPATH: /home/circleci/go
@@ -32,7 +32,7 @@ jobs:
 
   deploy-master:
     docker:
-      - image: cimg/go:1.26.2
+      - image: cimg/go:1.26.3
 
     environment:
       GOPATH: /home/circleci/go
@@ -58,7 +58,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: cimg/go:1.26.2
+      - image: cimg/go:1.26.3
 
     environment:
       GOPATH: /home/circleci/go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Matchers operate per HTTP field (method, path, query, headers, body, scheme, des
 
 ## Tech Stack
 
-- **Go 1.26.2**, modules in `go.mod`
+- **Go 1.26.3**, modules in `go.mod`
 - **Proxy:** `github.com/SpectoLabs/goproxy` (custom MITM fork)
 - **CLI:** `cobra` + `viper`
 - **Routing (admin API):** `gorilla/mux`, `go-zoo/bone`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing to Hoverfly! This guide will help you g
 
 ### Prerequisites
 
-- **Go 1.26.2+** — install from [golang.org/dl](https://golang.org/dl)
+- **Go 1.26.3+** — install from [golang.org/dl](https://golang.org/dl)
 - **Ruby** and **Python** — needed for some middleware tests
   ```bash
   # macOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS build-env
+FROM golang:1.26.3 AS build-env
 WORKDIR /usr/local/go/src/github.com/SpectoLabs/hoverfly
 COPY . /usr/local/go/src/github.com/SpectoLabs/hoverfly
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SpectoLabs/hoverfly
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/ChrisTrenkamp/xsel v0.9.16


### PR DESCRIPTION
The 1.26.2 golang version has a vuln https://nvd.nist.gov/vuln/detail/CVE-2026-39836

