### PR TITLE
fix(action): timeout remote post-serve HTTP client (GHSA-42j2-w334-qxw7)

### DIFF
--- a/core/action/action.go
+++ b/core/action/action.go
@@ -18,6 +18,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// RemoteActionTimeout caps the total time spent on a remote post-serve action
+// HTTP call (dial, TLS handshake, request write, response read). Without it a
+// non-responsive endpoint would leak the calling goroutine forever
+// (GHSA-42j2-w334-qxw7). Exported so tests can lower it.
+var RemoteActionTimeout = 30 * time.Second
+
 type Action struct {
 	Binary    string
 	Script    *os.File
@@ -140,7 +146,8 @@ func (action *Action) Execute(pair *models.RequestResponsePair, journalIDChannel
 		req.Header.Add("Content-Type", "application/json")
 		req.Header.Add("X-CORRELATION-ID", correlationID)
 
-		resp, err := http.DefaultClient.Do(req)
+		client := &http.Client{Timeout: RemoteActionTimeout}
+		resp, err := client.Do(req)
 		completionTime := time.Now()
 		journalID, received := receiveJournalIdWithTimeout(journalIDChannel, time.Second)
 		log.Info("Journal ID received ", journalID)

--- a/core/action/action_test.go
+++ b/core/action/action_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/SpectoLabs/hoverfly/core/journal"
 	"github.com/gorilla/mux"
@@ -165,4 +166,45 @@ func Test_ExecuteRemotePostServeAction_WithUnReachableHost(t *testing.T) {
 
 func processHandlerOkay(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
+}
+
+// Regression test for GHSA-42j2-w334-qxw7: a remote post-serve action pointed
+// at a non-responsive endpoint must not block forever. Without the client
+// timeout the goroutine would leak indefinitely.
+func Test_ExecuteRemotePostServeAction_TimesOutOnSlowEndpoint(t *testing.T) {
+	RegisterTestingT(t)
+
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer server.Close() // runs last; needs handler to have exited
+	defer close(block)   // runs first; unblocks handler so server can close
+
+	originalTimeout := action.RemoteActionTimeout
+	action.RemoteActionTimeout = 100 * time.Millisecond
+	defer func() { action.RemoteActionTimeout = originalTimeout }()
+
+	newAction, err := action.NewRemoteAction(server.URL+"/slow", 0)
+	Expect(err).To(BeNil())
+
+	originalPair := models.RequestResponsePair{
+		Response: models.ResponseDetails{Body: "Normal body"},
+	}
+	journalIDChannel := make(chan string, 1)
+	journalIDChannel <- "1"
+	newJournal := journal.NewJournal()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- newAction.Execute(&originalPair, journalIDChannel, newJournal)
+	}()
+
+	select {
+	case err := <-done:
+		Expect(err).NotTo(BeNil())
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return within 5s — timeout not applied")
+	}
+	close(journalIDChannel)
 }


### PR DESCRIPTION
## Summary
- Remote post-serve actions used `http.DefaultClient` (no timeout) inside an unbounded goroutine, so a non-responsive endpoint would leak the calling goroutine forever — an attacker with admin-API access could exhaust memory and crash the process (GHSA-42j2-w334-qxw7).
- Switch to a dedicated `*http.Client` with a 30s `Timeout`, which caps dial → TLS handshake → request write → response read. Every in-flight remote-action goroutine is now guaranteed to terminate.
- Timeout is exposed as `action.RemoteActionTimeout` so tests can override it.

## Test plan
- [x] `go test ./core/action/... -count=1` (all green)
- [x] New regression test `Test_ExecuteRemotePostServeAction_TimesOutOnSlowEndpoint` against an `httptest` server that never responds — fails (hangs past timeout) without the fix, passes in ~0.3s with it
- [x] `go vet ./core/action/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)