### PR TITLE
docs: replace dead jsontest.com example URLs

### DIFF
--- a/docs/pages/simulations/multiple-hosts-delay-simulation.json
+++ b/docs/pages/simulations/multiple-hosts-delay-simulation.json
@@ -26,12 +26,12 @@
       "globalActions": {
          "delays": [
             {
-               "urlPattern": "time\\.jsontest\\.com",
+                "urlPattern": "api\\.ipify\\.org",
                "httpMethod": "",
                "delay": 1000
             },
             {
-               "urlPattern": "date\\.jsontest\\.com",
+               "urlPattern": "httpbin\\.org",
                "httpMethod": "",
                "delay": 2000
             }

--- a/docs/pages/tutorials/basic/delays/multiplehosts/delays-capture.sh
+++ b/docs/pages/tutorials/basic/delays/multiplehosts/delays-capture.sh
@@ -1,6 +1,6 @@
 hoverctl start
 hoverctl mode capture
-curl --proxy localhost:8500 http://time.jsontest.com
-curl --proxy localhost:8500 http://date.jsontest.com
+curl --proxy localhost:8500 https://api.ipify.org
+curl --proxy localhost:8500 https://httpbin.org
 hoverctl export simulation.json
 hoverctl stop

--- a/docs/pages/tutorials/basic/delays/multiplehosts/delays-simulate.sh
+++ b/docs/pages/tutorials/basic/delays/multiplehosts/delays-simulate.sh
@@ -1,5 +1,5 @@
 hoverctl start
 hoverctl import simulation.json
-curl --proxy localhost:8500 http://time.jsontest.com
-curl --proxy localhost:8500 http://date.jsontest.com
+curl --proxy localhost:8500 https://api.ipify.org
+curl --proxy localhost:8500 https://httpbin.org
 hoverctl stop

--- a/docs/pages/tutorials/basic/delays/multiplehosts/multiplehosts.rst
+++ b/docs/pages/tutorials/basic/delays/multiplehosts/multiplehosts.rst
@@ -1,7 +1,7 @@
 Applying different delays based on host
 =======================================
 
-Now let's apply a delay of 1 second on responses from ``time.jsontest.com`` and a delay of 2 seconds on responses from ``date.jsontest.com``.
+Now let's apply a delay of 1 second on responses from ``api.ipify.org`` and a delay of 2 seconds on responses from ``httpbin.org``.
 
 Run the following to create and export a simulation.
 
@@ -20,7 +20,7 @@ Now run the following to import the edited ``simulation.json`` file and run the 
 .. literalinclude:: delays-simulate.sh
    :language: sh
 
-You should notice a 1 second delay on responses from ``time.jsontest.com``, and a 2 second delay on responses from ``date.jsontest.com``.
+You should notice a 1 second delay on responses from ``api.ipify.org``, and a 2 second delay on responses from ``httpbin.org``.
 
 
 .. note::

--- a/docs/pages/tutorials/basic/specificurls/filter-dest-dry-run.sh
+++ b/docs/pages/tutorials/basic/specificurls/filter-dest-dry-run.sh
@@ -1,4 +1,4 @@
 hoverctl start
-hoverctl destination "ip" --dry-run http://ip.jsontest.com
-hoverctl destination "ip" --dry-run http://time.jsontest.com
+hoverctl destination "ip" --dry-run https://api.ipify.org
+hoverctl destination "ip" --dry-run https://httpbin.org
 hoverctl stop

--- a/docs/pages/tutorials/basic/specificurls/filter-dest.sh
+++ b/docs/pages/tutorials/basic/specificurls/filter-dest.sh
@@ -1,8 +1,8 @@
 hoverctl start
 hoverctl destination "ip" 
 hoverctl mode capture
-curl --proxy http://localhost:8500 http://ip.jsontest.com
-curl --proxy http://localhost:8500 http://time.jsontest.com
+curl --proxy http://localhost:8500 https://api.ipify.org
+curl --proxy http://localhost:8500 https://httpbin.org
 hoverctl logs
 hoverctl export simulation.json
 hoverctl stop

--- a/docs/pages/tutorials/basic/specificurls/specificurls.rst
+++ b/docs/pages/tutorials/basic/specificurls/specificurls.rst
@@ -10,8 +10,8 @@ will filter out URLs as required.
 .. literalinclude:: filter-dest-dry-run.sh
     :language: sh
 
-This tells us that setting the destination to ``ip`` will allow the URL ``http://ip.jsontest.com`` to be captured or simulated, while the URL
-``http://time.jsontest.com`` will be ignored.
+This tells us that setting the destination to ``ip`` will allow the URL ``https://api.ipify.org`` to be captured or simulated, while the URL
+``https://httpbin.org`` will be ignored.
 
 
 Now we have checked the destination setting, we can apply it to filter out the URLs we don't want to capture.
@@ -19,7 +19,7 @@ Now we have checked the destination setting, we can apply it to filter out the U
 .. literalinclude:: filter-dest.sh
     :language: sh
 
-If we examine the logs and the ``simulation.json`` file, we can see that `only` a request response pair to the ``http://ip.jsontest.com``
+If we examine the logs and the ``simulation.json`` file, we can see that `only` a request response pair to the ``https://api.ipify.org``
 URL has been captured.
 
 The destination setting can be either a string or a regular expression. 


### PR DESCRIPTION
`jsontest.com` (used as the example host in the delays and specific-URLs tutorials) is no longer live - it now returns a Cloudflare 530 (origin unreachable) error, so these tutorials no longer work as written for anyone following along.

This replaces the dead URLs with two live public test APIs: `api.ipify.org` in place of `ip.jsontest.com` / `time.jsontest.com` (kept the "contains ip" property the specific-URLs tutorial's destination filter relies on), and `httpbin.org` in place of `date.jsontest.com` / the second delay-example host.

Touches both tutorials end to end: the .rst prose, the shell script examples, and the shared multiple-hosts-delay-simulation.json fixture used by the delays tutorial. Happy to adjust to a different replacement host if you'd prefer - just wanted to get the dead link fixed since it breaks the copy-paste examples as they stand.