### PR TITLE
Sync go.mod Go version via Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,6 +36,18 @@
       ],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Go version in go.mod go directive",
+      "managerFilePatterns": [
+        "/^go\\.mod$/"
+      ],
+      "matchStrings": [
+        "(?m)^go (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "go"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## What

Adds a custom regex manager to `.github/renovate.json` so Renovate also bumps the `go` directive in `go.mod`.

## Why

The recent [Go 1.26.4 update](https://github.com/SpectoLabs/hoverfly/commit/dcaa9ece058fbc6175a4f7144a38d7bcfc9509e8) updated the CircleCI image, `Dockerfile`, `CONTRIBUTING.md`, and `CLAUDE.md` — but left `go.mod` at `go 1.26.3`. Renovate's built-in `gomod` manager treats the `go` directive as the module's *minimum language version* and intentionally won't bump it for patch releases, so `go.mod` drifted from every other Go version reference.

## How

A new custom regex manager scoped to `go.mod` matches the `go x.y.z` directive line (`(?m)^go ...`) and resolves it via the `golang-version` datasource under depName `go` — the same datasource/depName as the existing docs manager, so it folds into the same grouped "Go" PR rather than opening a separate one.

> [!NOTE]
> Raising the `go` directive sets the module's minimum required Go version, forcing builds onto the newer patch. That's a deliberate change from Renovate's default conservative stance — appropriate for an application like Hoverfly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)