### PR TITLE
fix: race in Diff mode crashes Hoverfly (GHSA-qrh4-p6v4-mrfg)

### DIFF
--- a/core/hoverfly.go
+++ b/core/hoverfly.go
@@ -47,6 +47,7 @@ type Hoverfly struct {
 	templator              *templating.Templator
 	PostServeActionDetails *action.PostServeActionDetails
 	responsesDiff          map[v2.SimpleRequestDefinitionView][]v2.DiffReport
+	responsesDiffMu        sync.RWMutex
 }
 
 func NewHoverfly() *Hoverfly {

--- a/core/hoverfly_service.go
+++ b/core/hoverfly_service.go
@@ -407,18 +407,28 @@ func (hf *Hoverfly) ClearState() {
 }
 
 func (hf *Hoverfly) GetDiff() map[v2.SimpleRequestDefinitionView][]v2.DiffReport {
-	return hf.responsesDiff
+	hf.responsesDiffMu.RLock()
+	defer hf.responsesDiffMu.RUnlock()
+	snapshot := make(map[v2.SimpleRequestDefinitionView][]v2.DiffReport, len(hf.responsesDiff))
+	for k, v := range hf.responsesDiff {
+		snapshot[k] = append([]v2.DiffReport(nil), v...)
+	}
+	return snapshot
 }
 
 func (hf *Hoverfly) ClearDiff() {
+	hf.responsesDiffMu.Lock()
+	defer hf.responsesDiffMu.Unlock()
 	hf.responsesDiff = make(map[v2.SimpleRequestDefinitionView][]v2.DiffReport)
 }
 
 func (hf *Hoverfly) AddDiff(requestView v2.SimpleRequestDefinitionView, diffReport v2.DiffReport) {
-	if len(diffReport.DiffEntries) > 0 {
-		diffs := hf.responsesDiff[requestView]
-		hf.responsesDiff[requestView] = append(diffs, diffReport)
+	if len(diffReport.DiffEntries) == 0 {
+		return
 	}
+	hf.responsesDiffMu.Lock()
+	defer hf.responsesDiffMu.Unlock()
+	hf.responsesDiff[requestView] = append(hf.responsesDiff[requestView], diffReport)
 }
 
 func (hf *Hoverfly) GetPACFile() []byte {
@@ -437,9 +447,10 @@ func (hf *Hoverfly) DeletePACFile() {
 }
 
 func (hf *Hoverfly) GetFilteredDiff(diffFilterView v2.DiffFilterView) map[v2.SimpleRequestDefinitionView][]v2.DiffReport {
-	responsesDiff := hf.responsesDiff
+	hf.responsesDiffMu.RLock()
+	defer hf.responsesDiffMu.RUnlock()
 	filteredResponsesDiff := make(map[v2.SimpleRequestDefinitionView][]v2.DiffReport)
-	for request, diffReports := range responsesDiff {
+	for request, diffReports := range hf.responsesDiff {
 		for _, diffReport := range diffReports {
 			var filteredDiffEntries []v2.DiffReportEntry
 			for _, diffEntry := range diffReport.DiffEntries {

--- a/core/hoverfly_service_test.go
+++ b/core/hoverfly_service_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/SpectoLabs/hoverfly/core/action"
@@ -1065,6 +1067,62 @@ func Test_Hoverfly_AddDiff_DoesntAddDiffReport_NoEntries(t *testing.T) {
 	unit.AddDiff(key, v2.DiffReport{Timestamp: "now"})
 
 	Expect(unit.responsesDiff).To(HaveLen(0))
+}
+
+// Regression for GHSA-qrh4-p6v4-mrfg: concurrent AddDiff/GetDiff/ClearDiff
+// used to trip Go's built-in map race check and crash the process with
+// "fatal error: concurrent map read and map write". Run with -race to also
+// catch slice-aliasing regressions.
+func Test_Hoverfly_Diff_ConcurrentAccess(t *testing.T) {
+	RegisterTestingT(t)
+
+	unit := NewHoverflyWithConfiguration(&Configuration{})
+
+	const writers = 32
+	const reads = 64
+	const writesPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(writers + reads + 1)
+
+	for i := 0; i < writers; i++ {
+		go func(id int) {
+			defer wg.Done()
+			key := v2.SimpleRequestDefinitionView{
+				Host: "test.com",
+				Path: "/" + strconv.Itoa(id),
+			}
+			for j := 0; j < writesPerGoroutine; j++ {
+				unit.AddDiff(key, v2.DiffReport{
+					Timestamp:   "now",
+					DiffEntries: []v2.DiffReportEntry{{Actual: strconv.Itoa(j)}},
+				})
+			}
+		}(i)
+	}
+
+	for i := 0; i < reads; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < writesPerGoroutine; j++ {
+				for _, reports := range unit.GetDiff() {
+					for _, r := range reports {
+						_ = r.Timestamp
+					}
+				}
+				_ = unit.GetFilteredDiff(v2.DiffFilterView{})
+			}
+		}()
+	}
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < writesPerGoroutine; i++ {
+			unit.ClearDiff()
+		}
+	}()
+
+	wg.Wait()
 }
 
 func Test_Hoverfly_GetPACFile_GetsPACFile(t *testing.T) {


### PR DESCRIPTION
## Summary

- Diff mode crashed with `fatal error: concurrent map read and map write` under concurrent proxy traffic because `responsesDiff` (in `core/hoverfly.go`) was a plain `map` with no synchronization. Trivially triggerable: any client with proxy access could send a handful of simultaneous requests and DoS the process. Reported as [GHSA-qrh4-p6v4-mrfg](https://github.com/SpectoLabs/hoverfly/security/advisories/GHSA-qrh4-p6v4-mrfg).
- Added a dedicated `sync.RWMutex` next to `responsesDiff` (mirroring the `state.State` pattern) and wrapped all four accessors: `AddDiff` / `ClearDiff` (write lock), `GetDiff` / `GetFilteredDiff` (read lock).
- `GetDiff` now returns a deep snapshot so `DiffHandler.convertToResponseDiffView` can iterate the result after the lock is released without reintroducing the race.

## Test plan

- [x] `go test -race -count=1 -v -run 'Test_Hoverfly_AddDiff|Test_Hoverfly_Diff_ConcurrentAccess|Test_Hoverfly_processRequest_CanHandleResponseDiff' github.com/SpectoLabs/hoverfly/core` — all green.
- [x] New `Test_Hoverfly_Diff_ConcurrentAccess` (32 writer goroutines × 64 readers × 1 clearer × 100 iterations each) — reliably trips Go's map-race check on pre-patch code; passes under `-race` with the patch (~110 ms).
- [x] `go vet github.com/SpectoLabs/hoverfly/core` — clean.
- [ ] Optional manual repro: run the advisory's curl POC against a built binary in Diff mode and confirm the process stays alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)